### PR TITLE
Updating Velocity templates to support basic navigation and CRUD operations

### DIFF
--- a/fcrepo-http-commons/src/main/resources/views/common.css
+++ b/fcrepo-http-commons/src/main/resources/views/common.css
@@ -1,0 +1,3 @@
+dt { font-weight: bold; }
+dd { margin-bottom: 1em; }
+body { font-family: sans-serif; }

--- a/fcrepo-http-commons/src/main/resources/views/common.js
+++ b/fcrepo-http-commons/src/main/resources/views/common.js
@@ -1,0 +1,60 @@
+
+function addChild()
+{
+    var id = document.getElementById("new_id").value;
+    var mixin = document.getElementById("new_mixin").value;
+    var newURI = window.location + "/" + id;
+    if ( mixin != '' ) {
+        var postURI = newURI + "?mixin=" + mixin;
+    } else {
+        var postURI = newURI;
+    }
+
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState == 4) {
+            window.location = newURI;
+        }
+    }
+    xhr.open('POST',postURI,true);
+    xhr.send(null);
+}
+function deleteItem()
+{
+    var uri = window.location;
+    var arr = uri.toString().split("/");
+    arr.pop();
+    var newURI = arr.join("/");
+
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState == 4) {
+            window.location = newURI;
+        }
+    }
+    xhr.open('DELETE',uri,true);
+    xhr.send(null);
+}
+function updateFile()
+{
+    var update_file = document.getElementById("update_file").files[0];
+    var url = window.location + "/fcr:content";
+    var reader = new FileReader();
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (xhr.readyState == 4) {
+            window.location = url;
+        }
+    }
+    xhr.open( "PUT", url );
+    xhr.setRequestHeader("Content-type", update_file.type);
+    reader.onload = function(e) {
+        var result = e.target.result;
+        var data = new Uint8Array(result.length);
+        for (var i = 0; i < result.length; i++) {
+            data[i] = (result.charCodeAt(i) & 0xff);
+        }
+        xhr.send(data.buffer);
+    };
+    reader.readAsBinaryString(update_file);
+}

--- a/fcrepo-http-commons/src/main/resources/views/common.vsl
+++ b/fcrepo-http-commons/src/main/resources/views/common.vsl
@@ -1,0 +1,38 @@
+#macro( triples $sub )
+    <div>
+        #if($sub.isURI())
+            <h2><a href="$sub.getURI()">$sub</a></h2>
+        #else
+            <h2>$sub.getURI()</h2>
+        #end
+
+        <dl>
+            #foreach($quad in $rdf.find($nodeany, $nodeany, $nodeany, $nodeany))
+                #if($sub.equals($quad.getSubject()))
+                    <dt>
+                        #if($quad.getPredicate().toString().startsWith("info:fedora/fedora-system:def/internal#") )
+                          fedora:$quad.getPredicate().toString().substring(39)
+                        #else
+                          $quad.getPredicate()
+                        #end
+</dt>
+                    <dd>
+                        #if($quad.getObject().isURI() && $quad.getObject().getURI().startsWith("http"))
+                            <a href="$quad.getObject().getURI()">$quad.getObject()</a>
+                        #else
+                            $quad.getObject()
+                        #end
+                        #if( $quad.getPredicate().toString().equals("info:fedora/digest") )
+                            <a href="$topic/fcr:fixity">check fixity</a>
+                        #end
+                    </dd>
+                #end
+            #end
+        </dl>
+    </div>
+#end
+#macro( isObject $sub )
+#set($type = $anynode.createURI("info:fedora/fedora-system:def/internal#mixinTypes"))
+#set($object = $anynode.createLiteral("fedora:object"))
+$rdf.find($nodeany, $sub, $type, $object).hasNext()
+#end

--- a/fcrepo-http-commons/src/main/resources/views/mode:root.vsl
+++ b/fcrepo-http-commons/src/main/resources/views/mode:root.vsl
@@ -2,12 +2,15 @@
 #* @vtlvariable name="subjects" type="com.hp.hpl.jena.rdf.model.ResIterator" *#
 #* @vtlvariable name="nodeany" type="com.hp.hpl.jena.graph.Node" *#
 #* @vtlvariable name="topic" type="com.hp.hpl.jena.graph.Node" *#
+#parse("views/common.vsl")
 <html>
-<head>
+  <head>
     <title>mode:root profile</title>
-</head>
-
-<body>
+    <style type="text/css">
+      #include("views/common.css")
+    </style>
+  </head>
+  <body>
     <h1>mode:root: $topic</h1>
 
     ## output triples for the topic node
@@ -20,53 +23,5 @@
       #end
     #end
 
-#*
-    <div>
-        #if($subject.isURIResource())
-            <h2><a href="$subject.getURI()">$subject</a></h2>
-        #else
-            <h2>$subject</h2>
-        #end
-
-        <dl>
-            #foreach($quad in $rdf.find($nodeany, $subject.asNode(), $nodeany, $nodeany))
-                <dt>$quad.getPredicate()</dt>
-
-                <dd>
-                    #if($quad.getObject().isURIResource())
-                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
-                    #else
-                        $quad.getObject()
-                    #end
-                </dd>
-            #end
-        </dl>
-    </div>
-    #end
-*#
-</body>
-
+  </body>
 </html>
