### PR TITLE
45628143: Store fixity data when a datastream is created or modified

### DIFF
--- a/fcrepo-kernel/src/main/java/org/fcrepo/Datastream.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/Datastream.java
@@ -11,10 +11,6 @@ import static org.modeshape.jcr.api.JcrConstants.NT_RESOURCE;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
 import javax.jcr.Node;
@@ -26,8 +22,8 @@ import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
 import javax.jcr.version.VersionException;
 
-import org.apache.commons.codec.binary.Hex;
 import org.fcrepo.utils.ContentDigest;
+import org.modeshape.jcr.api.Binary;
 import org.modeshape.jcr.api.JcrTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,8 +35,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class Datastream extends JcrTools {
-
-    private static MessageDigest md;
 
     private final static String CONTENT_SIZE = "fedora:size";
 
@@ -62,19 +56,6 @@ public class Datastream extends JcrTools {
      */
     public Node getNode() {
         return node;
-    }
-
-    private MessageDigest getMessageDigest() {
-
-        if (this.md == null) {
-            try {
-                this.md = MessageDigest.getInstance("SHA-1");
-            } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
-            }
-        }
-
-        return md;
     }
 
     /**
@@ -100,10 +81,19 @@ public class Datastream extends JcrTools {
             contentNode.addMixin("fedora:checksum");
         }
 
-        final DigestInputStream dis =
-                new DigestInputStream(content, getMessageDigest());
-
         logger.debug("Created content node at path: " + contentNode.getPath());
+
+        /*
+         * https://docs.jboss.org/author/display/MODE/Binary+values#Binaryvalues-
+         * ExtendedBinaryinterface
+         * promises: "All javax.jcr.Binary values returned by ModeShape will
+         * implement this public interface, so feel free to cast the values to
+         * gain access to the additional methods."
+         */
+        Binary binary =
+                (Binary) node.getSession().getValueFactory().createBinary(
+                        content);
+
         /*
          * This next line of code deserves explanation. If we chose for the
          * simpler line:
@@ -119,15 +109,12 @@ public class Datastream extends JcrTools {
          * code may still be useful to us for an asynchronous method that we
          * develop later.
          */
-        Property dataProperty =
-                contentNode.setProperty(JCR_DATA, node.getSession()
-                        .getValueFactory().createBinary(dis));
+        Property dataProperty = contentNode.setProperty(JCR_DATA, binary);
 
         contentNode.setProperty(CONTENT_SIZE, dataProperty.getLength());
-        contentNode.setProperty(DIGEST_VALUE, Hex.encodeHexString(dis
-                .getMessageDigest().digest()));
-        contentNode.setProperty(DIGEST_ALGORITHM, dis.getMessageDigest()
-                .getAlgorithm());
+        contentNode.setProperty(DIGEST_VALUE, binary.getHexHash());
+        contentNode.setProperty(DIGEST_ALGORITHM, "SHA-1");
+
         logger.debug("Created data property at path: " + dataProperty.getPath());
 
     }

--- a/fcrepo-kernel/src/test/java/org/fcrepo/DatastreamTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/DatastreamTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringWriter;
 
 import javax.inject.Inject;
 import javax.jcr.Node;
@@ -91,7 +90,8 @@ public class DatastreamTest extends AbstractTest {
         session.save();
 
         final Datastream ds = getDatastream("testObject", "testDatastreamNode2");
-        assertEquals("urn:sha1:3da541559918a808c2402bba5012f6c60b27661c", ds.getContentDigest().toString());
+        assertEquals("urn:sha1:3da541559918a808c2402bba5012f6c60b27661c", ds
+                .getContentDigest().toString());
         assertEquals(4L, ds.getContentSize());
 
 


### PR DESCRIPTION
Uses org.modeshape.jcr.api.Binary for retrieving SHA-1 digests rather than calculating anew.
Also see: https://docs.jboss.org/author/display/MODE/Binary+values

I think this means we should give up the pretense that we support digest algorithms other than SHA-1,
which I'm ok with.

https://www.pivotaltracker.com/story/show/45628143
