### PR TITLE
Adding topic URI to dataset context and velocity template

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraNodes.java
@@ -53,13 +53,17 @@ import org.fcrepo.services.DatastreamService;
 import org.fcrepo.services.LowLevelStorageService;
 import org.fcrepo.services.ObjectService;
 import org.fcrepo.utils.FedoraJcrTypes;
+import org.fcrepo.utils.JcrRdfTools;
 import org.modeshape.common.collection.Problems;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.codahale.metrics.annotation.Timed;
+import com.hp.hpl.jena.graph.Graph;
+import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.sparql.util.Symbol;
 import com.hp.hpl.jena.update.UpdateAction;
 
 @Component
@@ -102,8 +106,24 @@ public class FedoraNodes extends AbstractResource {
                 throw new WebApplicationException(builder.cacheControl(cc)
                         .lastModified(date).build());
             }
-            return resource.getGraphStore(new HttpGraphSubjects(FedoraNodes.class, uriInfo)).toDataset();
+            //return resource.getGraphStore(new HttpGraphSubjects(FedoraNodes.class, uriInfo)).toDataset();
 
+            // store the topic uri in the dataset context
+            HttpGraphSubjects subjects =
+                new HttpGraphSubjects(FedoraNodes.class, uriInfo);
+            Dataset dataset = resource.getGraphStore(subjects).toDataset();
+            String uri = null;
+            try {
+                uri = JcrRdfTools.getGraphSubject(
+                    subjects,session.getNode(path)).getURI();
+            } catch ( Exception ex ) { uri = null; }
+
+            com.hp.hpl.jena.sparql.util.Context context =
+                dataset.getContext();
+            if ( context == null ) { context = new com.hp.hpl.jena.sparql.util.Context(); }
+            context.set(Symbol.create("uri"),uri);
+
+            return dataset;
         } finally {
             session.logout();
         }

--- a/fcrepo-http-commons/src/main/resources/views/mode:root.vsl
+++ b/fcrepo-http-commons/src/main/resources/views/mode:root.vsl
@@ -1,0 +1,72 @@
+#* @vtlvariable name="rdf" type="com.hp.hpl.jena.sparql.core.DatasetGraph" *#
+#* @vtlvariable name="subjects" type="com.hp.hpl.jena.rdf.model.ResIterator" *#
+#* @vtlvariable name="nodeany" type="com.hp.hpl.jena.graph.Node" *#
+#* @vtlvariable name="topic" type="com.hp.hpl.jena.graph.Node" *#
+<html>
+<head>
+    <title>mode:root profile</title>
+</head>
+
+<body>
+    <h1>mode:root: $topic</h1>
+
+    ## output triples for the topic node
+    #triples($topic)
+
+    ## output other nodes
+    #foreach($subject in $subjects)
+      #if( $subject != $topic )
+        #triples($subject)
+      #end
+    #end
+
+#*
+    <div>
+        #if($subject.isURIResource())
+            <h2><a href="$subject.getURI()">$subject</a></h2>
+        #else
+            <h2>$subject</h2>
+        #end
+
+        <dl>
+            #foreach($quad in $rdf.find($nodeany, $subject.asNode(), $nodeany, $nodeany))
+                <dt>$quad.getPredicate()</dt>
+
+                <dd>
+                    #if($quad.getObject().isURIResource())
+                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
+                    #else
+                        $quad.getObject()
+                    #end
+                </dd>
+            #end
+        </dl>
+    </div>
+    #end
+*#
+</body>
+
+</html>
+#macro( triples $sub )
+    <div>
+        #if($sub.isURIResource())
+            <h2><a href="$sub.getURI()">$sub</a></h2>
+        #else
+            <h2>$sub</h2>
+        #end
+
+        <dl>
+            #foreach($quad in $rdf.find($nodeany, $sub.asNode(), $nodeany, $nodeany))
+                <dt>$quad.getPredicate()</dt>
+
+                <dd>
+                    #if($quad.getObject().isURIResource())
+                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
+                    #else
+                        $quad.getObject()
+                    #end
+                </dd>
+            #end
+        </dl>
+    </div>
+#end

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/responses/RdfSerializationUtilsTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/responses/RdfSerializationUtilsTest.java
@@ -1,6 +1,7 @@
 
 package org.fcrepo.responses;
 
+import static com.hp.hpl.jena.graph.Node.ANY;
 import static com.hp.hpl.jena.graph.Node.createLiteral;
 import static com.hp.hpl.jena.graph.Node.createURI;
 import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
@@ -33,9 +34,9 @@ public class RdfSerializationUtilsTest {
     @Test
     public void testGetFirstValueForPredicate() {
         final String foundValue =
-                getFirstValueForPredicate(testData, createURI("test:predicate"));
+            getFirstValueForPredicate(testData,ANY,createURI("test:predicate"));
         assertEquals("Didn't find correct value for predicate!", foundValue,
-                "test:object");
+            "test:object");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Uses the Dataset Context object to store the topic URI.  The Context object hold key-value pairs (with boolean or Object values), so it could also be used to pass a base URL, or other values the display code needs to fulfill the request.

HtmlProvider now uses the topic URI to choose the correct type and corresponding velocity template.