-#macro( triples $sub )
-    <div>
-        #if($sub.isURIResource())
-            <h2><a href="$sub.getURI()">$sub</a></h2>
-        #else
-            <h2>$sub</h2>
-        #end
-
-        <dl>
-            #foreach($quad in $rdf.find($nodeany, $sub.asNode(), $nodeany, $nodeany))
-                <dt>$quad.getPredicate()</dt>
-
-                <dd>
-                    #if($quad.getObject().isURIResource())
-                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
-                    #else
-                        $quad.getObject()
-                    #end
-                </dd>
-            #end
-        </dl>
-    </div>
-#end

--- a/fcrepo-http-commons/src/main/resources/views/nt:file.vsl
+++ b/fcrepo-http-commons/src/main/resources/views/nt:file.vsl
@@ -1,35 +1,40 @@
 #* @vtlvariable name="rdf" type="com.hp.hpl.jena.sparql.core.DatasetGraph" *#
 #* @vtlvariable name="subjects" type="com.hp.hpl.jena.rdf.model.ResIterator" *#
 #* @vtlvariable name="nodeany" type="com.hp.hpl.jena.graph.Node" *#
+#* @vtlvariable name="topic" type="com.hp.hpl.jena.graph.Node" *#
+#parse("views/common.vsl")
 <html>
-	<head>
-		<title>nt:file profile</title>
-	</head>
+  <head>
+    <title>nt:file profile</title>
+    <script type="text/javascript">
+      #include("views/common.js")
+    </script>
+    <style type="text/css">
+      #include("views/common.css")
+    </style>
+  </head>
+  <body>
+    <h1>nt:file: $topic</h1>
 
-<body>
-    #foreach($subject in $subjects)
-    <div>
-        #if($subject.isURIResource())
-            <h2><a href="$subject.getURI()">$subject</a></h2>
-        #else
-            <h2>$subject</h2>
-        #end
-
-        <dl>
-            #foreach($quad in $rdf.find($nodeany, $subject.asNode(), $nodeany, $nodeany))
-                <dt>$quad.getPredicate()</dt>
-
-                <dd>
-                    #if($quad.getObject().isURIResource())
-                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
-                    #else
-                        $quad.getObject()
-                    #end
-                </dd>
-            #end
-        </dl>
+    ## output actions
+    <div class="actions">
+      <form action="javascript:updateFile()">
+          <input type="file" id="update_file"/>
+          <input type="submit" value="update content">
+      </form>
+      <form action="javascript:deleteItem()">
+          <input type="submit" value="delete this datastream"/>
+      </form>
     </div>
-    #end
-</body>
 
+    ## output triples for the topic node
+    #triples($topic)
+
+    ## output other nodes
+    #foreach($subject in $subjects)
+      #if( $subject != $topic )
+        #triples($subject.asNode())
+      #end
+    #end
+  </body>
 </html>

--- a/fcrepo-http-commons/src/main/resources/views/nt:folder.vsl
+++ b/fcrepo-http-commons/src/main/resources/views/nt:folder.vsl
@@ -1,35 +1,47 @@
 #* @vtlvariable name="rdf" type="com.hp.hpl.jena.sparql.core.DatasetGraph" *#
 #* @vtlvariable name="subjects" type="com.hp.hpl.jena.rdf.model.ResIterator" *#
 #* @vtlvariable name="nodeany" type="com.hp.hpl.jena.graph.Node" *#
+#* @vtlvariable name="topic" type="com.hp.hpl.jena.graph.Node" *#
+#parse("views/common.vsl")
 <html>
-<head>
+  <head>
     <title>nt:folder profile</title>
-</head>
+    <script type="text/javascript">
+      #include("views/common.js")
+    </script>
+    <style type="text/css">
+      #include("views/common.css")
+    </style>
+  </head>
+  <body>
+    <h1>nt:folder: $topic</h1>
 
-<body>
-    #foreach($subject in $subjects)
-    <div>
-        #if($subject.isURIResource())
-            <h2><a href="$subject.getURI()">$subject</a></h2>
-        #else
-            <h2>$subject</h2>
-        #end
+    ## output actions
+    <div class="actions">
+      <form action="javascript:addChild()">
+        <select id="new_mixin">
+          <option value="">folder</option>
+          <option value="fedora:object">object</option>
+          <option value="fedora:datastream">datastream</option>
+        </select>
+        <input type="text" id="new_id" value="new_id"/>
+        <input type="submit" value="add">
+      </form>
+      <form action="javascript:deleteItem()">
+        <input type="submit" value="delete this folder"/>
 
-        <dl>
-            #foreach($quad in $rdf.find($nodeany, $subject.asNode(), $nodeany, $nodeany))
-                <dt>$quad.getPredicate()</dt>
-
-                <dd>
-                    #if($quad.getObject().isURIResource())
-                        <a href="$quad.getObject().getURI()">$quad.getObject()</a>
-                    #else
-                        $quad.getObject()
-                    #end
-                </dd>
-            #end
-        </dl>
+      </form>
     </div>
-    #end
-</body>
 
+    ## output triples for the topic node
+    #triples($topic)
+
+    ## output other nodes
+    #foreach($subject in $subjects)
+      #if( $subject != $topic )
+        #triples($subject.asNode())
+      #end
+    #end
+
+  </body>
 </html>


### PR DESCRIPTION
- HTTP URIs are converted to links to allow basic navigation
- Basic CRUD operations are supported using Javascript forms
- Simple Javascript and CSS are included from external files
- Manually tested on MacOSX 10.8.3 (Chrome 26.0, Firefox 21.0, Safari 6.0.4).
