### PR TITLE
Field injection of JCR Sessions into JAX-RS endpoints, except FedoraTransactions

### DIFF
--- a/fcrepo-generator-dc/src/test/resources/web.xml
+++ b/fcrepo-generator-dc/src/test/resources/web.xml
@@ -38,7 +38,7 @@
 		<servlet-class>com.sun.jersey.spi.spring.container.servlet.SpringServlet</servlet-class>
 		<init-param>
 			<param-name>com.sun.jersey.config.property.packages</param-name>
-			<param-value>org.fcrepo.api, org.fcrepo.generator, org.fcrepo.exceptionhandlers</param-value>
+			<param-value>org.fcrepo.api, org.fcrepo.generator, org.fcrepo.exceptionhandlers, org.fcrepo.session</param-value>
 		</init-param>
 		<init-param>
 			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -90,6 +90,12 @@
       <artifactId>jersey-grizzly2-servlet</artifactId>
       <scope>test</scope>
     </dependency>
+ <!--    <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-servlet-api</artifactId>
+        <version>7.0.21</version>
+        <scope>provided</scope>
+    </dependency> -->
 
     <dependency>
       <groupId>javax.mail</groupId>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraExport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraExport.java
@@ -6,9 +6,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Resource;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.DefaultValue;
@@ -24,51 +21,64 @@ import org.fcrepo.AbstractResource;
 import org.fcrepo.serialization.FedoraObjectSerializer;
 import org.fcrepo.serialization.SerializerUtil;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.fcrepo.session.InjectedSession;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
+@Scope("prototype")
 @Path("/{path: .*}/fcr:export")
 public class FedoraExport extends AbstractResource {
 
     @Autowired
     protected SerializerUtil serializers;
 
+    @InjectedSession
+    protected Session session;
+
     private final Logger logger = getLogger(this.getClass());
 
     @GET
-    public StreamingOutput exportObject(@PathParam("path") final List<PathSegment> pathList, @QueryParam("format")
+    public StreamingOutput exportObject(@PathParam("path")
+    final List<PathSegment> pathList, @QueryParam("format")
     @DefaultValue("jcr/xml")
     final String format) {
-		final String path = toPath(pathList);
+        final String path = toPath(pathList);
 
         logger.debug("Requested object serialization for: " + path +
                 " using serialization format " + format);
 
-		return new StreamingOutput() {
-			@Override
-			public void write(final OutputStream out) throws IOException {
-				final Session session = getAuthenticatedSession();
-				try {
-					logger.debug("Selecting from serializer map: " +
-							serializers);
-					final FedoraObjectSerializer serializer =
-							serializers.getSerializer(format);
-					logger.debug("Retrieved serializer for format: " + format);
-					serializer.serialize(objectService.getObject(session, path), out);
-					logger.debug("Successfully serialized object: " + path);
-				} catch (final RepositoryException e) {
-					throw new WebApplicationException(e);
-				} finally {
-					session.logout();
-				}
-			}
-		};
+        return new StreamingOutput() {
+
+            @Override
+            public void write(final OutputStream out) throws IOException {
+
+                try {
+                    logger.debug("Selecting from serializer map: " +
+                            serializers);
+                    final FedoraObjectSerializer serializer =
+                            serializers.getSerializer(format);
+                    logger.debug("Retrieved serializer for format: " + format);
+                    serializer.serialize(
+                            objectService.getObject(session, path), out);
+                    logger.debug("Successfully serialized object: " + path);
+                } catch (final RepositoryException e) {
+                    throw new WebApplicationException(e);
+                } finally {
+                    session.logout();
+                }
+            }
+        };
+
     }
 
-    public void setSerializers(final SerializerUtil  serializers) {
+    public void setSerializers(final SerializerUtil serializers) {
         this.serializers = serializers;
+    }
+
+    public void setSession(final Session session) {
+        this.session = session;
     }
 
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFixity.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api;
 
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
@@ -22,36 +23,52 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.UriInfo;
 
-import com.hp.hpl.jena.query.Dataset;
 import org.fcrepo.AbstractResource;
 import org.fcrepo.Datastream;
 import org.fcrepo.api.rdf.HttpGraphSubjects;
+import org.fcrepo.session.InjectedSession;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.codahale.metrics.annotation.Timed;
+import com.hp.hpl.jena.query.Dataset;
 
+/**
+ * @author ajs6f
+ * @date Jun 12, 2013
+ */
 @Component
+@Scope("prototype")
 @Path("/{path: .*}/fcr:fixity")
 public class FedoraFixity extends AbstractResource {
 
-	@GET
-	@Timed
-    @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON, NTRIPLES, TEXT_HTML})
-	public Dataset getDatastreamFixity(@PathParam("path") List<PathSegment> pathList,
-                                       @Context final Request request,
-                                       @Context final UriInfo uriInfo) throws RepositoryException {
+    @InjectedSession
+    protected Session session;
 
-		final Session session = getAuthenticatedSession();
+    @GET
+    @Timed
+    @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON, NTRIPLES,
+            TEXT_HTML})
+    public Dataset getDatastreamFixity(@PathParam("path")
+    final List<PathSegment> pathList, @Context
+    final Request request, @Context
+    final UriInfo uriInfo) throws RepositoryException {
 
-		try {
-			final String path = toPath(pathList);
+        try {
+            final String path = toPath(pathList);
 
-			final Datastream ds = datastreamService.getDatastream(session, path);
+            final Datastream ds =
+                    datastreamService.getDatastream(session, path);
 
-            return datastreamService.getFixityResultsModel(new HttpGraphSubjects(FedoraNodes.class, uriInfo), ds);
-		} finally {
-			session.logout();
-		}
-	}
+            return datastreamService.getFixityResultsModel(
+                    new HttpGraphSubjects(FedoraNodes.class, uriInfo), ds);
+        } finally {
+            session.logout();
+        }
+    }
+
+    public void setSession(final Session session) {
+        this.session = session;
+    }
 
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraIdentifiers.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraIdentifiers.java
@@ -4,8 +4,13 @@ package org.fcrepo.api;
 import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.ContiguousSet.create;
 import static com.google.common.collect.DiscreteDomain.integers;
+import static com.google.common.collect.ImmutableBiMap.of;
 import static com.google.common.collect.Range.closed;
+import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
+import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
+import static com.hp.hpl.jena.update.GraphStoreFactory.create;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
+import static org.fcrepo.RdfLexicon.HAS_MEMBER_OF_RESULT;
 import static org.fcrepo.http.RDFMediaType.N3;
 import static org.fcrepo.http.RDFMediaType.N3_ALT1;
 import static org.fcrepo.http.RDFMediaType.N3_ALT2;
@@ -18,7 +23,6 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -31,22 +35,19 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.AbstractResource;
-import org.fcrepo.RdfLexicon;
 import org.springframework.stereotype.Component;
 
 import com.codahale.metrics.annotation.Timed;
-import com.google.common.collect.ImmutableBiMap;
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.update.GraphStoreFactory;
 
 /**
  * JAX-RS Resource offering PID creation.
  * 
  * @author ajs6f
+ * @author cbeer
  * 
  */
 @Component
@@ -58,50 +59,46 @@ public class FedoraIdentifiers extends AbstractResource {
      * @return HTTP 200 with block of PIDs
      */
     @POST
-	@Timed
-    @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON,
-                      NTRIPLES, TEXT_HTML})
-    public Dataset getNextPid(@PathParam("path") final List<PathSegment> pathList, @QueryParam("numPids") @DefaultValue("1")
-                                  final Integer numPids,
-                              @Context final UriInfo uriInfo) throws RepositoryException {
+    @Timed
+    @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON, NTRIPLES,
+            TEXT_HTML})
+    public Dataset getNextPid(@PathParam("path")
+    final List<PathSegment> pathList, @QueryParam("numPids")
+    @DefaultValue("1")
+    final Integer numPids, @Context
+    final UriInfo uriInfo) throws RepositoryException {
 
+        final String path = toPath(pathList);
 
-        final Session session = getAuthenticatedSession();
+        final Model model = createDefaultModel();
 
-        String path = toPath(pathList);
+        final Resource pidsResult =
+                createResource(uriInfo.getAbsolutePath().toASCIIString());
 
-        try {
-            final Model model = ModelFactory.createDefaultModel();
+        final Collection<String> identifiers =
+                transform(create(closed(1, numPids), integers()), pidMinter
+                        .makePid());
 
+        final UriBuilder builder =
+                uriInfo.getBaseUriBuilder().path(FedoraNodes.class);
 
-            final Resource pidsResult =
-                    ResourceFactory.createResource(uriInfo.getAbsolutePath()
-                                                           .toASCIIString());
+        for (final String identifier : identifiers) {
 
-            final Collection<String> identifiers = transform(create(closed(1, numPids),
-                                                                         integers()), pidMinter.makePid());
-
-            final UriBuilder builder = uriInfo.getBaseUriBuilder().path(FedoraNodes.class);
-
-            for (String identifier : identifiers) {
-
-                final String absPath;
-                if (path.equals("/")) {
-                    absPath = identifier;
-                } else {
-                    absPath = path.substring(1) + "/" + identifier;
-                }
-
-                final String s = builder.buildFromMap(ImmutableBiMap.of("path", absPath)).toASCIIString();
-
-                model.add(pidsResult, RdfLexicon.HAS_MEMBER_OF_RESULT, ResourceFactory.createResource(s));
+            final String absPath;
+            if (path.equals("/")) {
+                absPath = identifier;
+            } else {
+                absPath = path.substring(1) + "/" + identifier;
             }
 
-            return GraphStoreFactory.create(model).toDataset();
+            final String s =
+                    builder.buildFromMap(of("path", absPath)).toASCIIString();
 
-        } finally {
-            session.logout();
+            model.add(pidsResult, HAS_MEMBER_OF_RESULT, ResourceFactory
+                    .createResource(s));
         }
+
+        return create(model).toDataset();
 
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
@@ -35,14 +35,20 @@ import org.fcrepo.AbstractResource;
 import org.fcrepo.FedoraResource;
 import org.fcrepo.api.rdf.HttpGraphSubjects;
 import org.fcrepo.responses.GraphStoreStreamingOutput;
+import org.fcrepo.session.InjectedSession;
 import org.slf4j.Logger;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 import com.hp.hpl.jena.query.Dataset;
 
 @Component
+@Scope("prototype")
 @Path("/{path: .*}/fcr:versions")
 public class FedoraVersions extends AbstractResource {
+
+    @InjectedSession
+    protected Session session;
 
     private static final Logger LOGGER = getLogger(FedoraNodes.class);
 
@@ -50,7 +56,8 @@ public class FedoraVersions extends AbstractResource {
     @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON, NTRIPLES})
     public Response getVersionList(@PathParam("path")
     final List<PathSegment> pathList, @Context
-    final Request request, @Context UriInfo uriInfo) throws RepositoryException {
+    final Request request, @Context
+    final UriInfo uriInfo) throws RepositoryException {
         final String path = toPath(pathList);
 
         LOGGER.trace("getting versions list for {}", path);
@@ -65,8 +72,9 @@ public class FedoraVersions extends AbstractResource {
 
             return Response.ok(
                     new GraphStoreStreamingOutput(resource
-                            .getVersionDataset(new HttpGraphSubjects(FedoraNodes.class, uriInfo)), bestPossibleResponse
-                            .getMediaType())).build();
+                            .getVersionDataset(new HttpGraphSubjects(
+                                    FedoraNodes.class, uriInfo)),
+                            bestPossibleResponse.getMediaType())).build();
 
         } finally {
             session.logout();
@@ -98,7 +106,8 @@ public class FedoraVersions extends AbstractResource {
     @Produces({N3, N3_ALT1, N3_ALT2, TURTLE, RDF_XML, RDF_JSON, NTRIPLES})
     public Dataset getVersion(@PathParam("path")
     final List<PathSegment> pathList, @PathParam("versionLabel")
-    final String versionLabel, @Context UriInfo uriInfo) throws RepositoryException, IOException {
+    final String versionLabel, @Context
+    final UriInfo uriInfo) throws RepositoryException, IOException {
         final String path = toPath(pathList);
         LOGGER.trace("getting version profile for {} at version {}", path,
                 versionLabel);
@@ -112,12 +121,17 @@ public class FedoraVersions extends AbstractResource {
                 throw new WebApplicationException(status(NOT_FOUND).build());
             } else {
 
-                return resource.getPropertiesDataset(new HttpGraphSubjects(FedoraNodes.class, uriInfo));
+                return resource.getPropertiesDataset(new HttpGraphSubjects(
+                        FedoraNodes.class, uriInfo));
             }
 
         } finally {
             session.logout();
         }
 
+    }
+
+    public void setSession(final Session session) {
+        this.session = session;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryIdentifiers.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryIdentifiers.java
@@ -1,11 +1,19 @@
+
 package org.fcrepo.api.repository;
 
+import javax.jcr.Session;
 import javax.ws.rs.Path;
 
 import org.fcrepo.api.FedoraIdentifiers;
+import org.fcrepo.session.InjectedSession;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
+@Scope("prototype")
 @Path("/fcr:pid")
 public class FedoraRepositoryIdentifiers extends FedoraIdentifiers {
+
+    @InjectedSession
+    protected Session session;
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryImport.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryImport.java
@@ -1,30 +1,19 @@
+
 package org.fcrepo.api.repository;
 
-
-import static javax.ws.rs.core.Response.created;
-import static org.slf4j.LoggerFactory.getLogger;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
-import javax.annotation.Resource;
-import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Response;
-
-import org.fcrepo.AbstractResource;
 import org.fcrepo.api.FedoraImport;
-import org.fcrepo.exception.InvalidChecksumException;
-import org.fcrepo.serialization.FedoraObjectSerializer;
-import org.slf4j.Logger;
+import org.fcrepo.session.InjectedSession;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
+@Scope("prototype")
 @Path("/fcr:import")
 public class FedoraRepositoryImport extends FedoraImport {
+
+    @InjectedSession
+    protected Session session;
+
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryUnnamedObjects.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryUnnamedObjects.java
@@ -1,6 +1,9 @@
+
 package org.fcrepo.api.repository;
 
 import static javax.ws.rs.core.Response.created;
+import static javax.ws.rs.core.Response.status;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -18,52 +21,69 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.http.HttpStatus;
 import org.fcrepo.AbstractResource;
 import org.fcrepo.FedoraResource;
 import org.fcrepo.api.FedoraNodes;
 import org.fcrepo.exception.InvalidChecksumException;
+import org.fcrepo.session.InjectedSession;
 import org.fcrepo.utils.FedoraJcrTypes;
 import org.slf4j.Logger;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
+@Scope("prototype")
 @Path("/fcr:new")
 public class FedoraRepositoryUnnamedObjects extends AbstractResource {
 
-    private static final Logger logger = getLogger(FedoraRepositoryUnnamedObjects.class);
+    @InjectedSession
+    protected Session session;
+
+    private static final Logger logger =
+            getLogger(FedoraRepositoryUnnamedObjects.class);
 
     /**
      * Create an anonymous object with a newly minted name
      * @return 201
      */
     @POST
-    public Response ingestAndMint(
-                                  @QueryParam("mixin") @DefaultValue(FedoraJcrTypes.FEDORA_OBJECT) String mixin,
-                                  @QueryParam("checksumType") final String checksumType,
-                                  @QueryParam("checksum") final String checksum,
-                                  @HeaderParam("Content-Type") final MediaType requestContentType,
-                                  final InputStream requestBodyStream, @Context UriInfo uriInfo) throws RepositoryException, IOException, InvalidChecksumException {
+    public Response ingestAndMint(@QueryParam("mixin")
+    @DefaultValue(FedoraJcrTypes.FEDORA_OBJECT)
+    final String mixin, @QueryParam("checksumType")
+    final String checksumType, @QueryParam("checksum")
+    final String checksum, @HeaderParam("Content-Type")
+    final MediaType requestContentType, final InputStream requestBodyStream,
+            @Context
+            final UriInfo uriInfo) throws RepositoryException, IOException,
+            InvalidChecksumException {
         final String pid = pidMinter.mintPid();
-
-        String path = "/" + pid;
-
+        final String path = "/" + pid;
         logger.debug("Attempting to ingest with path: {}", path);
-
-        final Session session = getAuthenticatedSession();
 
         try {
             if (nodeService.exists(session, path)) {
-                return Response.status(HttpStatus.SC_CONFLICT).entity(path + " is an existing resource").build();
+                return status(SC_CONFLICT).entity(
+                        path + " is an existing resource").build();
             }
 
-            final FedoraResource resource = createObjectOrDatastreamFromRequestContent(FedoraNodes.class, session, path, mixin, uriInfo, requestBodyStream, requestContentType, checksumType, checksum);
+            final FedoraResource resource =
+                    createObjectOrDatastreamFromRequestContent(
+                            FedoraNodes.class, session, path, mixin, uriInfo,
+                            requestBodyStream, requestContentType,
+                            checksumType, checksum);
 
             session.save();
             logger.debug("Finished creating {} with path: {}", mixin, path);
-            return created(uriInfo.getBaseUriBuilder().path(FedoraNodes.class).build(resource.getPath().substring(1))).entity(path).build();
+            return created(
+                    uriInfo.getBaseUriBuilder().path(FedoraNodes.class).build(
+                            resource.getPath().substring(1))).entity(path)
+                    .build();
         } finally {
             session.logout();
         }
+    }
+
+    public void setSession(final Session session) {
+        this.session = session;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/url/HttpApiResources.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/url/HttpApiResources.java
@@ -1,11 +1,22 @@
+
 package org.fcrepo.url;
 
-import com.google.common.collect.ImmutableBiMap;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.hp.hpl.jena.rdf.model.Resource;
+import static com.google.common.collect.ImmutableBiMap.of;
+import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.RdfLexicon.HAS_FIXITY_SERVICE;
+import static org.fcrepo.RdfLexicon.HAS_NAMESPACE_SERVICE;
+import static org.fcrepo.RdfLexicon.HAS_SEARCH_SERVICE;
+import static org.fcrepo.RdfLexicon.HAS_SERIALIZATION;
+import static org.fcrepo.RdfLexicon.HAS_SITEMAP;
+import static org.fcrepo.RdfLexicon.HAS_TRANSACTION_SERVICE;
+import static org.fcrepo.RdfLexicon.HAS_VERSION_HISTORY;
+
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.ws.rs.core.UriInfo;
+
 import org.fcrepo.FedoraResource;
-import org.fcrepo.RdfLexicon;
 import org.fcrepo.api.FedoraExport;
 import org.fcrepo.api.FedoraFieldSearch;
 import org.fcrepo.api.FedoraFixity;
@@ -18,10 +29,8 @@ import org.fcrepo.rdf.GraphSubjects;
 import org.fcrepo.serialization.FedoraObjectSerializer;
 import org.springframework.stereotype.Component;
 
-import javax.jcr.RepositoryException;
-import javax.ws.rs.core.UriInfo;
-
-import java.util.Map;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Resource;
 
 @Component
 public class HttpApiResources implements UriAwareResourceModelFactory {
@@ -30,32 +39,52 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
     protected Map<String, FedoraObjectSerializer> serializers;
 
     @Override
-    public Model createModelForResource(FedoraResource resource, UriInfo uriInfo, GraphSubjects graphSubjects) throws RepositoryException {
+    public Model createModelForResource(final FedoraResource resource,
+            final UriInfo uriInfo, final GraphSubjects graphSubjects)
+            throws RepositoryException {
 
-        final Model model = ModelFactory.createDefaultModel();
+        final Model model = createDefaultModel();
         final Resource s = graphSubjects.getGraphSubject(resource.getNode());
 
         if (resource.getNode().getPrimaryNodeType().isNodeType("mode:root")) {
-            model.add(s, RdfLexicon.HAS_SEARCH_SERVICE, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraFieldSearch.class).build().toASCIIString()));
-            model.add(s, RdfLexicon.HAS_SITEMAP, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraSitemap.class).build().toASCIIString()));
-            model.add(s, RdfLexicon.HAS_TRANSACTION_SERVICE, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraTransactions.class).build().toASCIIString()));
-            model.add(s, RdfLexicon.HAS_NAMESPACE_SERVICE, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraRepositoryNamespaces.class).build().toASCIIString()));
+            model.add(s, HAS_SEARCH_SERVICE, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraFieldSearch.class).build()
+                    .toASCIIString()));
+            model.add(s, HAS_SITEMAP, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraSitemap.class).build()
+                    .toASCIIString()));
+            model.add(s, HAS_TRANSACTION_SERVICE, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraTransactions.class).build()
+                    .toASCIIString()));
+            model.add(s, HAS_NAMESPACE_SERVICE, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraRepositoryNamespaces.class)
+                    .build().toASCIIString()));
 
         } else {
 
-            for (String key : serializers.keySet()) {
-                final Map<String, String> pathMap = ImmutableBiMap.of("path", resource.getPath().substring(1), "format", key);
-                model.add(s, RdfLexicon.HAS_SERIALIZATION, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraExport.class).buildFromMap(pathMap).toASCIIString()));
+            for (final String key : serializers.keySet()) {
+                final Map<String, String> pathMap =
+                        of("path", resource.getPath().substring(1), "format",
+                                key);
+                model.add(s, HAS_SERIALIZATION, model.createResource(uriInfo
+                        .getBaseUriBuilder().path(FedoraExport.class)
+                        .buildFromMap(pathMap).toASCIIString()));
             }
 
-            final Map<String, String> pathMap = ImmutableBiMap.of("path", resource.getPath().substring(1));
-            model.add(s, RdfLexicon.HAS_VERSION_HISTORY, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraVersions.class).buildFromMap(pathMap).toASCIIString()));
+            final Map<String, String> pathMap =
+                    of("path", resource.getPath().substring(1));
+            model.add(s, HAS_VERSION_HISTORY, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraVersions.class)
+                    .buildFromMap(pathMap).toASCIIString()));
 
         }
 
         if (resource.hasContent()) {
-            final Map<String, String> pathMap = ImmutableBiMap.of("path", resource.getPath().substring(1));
-            model.add(s, RdfLexicon.HAS_FIXITY_SERVICE, model.createResource(uriInfo.getBaseUriBuilder().path(FedoraFixity.class).buildFromMap(pathMap).toASCIIString()));
+            final Map<String, String> pathMap =
+                    of("path", resource.getPath().substring(1));
+            model.add(s, HAS_FIXITY_SERVICE, model.createResource(uriInfo
+                    .getBaseUriBuilder().path(FedoraFixity.class).buildFromMap(
+                            pathMap).toASCIIString()));
         }
 
         return model;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraContentTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraContentTest.java
@@ -39,6 +39,7 @@ public class FedoraContentTest {
     FedoraContent testObj;
 
     DatastreamService mockDatastreams;
+
     NodeService mockNodeService;
 
     Session mockSession;
@@ -52,7 +53,7 @@ public class FedoraContentTest {
         testObj.setDatastreamService(mockDatastreams);
         testObj.setNodeService(mockNodeService);
         mockSession = TestHelpers.mockSession(testObj);
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
@@ -69,56 +70,66 @@ public class FedoraContentTest {
         final String dsContent = "asdf";
         final String dsPath = "/" + pid + "/" + dsId;
         final InputStream dsContentStream = IOUtils.toInputStream(dsContent);
-        Node mockNode = mock(Node.class);
+        final Node mockNode = mock(Node.class);
         when(mockNode.isNew()).thenReturn(true);
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
-        when(mockDatastreams.createDatastreamNode(any(Session.class),
-                                                         eq(dsPath), anyString(), any(InputStream.class))).thenReturn(mockNode);
+        when(
+                mockDatastreams.createDatastreamNode(any(Session.class),
+                        eq(dsPath), anyString(), any(InputStream.class)))
+                .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-                testObj.modifyContent(createPathList(pid, dsId), null, dsContentStream, null);
+                testObj.modifyContent(createPathList(pid, dsId), null,
+                        dsContentStream, null);
         assertEquals(Status.CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
                 eq(dsPath), anyString(), any(InputStream.class));
         verify(mockSession).save();
     }
 
-
     @Test
     public void testModifyContent() throws RepositoryException, IOException,
-                                                   InvalidChecksumException {
+            InvalidChecksumException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "testDS";
         final String dsContent = "asdf";
         final String dsPath = "/" + pid + "/" + dsId;
         final InputStream dsContentStream = IOUtils.toInputStream(dsContent);
-        Node mockNode = mock(Node.class);
+        final Node mockNode = mock(Node.class);
         when(mockNode.isNew()).thenReturn(false);
 
-        final Datastream mockDs = TestHelpers.mockDatastream(pid, dsId, dsContent);
-        when(mockDatastreams.getDatastream(mockSession, dsPath)).thenReturn(mockDs);
+        final Datastream mockDs =
+                TestHelpers.mockDatastream(pid, dsId, dsContent);
+        when(mockDatastreams.getDatastream(mockSession, dsPath)).thenReturn(
+                mockDs);
         final Request mockRequest = mock(Request.class);
-        when(mockRequest.evaluatePreconditions(any(Date.class), any(EntityTag.class))).thenReturn(null);
-        when(mockDatastreams.createDatastreamNode(any(Session.class),
-                                                         eq(dsPath), anyString(), any(InputStream.class))).thenReturn(mockNode);
+        when(
+                mockRequest.evaluatePreconditions(any(Date.class),
+                        any(EntityTag.class))).thenReturn(null);
+        when(
+                mockDatastreams.createDatastreamNode(any(Session.class),
+                        eq(dsPath), anyString(), any(InputStream.class)))
+                .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-                testObj.modifyContent(createPathList(pid, dsId), null, dsContentStream, mockRequest);
+                testObj.modifyContent(createPathList(pid, dsId), null,
+                        dsContentStream, mockRequest);
         assertEquals(Status.NO_CONTENT.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
-                                                            eq(dsPath), anyString(), any(InputStream.class));
+                eq(dsPath), anyString(), any(InputStream.class));
         verify(mockSession).save();
     }
 
     @Test
-    public void testGetContent() throws RepositoryException,
-            IOException {
+    public void testGetContent() throws RepositoryException, IOException {
         final String pid = "FedoraDatastreamsTest1";
-		final String dsId = "testDS";
+        final String dsId = "testDS";
         final String path = "/" + pid + "/" + dsId;
         final String dsContent = "asdf";
-        final Datastream mockDs = TestHelpers.mockDatastream(pid, dsId, dsContent);
-        when(mockDatastreams.getDatastream(mockSession, path)).thenReturn(mockDs);
+        final Datastream mockDs =
+                TestHelpers.mockDatastream(pid, dsId, dsContent);
+        when(mockDatastreams.getDatastream(mockSession, path)).thenReturn(
+                mockDs);
         final Request mockRequest = mock(Request.class);
         final Response actual =
                 testObj.getContent(createPathList(pid, dsId), mockRequest);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraDatastreamsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraDatastreamsTest.java
@@ -52,7 +52,6 @@ public class FedoraDatastreamsTest {
 
     Session mockSession;
 
-
     @Before
     public void setUp() throws LoginException, RepositoryException {
         mockDatastreams = mock(DatastreamService.class);
@@ -63,7 +62,7 @@ public class FedoraDatastreamsTest {
         testObj.setDatastreamService(mockDatastreams);
 
         mockSession = TestHelpers.mockSession(testObj);
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
@@ -83,8 +82,8 @@ public class FedoraDatastreamsTest {
         atts.put(dsId2, "sdfg");
         final MultiPart multipart = TestHelpers.getStringsAsMultipart(atts);
         final Response actual =
-                testObj.modifyDatastreams(createPathList(pid), Arrays
-                        .asList(dsId1, dsId2), multipart);
+                testObj.modifyDatastreams(createPathList(pid), Arrays.asList(
+                        dsId1, dsId2), multipart);
         assertEquals(Status.CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
                 eq("/" + pid + "/" + dsId1), anyString(),
@@ -99,8 +98,7 @@ public class FedoraDatastreamsTest {
     public void testDeleteDatastreams() throws RepositoryException, IOException {
         final String pid = "FedoraDatastreamsTest1";
         final String path = "/" + pid;
-        final List<String> dsidList =
-                Arrays.asList("ds1", "ds2");
+        final List<String> dsidList = Arrays.asList("ds1", "ds2");
         final Response actual =
                 testObj.deleteDatastreams(createPathList(pid), dsidList);
         assertEquals(Status.NO_CONTENT.getStatusCode(), actual.getStatus());
@@ -128,7 +126,7 @@ public class FedoraDatastreamsTest {
         when(mockIterator.nextNode()).thenReturn(mockDsNode);
 
         when(mockObject.getNode()).thenReturn(mockNode);
-        when(mockNode.getNodes(new String[]{dsId})).thenReturn(mockIterator);
+        when(mockNode.getNodes(new String[] {dsId})).thenReturn(mockIterator);
 
         when(mockNodes.getObject(mockSession, "/FedoraDatastreamsTest1"))
                 .thenReturn(mockObject);
@@ -144,7 +142,8 @@ public class FedoraDatastreamsTest {
         assertEquals(1, multipart.getBodyParts().size());
         final InputStream actualContent =
                 (InputStream) multipart.getBodyParts().get(0).getEntity();
-        assertEquals("/FedoraDatastreamsTest1/testDS", multipart.getBodyParts().get(0).getContentDisposition().getFileName());
+        assertEquals("/FedoraDatastreamsTest1/testDS", multipart.getBodyParts()
+                .get(0).getContentDisposition().getFileName());
         assertEquals("asdf", IOUtils.toString(actualContent, "UTF-8"));
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraFieldSearchTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraFieldSearchTest.java
@@ -21,7 +21,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Variant;
 
-import com.hp.hpl.jena.query.DatasetFactory;
 import org.fcrepo.rdf.GraphSubjects;
 import org.fcrepo.services.NodeService;
 import org.fcrepo.test.util.TestHelpers;
@@ -29,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.hp.hpl.jena.query.DatasetFactory;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 
 public class FedoraFieldSearchTest {
@@ -36,7 +36,9 @@ public class FedoraFieldSearchTest {
     FedoraFieldSearch testObj;
 
     Session mockSession;
+
     private NodeService mockNodeService;
+
     private UriInfo uriInfo;
 
     @Before
@@ -47,6 +49,7 @@ public class FedoraFieldSearchTest {
         testObj.setUriInfo(uriInfo);
         mockNodeService = mock(NodeService.class);
         testObj.setNodeService(mockNodeService);
+        testObj.setSession(mockSession);
     }
 
     @After
@@ -55,26 +58,42 @@ public class FedoraFieldSearchTest {
     }
 
     @Test
-    public void testFieldSearch() throws RepositoryException, URISyntaxException {
+    public void testFieldSearch() throws RepositoryException,
+            URISyntaxException {
 
         final Request mockRequest = mock(Request.class);
 
-        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost/fcrepo/path/to/query/endpoint"));
+        when(uriInfo.getRequestUri()).thenReturn(
+                new URI("http://localhost/fcrepo/path/to/query/endpoint"));
         when(mockRequest.selectVariant(any(List.class))).thenReturn(
-                                                                           new Variant(MediaType.valueOf("application/n-triples"), null,
-                                                                                              null));
+                new Variant(MediaType.valueOf("application/n-triples"), null,
+                        null));
 
-        when(mockNodeService.searchRepository(any(GraphSubjects.class), eq(ResourceFactory.createResource("http://localhost/fcrepo/path/to/query/endpoint")), eq(mockSession), eq("ZZZ"), eq(0), eq(0L))).thenReturn(DatasetFactory.create());
+        when(
+                mockNodeService
+                        .searchRepository(
+                                any(GraphSubjects.class),
+                                eq(ResourceFactory
+                                        .createResource("http://localhost/fcrepo/path/to/query/endpoint")),
+                                eq(mockSession), eq("ZZZ"), eq(0), eq(0L)))
+                .thenReturn(DatasetFactory.create());
         final UriBuilder mockUriBuilder = mock(UriBuilder.class);
 
-        when(mockUriBuilder.path(FedoraFieldSearch.class)).thenReturn(mockUriBuilder);
-        when(mockUriBuilder.buildFromMap(any(Map.class))).thenReturn(new URI("path/to/object"));
+        when(mockUriBuilder.path(FedoraFieldSearch.class)).thenReturn(
+                mockUriBuilder);
+        when(mockUriBuilder.buildFromMap(any(Map.class))).thenReturn(
+                new URI("path/to/object"));
 
-                    when(uriInfo.getRequestUriBuilder()).thenReturn(mockUriBuilder);
+        when(uriInfo.getRequestUriBuilder()).thenReturn(mockUriBuilder);
 
         testObj.searchSubmitRdf("ZZZ", 0, 0, mockRequest, uriInfo);
 
-        verify(mockNodeService).searchRepository(any(GraphSubjects.class), eq(ResourceFactory.createResource("http://localhost/fcrepo/path/to/query/endpoint")), eq(mockSession), eq("ZZZ"), eq(0), eq(0L));
+        verify(mockNodeService)
+                .searchRepository(
+                        any(GraphSubjects.class),
+                        eq(ResourceFactory
+                                .createResource("http://localhost/fcrepo/path/to/query/endpoint")),
+                        eq(mockSession), eq("ZZZ"), eq(0), eq(0L));
     }
 
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraFixityTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraFixityTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api;
 
 import static org.fcrepo.test.util.PathSegmentImpl.createPathList;
@@ -25,47 +26,53 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FedoraFixityTest {
-	FedoraFixity testObj;
 
-	DatastreamService mockDatastreams;
+    FedoraFixity testObj;
 
-	Session mockSession;
+    DatastreamService mockDatastreams;
+
+    Session mockSession;
 
     private UriInfo uriInfo;
+
     private Request mockRequest;
 
     @Before
-	public void setUp() throws LoginException, RepositoryException {
+    public void setUp() throws LoginException, RepositoryException {
 
         mockRequest = mock(Request.class);
-		mockDatastreams = mock(DatastreamService.class);
+        mockDatastreams = mock(DatastreamService.class);
 
-		testObj = new FedoraFixity();
-		testObj.setDatastreamService(mockDatastreams);
+        testObj = new FedoraFixity();
+        testObj.setDatastreamService(mockDatastreams);
 
         uriInfo = TestHelpers.getUriInfoImpl();
         testObj.setUriInfo(uriInfo);
 
+        mockSession = TestHelpers.mockSession(testObj);
+        testObj.setSession(mockSession);
+    }
 
-		mockSession = TestHelpers.mockSession(testObj);
-	}
+    @After
+    public void tearDown() {
 
-	@After
-	public void tearDown() {
+    }
 
-	}
-	@Test
-	public void testGetDatastreamFixity() throws RepositoryException,
-														 IOException {
-		final String pid = "FedoraDatastreamsTest1";
-		final String path = "/objects/" + pid + "/testDS";
-		final String dsId = "testDS";
-		final Datastream mockDs = TestHelpers.mockDatastream(pid, dsId, null);
-		Node mockNode = mock(Node.class);
-		when(mockNode.getSession()).thenReturn(mockSession);
-		when(mockDs.getNode()).thenReturn(mockNode);
-		when(mockDatastreams.getDatastream(mockSession, path)).thenReturn(mockDs);
-		testObj.getDatastreamFixity(createPathList("objects", pid, "testDS"), mockRequest, uriInfo);
-        verify(mockDatastreams).getFixityResultsModel(any(GraphSubjects.class), eq(mockDs));
-	}
+    @Test
+    public void testGetDatastreamFixity() throws RepositoryException,
+            IOException {
+        final String pid = "FedoraDatastreamsTest1";
+        final String path = "/objects/" + pid + "/testDS";
+        final String dsId = "testDS";
+        final Datastream mockDs = TestHelpers.mockDatastream(pid, dsId, null);
+        final Node mockNode = mock(Node.class);
+        when(mockNode.getSession()).thenReturn(mockSession);
+        when(mockDs.getNode()).thenReturn(mockNode);
+        when(mockDatastreams.getDatastream(mockSession, path)).thenReturn(
+                mockDs);
+        testObj.getDatastreamFixity(createPathList("objects", pid, "testDS"),
+                mockRequest, uriInfo);
+        verify(mockDatastreams).getFixityResultsModel(any(GraphSubjects.class),
+                eq(mockDs));
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraIdentifiersTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraIdentifiersTest.java
@@ -1,7 +1,11 @@
 
 package org.fcrepo.api;
 
+import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.RdfLexicon.HAS_MEMBER_OF_RESULT;
 import static org.fcrepo.test.util.PathSegmentImpl.createPathList;
+import static org.fcrepo.test.util.TestHelpers.getUriInfoImpl;
+import static org.fcrepo.test.util.TestHelpers.mockSession;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -14,16 +18,13 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.core.UriInfo;
 
-import org.fcrepo.RdfLexicon;
 import org.fcrepo.identifiers.PidMinter;
-import org.fcrepo.test.util.TestHelpers;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 
 import com.google.common.base.Function;
 import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
 
 public class FedoraIdentifiersTest {
 
@@ -43,9 +44,8 @@ public class FedoraIdentifiersTest {
 
         mockPidMinter = mock(PidMinter.class);
 
-        mockSession = TestHelpers.mockSession(testObj);
-
-        uriInfo = TestHelpers.getUriInfoImpl();
+        mockSession = mockSession(testObj);
+        uriInfo = getUriInfoImpl();
         testObj.setUriInfo(uriInfo);
 
     }
@@ -61,7 +61,6 @@ public class FedoraIdentifiersTest {
                     }
                 });
 
-
         testObj.setPidMinter(mockPidMinter);
 
         when(uriInfo.getAbsolutePath()).thenReturn(
@@ -70,14 +69,10 @@ public class FedoraIdentifiersTest {
         final Dataset np = testObj.getNextPid(createPathList(""), 2, uriInfo);
 
         LOGGER.debug("Got dataset {}", np.getDefaultModel().toString());
-        assertTrue(np
-                .getDefaultModel()
-                .contains(
-                        ResourceFactory
-                                .createResource("http://localhost/fcrepo/fcr:pid"),
-                        RdfLexicon.HAS_MEMBER_OF_RESULT,
-                        ResourceFactory
-                        .createResource("http://localhost/fcrepo/asdf:123")));
+        assertTrue(np.getDefaultModel().contains(
+                createResource("http://localhost/fcrepo/fcr:pid"),
+                HAS_MEMBER_OF_RESULT,
+                createResource("http://localhost/fcrepo/asdf:123")));
 
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraImportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraImportTest.java
@@ -1,13 +1,13 @@
+
 package org.fcrepo.api;
 
 import static org.fcrepo.test.util.PathSegmentImpl.createPathList;
+import static org.fcrepo.test.util.TestHelpers.mockSession;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
-import java.util.Map;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -22,29 +22,34 @@ public class FedoraImportTest {
     FedoraImport testObj;
 
     Session mockSession;
+
     SerializerUtil mockSerializers;
+
+    FedoraObjectSerializer mockSerializer;
 
     @Before
     public void setUp() throws RepositoryException {
 
         testObj = new FedoraImport();
 
-        mockSession = TestHelpers.mockSession(testObj);
+        mockSession = mockSession(testObj);
         mockSerializers = mock(SerializerUtil.class);
+        mockSerializer = mock(FedoraObjectSerializer.class);
+        when(mockSerializers.getSerializer("fake-format")).thenReturn(
+                mockSerializer);
         testObj.setSerializers(mockSerializers);
-
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
     @Test
     public void testImportObject() throws Exception {
-        InputStream mockInputStream = mock(InputStream.class);
-        FedoraObjectSerializer mockSerializer = mock(FedoraObjectSerializer.class);
-        when(mockSerializers.getSerializer("fake-format")).thenReturn(mockSerializer);
+        final InputStream mockInputStream = mock(InputStream.class);
 
-        testObj.importObject(createPathList("test", "object"), "fake-format", mockInputStream);
-        verify(mockSerializer).deserialize(mockSession, "/test/object", mockInputStream);
+        testObj.importObject(createPathList("test", "object"), "fake-format",
+                mockInputStream);
+        verify(mockSerializer).deserialize(mockSession, "/test/object",
+                mockInputStream);
 
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraNodesTest.java
@@ -68,6 +68,7 @@ public class FedoraNodesTest {
         mockSession = TestHelpers.mockSession(testObj);
         testObj.setObjectService(mockObjects);
         testObj.setNodeService(mockNodes);
+        testObj.setSession(mockSession);
         testObj.setDatastreamService(mockDatastreams);
         uriInfo = TestHelpers.getUriInfoImpl();
         testObj.setUriInfo(uriInfo);
@@ -88,18 +89,22 @@ public class FedoraNodesTest {
     }
 
     @Test
-    public void testModify() throws RepositoryException, IOException, InvalidChecksumException {
+    public void testModify() throws RepositoryException, IOException,
+            InvalidChecksumException {
         final String pid = "testObject";
 
         final FedoraResource mockResource = mock(FedoraResource.class);
         when(mockResource.isNew()).thenReturn(false);
         when(mockResource.getLastModifiedDate()).thenReturn(new Date());
-        when(mockNodes.findOrCreateObject(mockSession, "/testObject")).thenReturn(mockResource);
+        when(mockNodes.findOrCreateObject(mockSession, "/testObject"))
+                .thenReturn(mockResource);
         final Request mockRequest = mock(Request.class);
-        when(mockRequest.evaluatePreconditions(any(Date.class))).thenReturn(null);
+        when(mockRequest.evaluatePreconditions(any(Date.class))).thenReturn(
+                null);
         final Response actual =
                 testObj.modifyObject(createPathList(pid), TestHelpers
-                        .getUriInfoImpl(), new ByteArrayInputStream("".getBytes()), null, mockRequest);
+                        .getUriInfoImpl(), new ByteArrayInputStream(""
+                        .getBytes()), null, mockRequest);
         assertNotNull(actual);
         assertEquals(Status.NO_CONTENT.getStatusCode(), actual.getStatus());
         // this verify will fail when modify is actually implemented, thus encouraging the unit test to be updated appropriately.
@@ -172,7 +177,8 @@ public class FedoraNodesTest {
         when(mockDataset.getDefaultModel()).thenReturn(mockModel);
 
         when(mockObject.getLastModifiedDate()).thenReturn(null);
-        when(mockObject.getPropertiesDataset(any(GraphSubjects.class))).thenReturn(mockDataset);
+        when(mockObject.getPropertiesDataset(any(GraphSubjects.class)))
+                .thenReturn(mockDataset);
         when(
                 mockNodes.getObject(Mockito.isA(Session.class), Mockito
                         .isA(String.class))).thenReturn(mockObject);
@@ -199,7 +205,7 @@ public class FedoraNodesTest {
                 mockStream);
 
         verify(mockObject).updatePropertiesDataset(any(GraphSubjects.class),
-                                                          eq("my-sparql-statement"));
+                eq("my-sparql-statement"));
         verify(mockSession).save();
         verify(mockSession).logout();
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraRepositoryNamespacesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraRepositoryNamespacesTest.java
@@ -13,10 +13,6 @@ import javax.jcr.LoginException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.query.DatasetFactory;
-import com.hp.hpl.jena.rdf.model.Model;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
 import org.fcrepo.api.repository.FedoraRepositoryNamespaces;
 import org.fcrepo.services.NodeService;
 import org.fcrepo.test.util.TestHelpers;
@@ -24,11 +20,17 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.query.DatasetFactory;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
+
 public class FedoraRepositoryNamespacesTest {
 
     FedoraRepositoryNamespaces testObj;
 
     NodeService mockNodeService;
+
     private Session mockSession;
 
     @Before
@@ -38,6 +40,7 @@ public class FedoraRepositoryNamespacesTest {
 
         testObj = new FedoraRepositoryNamespaces();
         mockSession = TestHelpers.mockSession(testObj);
+        testObj.setSession(mockSession);
         testObj.setNodeService(mockNodeService);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
@@ -50,9 +53,10 @@ public class FedoraRepositoryNamespacesTest {
     @Test
     public void testGetNamespaces() throws RepositoryException, IOException {
 
-        Dataset mockDataset = mock(Dataset.class);
+        final Dataset mockDataset = mock(Dataset.class);
 
-        when(mockNodeService.getNamespaceRegistryGraph(mockSession)).thenReturn(mockDataset);
+        when(mockNodeService.getNamespaceRegistryGraph(mockSession))
+                .thenReturn(mockDataset);
         assertEquals(mockDataset, testObj.getNamespaces());
     }
 
@@ -60,11 +64,14 @@ public class FedoraRepositoryNamespacesTest {
     public void testUpdateNamespaces() throws RepositoryException, IOException {
 
         final Model model = ModelFactory.createDefaultModel();
-        Dataset mockDataset = DatasetFactory.create(model);
+        final Dataset mockDataset = DatasetFactory.create(model);
 
-        when(mockNodeService.getNamespaceRegistryGraph(mockSession)).thenReturn(mockDataset);
+        when(mockNodeService.getNamespaceRegistryGraph(mockSession))
+                .thenReturn(mockDataset);
 
-        testObj.updateNamespaces(new ByteArrayInputStream("INSERT { <http://example.com/this> <http://example.com/is> \"abc\"} WHERE { }".getBytes()));
+        testObj.updateNamespaces(new ByteArrayInputStream(
+                "INSERT { <http://example.com/this> <http://example.com/is> \"abc\"} WHERE { }"
+                        .getBytes()));
 
         assertEquals(1, model.size());
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraSitemapTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraSitemapTest.java
@@ -2,19 +2,15 @@
 package org.fcrepo.api;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import javax.jcr.LoginException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.SecurityContext;
 
 import org.fcrepo.jaxb.responses.sitemap.SitemapIndex;
 import org.fcrepo.services.ObjectService;
-import org.fcrepo.session.SessionFactory;
 import org.fcrepo.test.util.TestHelpers;
 import org.junit.After;
 import org.junit.Before;
@@ -35,6 +31,7 @@ public class FedoraSitemapTest {
         testObj.setObjectService(mockObjects);
         mockSession = TestHelpers.mockSession(testObj);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
+        testObj.setSession(mockSession);
     }
 
     @After
@@ -44,8 +41,7 @@ public class FedoraSitemapTest {
 
     @Test
     public void testGetSitemapIndex() throws Exception {
-        when(mockObjects.getRepositoryObjectCount()).thenReturn(
-                49999L);
+        when(mockObjects.getRepositoryObjectCount()).thenReturn(49999L);
 
         final SitemapIndex sitemapIndex = testObj.getSitemapIndex();
 
@@ -54,8 +50,7 @@ public class FedoraSitemapTest {
 
     @Test
     public void testGetSitemapIndexMultiplePages() throws Exception {
-        when(mockObjects.getRepositoryObjectCount()).thenReturn(
-                50001L);
+        when(mockObjects.getRepositoryObjectCount()).thenReturn(50001L);
 
         final SitemapIndex sitemapIndex = testObj.getSitemapIndex();
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraTransactionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraTransactionsTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api;
 
 import static org.junit.Assert.assertNotNull;
@@ -21,87 +22,91 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class FedoraTransactionsTest {
-	
-	private static final String IS_A_TX = "foo";
-	private static final String NOT_A_TX = "bar";
 
-	FedoraTransactions resource;
+    private static final String IS_A_TX = "foo";
 
-	Session mockSession;
-	
-	Transaction mockTx;
+    private static final String NOT_A_TX = "bar";
 
-	@Before
-	public void setup() throws Exception {
-		resource = new FedoraTransactions();
-		mockSession = TestHelpers.mockSession(resource);
-		mockTx = mock(Transaction.class);
-		when(mockTx.getId()).thenReturn(IS_A_TX);
-		Field txsField = FedoraTransactions.class.getDeclaredField("TRANSACTIONS");
-		txsField.setAccessible(true);
-		@SuppressWarnings("unchecked")
-		Map<String, Transaction> txs = (Map<String, Transaction>) txsField.get(FedoraTransactions.class);
-		txs.put(IS_A_TX, mockTx);
-	}
-	
-	@Test
-	public void testExpiration() throws Exception {
-		Date fiveSecondsAgo = new Date(System.currentTimeMillis() - 5000);
-		when(mockTx.getExpires()).thenReturn(fiveSecondsAgo);
-		resource.removeAndRollbackExpired();
-		verify(mockTx).rollback();
-	}
+    FedoraTransactions resource;
 
-	@Test
-	public void testCreateTx() throws Exception {
-		Transaction tx = resource.createTransaction();
-		
-		assertNotNull(tx);
-		assertNotNull(tx.getCreated());
-		assertNotNull(tx.getId());
-		assertTrue(tx.getState() == State.NEW);
-	}
+    Session mockSession;
 
-	@Test
-	public void testGetTx() throws Exception {
-		Transaction tx = resource.getTransaction(IS_A_TX);
+    Transaction mockTx;
 
-		assertNotNull(tx);
+    @Before
+    public void setup() throws Exception {
+        resource = new FedoraTransactions();
+        mockSession = TestHelpers.mockSession(resource);
+        mockTx = mock(Transaction.class);
+        when(mockTx.getId()).thenReturn(IS_A_TX);
+        final Field txsField =
+                FedoraTransactions.class.getDeclaredField("TRANSACTIONS");
+        txsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        final Map<String, Transaction> txs =
+                (Map<String, Transaction>) txsField
+                        .get(FedoraTransactions.class);
+        txs.put(IS_A_TX, mockTx);
+    }
 
-		try{
-			tx = resource.getTransaction(NOT_A_TX);
-			fail("Transaction retrieved for nonexistent id " + NOT_A_TX);
-		}catch(RepositoryException e){
-			// just checking that the exception occurs
-		}
-	}
+    @Test
+    public void testExpiration() throws Exception {
+        final Date fiveSecondsAgo = new Date(System.currentTimeMillis() - 5000);
+        when(mockTx.getExpires()).thenReturn(fiveSecondsAgo);
+        resource.removeAndRollbackExpired();
+        verify(mockTx).rollback();
+    }
 
-	@Test
-	public void testCommitTx() throws Exception {
-		Transaction tx = resource.commit(IS_A_TX);
+    @Test
+    public void testCreateTx() throws Exception {
+        final Transaction tx = resource.createTransaction();
 
-		assertNotNull(tx);
-		verify(mockTx).commit();
-		try{
-			tx = resource.getTransaction(tx.getId());
-			fail("Transaction is available after commit");
-		}catch(RepositoryException e){
-			// just checking that the exception occurs
-		}
-	}
+        assertNotNull(tx);
+        assertNotNull(tx.getCreated());
+        assertNotNull(tx.getId());
+        assertTrue(tx.getState() == State.NEW);
+    }
 
-	@Test
-	public void testRollbackTx() throws Exception {
-		Transaction tx = resource.rollback(IS_A_TX);
-		
-		assertNotNull(tx);
-		verify(mockTx).rollback();
-		try{
-			tx = resource.getTransaction(tx.getId());
-			fail("Transaction is available after commit");
-		}catch(RepositoryException e){
-			// just checking that the exception occurs
-		}
-	}
+    @Test
+    public void testGetTx() throws Exception {
+        Transaction tx = resource.getTransaction(IS_A_TX);
+
+        assertNotNull(tx);
+
+        try {
+            tx = resource.getTransaction(NOT_A_TX);
+            fail("Transaction retrieved for nonexistent id " + NOT_A_TX);
+        } catch (final RepositoryException e) {
+            // just checking that the exception occurs
+        }
+    }
+
+    @Test
+    public void testCommitTx() throws Exception {
+        Transaction tx = resource.commit(IS_A_TX);
+
+        assertNotNull(tx);
+        verify(mockTx).commit();
+        try {
+            tx = resource.getTransaction(tx.getId());
+            fail("Transaction is available after commit");
+        } catch (final RepositoryException e) {
+            // just checking that the exception occurs
+        }
+    }
+
+    @Test
+    public void testRollbackTx() throws Exception {
+        Transaction tx = resource.rollback(IS_A_TX);
+
+        assertNotNull(tx);
+        verify(mockTx).rollback();
+        try {
+            tx = resource.getTransaction(tx.getId());
+            fail("Transaction is available after commit");
+        } catch (final RepositoryException e) {
+            // just checking that the exception occurs
+        }
+    }
 
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraUnnamedObjectsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraUnnamedObjectsTest.java
@@ -33,6 +33,7 @@ public class FedoraUnnamedObjectsTest {
     Session mockSession;
 
     ObjectService mockObjects;
+
     NodeService mockNodeService;
 
     @Before
@@ -43,7 +44,7 @@ public class FedoraUnnamedObjectsTest {
         mockSession = TestHelpers.mockSession(testObj);
         testObj.setNodeService(mockNodeService);
         testObj.setObjectService(mockObjects);
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
@@ -61,13 +62,17 @@ public class FedoraUnnamedObjectsTest {
 
         final FedoraObject mockObject = mock(FedoraObject.class);
         when(mockObject.getPath()).thenReturn("/objects/uuid-123");
-        when(mockObjects.createObject(mockSession, "/objects/uuid-123")).thenReturn(mockObject);
+        when(mockObjects.createObject(mockSession, "/objects/uuid-123"))
+                .thenReturn(mockObject);
         final Response actual =
                 testObj.ingestAndMint(createPathList("objects"),
-                                             FedoraJcrTypes.FEDORA_OBJECT, null, null, null, null, TestHelpers.getUriInfoImpl());
+                        FedoraJcrTypes.FEDORA_OBJECT, null, null, null, null,
+                        TestHelpers.getUriInfoImpl());
         assertNotNull(actual);
-        assertEquals("http://localhost/fcrepo/objects/uuid-123", actual.getMetadata().getFirst("Location").toString());
-        assertEquals(Response.Status.CREATED.getStatusCode(), actual.getStatus());
+        assertEquals("http://localhost/fcrepo/objects/uuid-123", actual
+                .getMetadata().getFirst("Location").toString());
+        assertEquals(Response.Status.CREATED.getStatusCode(), actual
+                .getStatus());
         assertTrue(actual.getEntity().toString().endsWith("uuid-123"));
         verify(mockObjects).createObject(mockSession, "/objects/uuid-123");
         verify(mockNodeService).exists(mockSession, "/objects/uuid-123");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraVersionsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraVersionsTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api;
 
 import static org.mockito.Mockito.mock;
@@ -11,28 +12,24 @@ import org.fcrepo.test.util.TestHelpers;
 import org.junit.Before;
 
 public class FedoraVersionsTest {
-	
-	FedoraVersions testObj;
-	
-	NodeService mockNodes;
 
-	Session mockSession;
+    FedoraVersions testObj;
 
-	
+    NodeService mockNodes;
+
+    Session mockSession;
 
     @Before
     public void setUp() throws LoginException, RepositoryException {
 
-	    testObj = new FedoraVersions();
+        testObj = new FedoraVersions();
 
-		mockNodes = mock(NodeService.class);
-		testObj.setNodeService(mockNodes);
-
-		mockSession = TestHelpers.mockSession(testObj);
+        mockNodes = mock(NodeService.class);
+        testObj.setNodeService(mockNodes);
+        mockSession = TestHelpers.mockSession(testObj);
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
-        
+
     }
 
-
-    
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoriesPropertiesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoriesPropertiesTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api.repository;
 
 import static org.mockito.Mockito.mock;
@@ -19,9 +20,10 @@ import org.junit.Test;
 
 public class FedoraRepositoriesPropertiesTest {
 
-
     private FedoraRepositoriesProperties testObj;
+
     private NodeService mockNodes;
+
     private Session mockSession;
 
     @Before
@@ -29,10 +31,10 @@ public class FedoraRepositoriesPropertiesTest {
         mockNodes = mock(NodeService.class);
         testObj = new FedoraRepositoriesProperties();
         mockSession = TestHelpers.mockSession(testObj);
+        testObj.setSession(mockSession);
         testObj.setNodeService(mockNodes);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
-
 
     @Test
     public void testSparqlUpdate() throws RepositoryException, IOException {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryImportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryImportTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api.repository;
 
 import static org.fcrepo.test.util.PathSegmentImpl.createPathList;
@@ -6,8 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
-import java.util.Map;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -22,6 +21,7 @@ public class FedoraRepositoryImportTest {
     FedoraRepositoryImport testObj;
 
     Session mockSession;
+
     SerializerUtil mockSerializers;
 
     @Before
@@ -32,16 +32,17 @@ public class FedoraRepositoryImportTest {
         mockSession = TestHelpers.mockSession(testObj);
         mockSerializers = mock(SerializerUtil.class);
         testObj.setSerializers(mockSerializers);
-
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
     @Test
     public void testImportObject() throws Exception {
-        InputStream mockInputStream = mock(InputStream.class);
-        FedoraObjectSerializer mockSerializer = mock(FedoraObjectSerializer.class);
-        when(mockSerializers.getSerializer("fake-format")).thenReturn(mockSerializer);
+        final InputStream mockInputStream = mock(InputStream.class);
+        final FedoraObjectSerializer mockSerializer =
+                mock(FedoraObjectSerializer.class);
+        when(mockSerializers.getSerializer("fake-format")).thenReturn(
+                mockSerializer);
 
         testObj.importObject(createPathList(), "fake-format", mockInputStream);
         verify(mockSerializer).deserialize(mockSession, "/", mockInputStream);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryUnnamedObjectsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryUnnamedObjectsTest.java
@@ -1,3 +1,4 @@
+
 package org.fcrepo.api.repository;
 
 import static org.junit.Assert.assertEquals;
@@ -31,6 +32,7 @@ public class FedoraRepositoryUnnamedObjectsTest {
     Session mockSession;
 
     ObjectService mockObjects;
+
     NodeService mockNodeService;
 
     @Before
@@ -41,7 +43,7 @@ public class FedoraRepositoryUnnamedObjectsTest {
         mockSession = TestHelpers.mockSession(testObj);
         testObj.setNodeService(mockNodeService);
         testObj.setObjectService(mockObjects);
-
+        testObj.setSession(mockSession);
         testObj.setUriInfo(TestHelpers.getUriInfoImpl());
     }
 
@@ -52,20 +54,24 @@ public class FedoraRepositoryUnnamedObjectsTest {
 
     @Test
     public void testIngestAndMint() throws RepositoryException, IOException,
-                                                   InvalidChecksumException {
+            InvalidChecksumException {
         final UUIDPidMinter mockMint = mock(UUIDPidMinter.class);
         testObj.setPidMinter(mockMint);
         when(mockMint.mintPid()).thenReturn("uuid-123");
 
         final FedoraObject mockObject = mock(FedoraObject.class);
         when(mockObject.getPath()).thenReturn("/uuid-123");
-        when(mockObjects.createObject(mockSession, "/uuid-123")).thenReturn(mockObject);
+        when(mockObjects.createObject(mockSession, "/uuid-123")).thenReturn(
+                mockObject);
 
         final Response actual =
-                testObj.ingestAndMint(FedoraJcrTypes.FEDORA_OBJECT, null, null, null, null, TestHelpers.getUriInfoImpl());
+                testObj.ingestAndMint(FedoraJcrTypes.FEDORA_OBJECT, null, null,
+                        null, null, TestHelpers.getUriInfoImpl());
         assertNotNull(actual);
-        assertEquals("http://localhost/fcrepo/uuid-123", actual.getMetadata().getFirst("Location").toString());
-        assertEquals(Response.Status.CREATED.getStatusCode(), actual.getStatus());
+        assertEquals("http://localhost/fcrepo/uuid-123", actual.getMetadata()
+                .getFirst("Location").toString());
+        assertEquals(Response.Status.CREATED.getStatusCode(), actual
+                .getStatus());
         assertTrue(actual.getEntity().toString().endsWith("uuid-123"));
         verify(mockObjects).createObject(mockSession, "/uuid-123");
         verify(mockNodeService).exists(mockSession, "/uuid-123");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraFixityIT.java
@@ -3,10 +3,6 @@ package org.fcrepo.integration.api;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.rdf.model.Property;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.update.GraphStore;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -14,6 +10,10 @@ import org.apache.http.client.methods.HttpPost;
 import org.fcrepo.RdfLexicon;
 import org.fcrepo.test.util.TestHelpers;
 import org.junit.Test;
+
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.hp.hpl.jena.update.GraphStore;
 
 public class FedoraFixityIT extends AbstractResourceIT {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraIdentifiersIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraIdentifiersIT.java
@@ -8,15 +8,16 @@ import java.io.IOException;
 
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.collect.Iterators;
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.update.GraphStore;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.fcrepo.RdfLexicon;
 import org.fcrepo.test.util.TestHelpers;
 import org.junit.Test;
+
+import com.google.common.collect.Iterators;
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.hp.hpl.jena.update.GraphStore;
 
 public class FedoraIdentifiersIT extends AbstractResourceIT {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNamespacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNamespacesIT.java
@@ -5,19 +5,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.hp.hpl.jena.graph.Node;
-import com.hp.hpl.jena.rdf.model.ResourceFactory;
-import com.hp.hpl.jena.update.GraphStore;
+import java.io.ByteArrayInputStream;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.BasicHttpEntity;
 import org.fcrepo.RdfLexicon;
 import org.fcrepo.test.util.TestHelpers;
-import org.fcrepo.utils.JcrRdfTools;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.hp.hpl.jena.update.GraphStore;
 
 public class FedoraNamespacesIT extends AbstractResourceIT {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNodesIT.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import javax.jcr.RepositoryException;
 import javax.ws.rs.core.Response;
 
-import com.hp.hpl.jena.sparql.core.Quad;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -32,6 +31,7 @@ import org.junit.Test;
 import com.hp.hpl.jena.graph.Graph;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.sparql.core.Quad;
 import com.hp.hpl.jena.update.GraphStore;
 
 public class FedoraNodesIT extends AbstractResourceIT {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraTransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraTransactionsIT.java
@@ -19,11 +19,11 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
     @Test
     public void testCreateAndGetTransaction() throws Exception {
         /* create a tx */
-        HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
+        final HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
         HttpResponse resp = execute(createTx);
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
-        ObjectMapper mapper = new ObjectMapper();
-        Transaction tx =
+        final ObjectMapper mapper = new ObjectMapper();
+        final Transaction tx =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         createTx.releaseConnection();
@@ -34,11 +34,12 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         assertTrue(tx.getState() == State.NEW);
 
         /* fetch the created tx from the endpoint */
-        HttpGet getTx = new HttpGet(serverAddress + "fcr:tx/" + tx.getId());
+        final HttpGet getTx =
+                new HttpGet(serverAddress + "fcr:tx/" + tx.getId());
         getTx.setHeader("Accept", "application/json");
         resp = execute(getTx);
         assertEquals(200, resp.getStatusLine().getStatusCode());
-        Transaction fetched =
+        final Transaction fetched =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         getTx.releaseConnection();
@@ -50,15 +51,16 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
     @Test
     public void testCreateAndTimeoutTransaction() throws Exception {
 
-        long start = System.currentTimeMillis();
+        final long start = System.currentTimeMillis();
         /* create a tx that will timeout in 10 ms */
-        long testTimeout = 10;
-    	System.setProperty(Transaction.TIMEOUT_SYSTEM_PROPERTY, Long.toString(testTimeout));
-        HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
+        final long testTimeout = 10;
+        System.setProperty(Transaction.TIMEOUT_SYSTEM_PROPERTY, Long
+                .toString(testTimeout));
+        final HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
         HttpResponse resp = execute(createTx);
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
-        ObjectMapper mapper = new ObjectMapper();
-        Transaction tx =
+        final ObjectMapper mapper = new ObjectMapper();
+        final Transaction tx =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         assertNotNull(tx);
@@ -72,20 +74,21 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         long diff = 0;
         // the loop should be able to run for at least the tx reaping interval
         while (!expired &&
-        		(diff = (System.currentTimeMillis() - start)) < (2* FedoraTransactions.REAP_INTERVAL)) {
+                (diff = (System.currentTimeMillis() - start)) < (2 * FedoraTransactions.REAP_INTERVAL)) {
             /* check that the tx is removed */
-            HttpGet getTx = new HttpGet(serverAddress + "fcr:tx/" + tx.getId());
+            final HttpGet getTx =
+                    new HttpGet(serverAddress + "fcr:tx/" + tx.getId());
             resp = execute(getTx);
             getTx.releaseConnection();
             expired = (404 == resp.getStatusLine().getStatusCode());
         }
 
         try {
-        	assertTrue("Transaction did not expire", expired);
-        	assertTrue(diff >= testTimeout);
+            assertTrue("Transaction did not expire", expired);
+            assertTrue(diff >= testTimeout);
         } finally {
-        	System.setProperty(Transaction.TIMEOUT_SYSTEM_PROPERTY,
-        			Long.toString(Transaction.DEFAULT_TIMEOUT));
+            System.setProperty(Transaction.TIMEOUT_SYSTEM_PROPERTY, Long
+                    .toString(Transaction.DEFAULT_TIMEOUT));
         }
         System.clearProperty("fcrepo4.tx.timeout");
     }
@@ -93,11 +96,11 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
     @Test
     public void testCreateAndCommitTransaction() throws Exception {
         /* create a tx */
-        HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
+        final HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
         HttpResponse resp = execute(createTx);
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
-        ObjectMapper mapper = new ObjectMapper();
-        Transaction tx =
+        final ObjectMapper mapper = new ObjectMapper();
+        final Transaction tx =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         createTx.releaseConnection();
@@ -108,7 +111,7 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         assertTrue(tx.getState() == State.NEW);
 
         /* create a new object inside the tx */
-        HttpPost postNew =
+        final HttpPost postNew =
                 new HttpPost(serverAddress + "fcr:tx/" + tx.getId() +
                         "/objects/testobj1/fcr:newhack");
         resp = execute(postNew);
@@ -116,19 +119,19 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
 
         /* check if the object is already there, before the commit */
-        HttpGet getObj = new HttpGet(serverAddress + "/objects/testobj1");
+        final HttpGet getObj = new HttpGet(serverAddress + "/objects/testobj1");
         resp = execute(getObj);
         getObj.releaseConnection();
         assertTrue(resp.getStatusLine().toString(), resp.getStatusLine()
                 .getStatusCode() == 404);
 
         /* commit the tx */
-        HttpPost commitTx =
+        final HttpPost commitTx =
                 new HttpPost(serverAddress + "fcr:tx/" + tx.getId() +
                         "/fcr:commit");
         resp = execute(commitTx);
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
-        Transaction committed =
+        final Transaction committed =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         commitTx.releaseConnection();
@@ -144,11 +147,11 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
     @Test
     public void testCreateAndRollbackTransaction() throws Exception {
         /* create a tx */
-        HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
+        final HttpPost createTx = new HttpPost(serverAddress + "fcr:tx");
         HttpResponse resp = execute(createTx);
         assertTrue(resp.getStatusLine().getStatusCode() == 200);
-        ObjectMapper mapper = new ObjectMapper();
-        Transaction tx =
+        final ObjectMapper mapper = new ObjectMapper();
+        final Transaction tx =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         createTx.releaseConnection();
@@ -159,7 +162,7 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         assertTrue(tx.getState() == State.NEW);
 
         /* create a new object inside the tx */
-        HttpPost postNew =
+        final HttpPost postNew =
                 new HttpPost(serverAddress + "fcr:tx/" + tx.getId() +
                         "/objects/testobj2/fcr:newhack");
         resp = execute(postNew);
@@ -167,18 +170,18 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
         postNew.releaseConnection();
 
         /* check if the object is already there, before the commit */
-        HttpGet getObj = new HttpGet(serverAddress + "/objects/testobj2");
+        final HttpGet getObj = new HttpGet(serverAddress + "/objects/testobj2");
         resp = execute(getObj);
         getObj.releaseConnection();
         assertTrue(resp.getStatusLine().toString(), resp.getStatusLine()
                 .getStatusCode() == 404);
 
         /* and rollback */
-        HttpPost rollbackTx =
+        final HttpPost rollbackTx =
                 new HttpPost(serverAddress + "fcr:tx/" + tx.getId() +
                         "/fcr:rollback");
         resp = execute(rollbackTx);
-        Transaction rolledBack =
+        final Transaction rolledBack =
                 mapper.readValue(resp.getEntity().getContent(),
                         Transaction.class);
         rollbackTx.releaseConnection();

--- a/fcrepo-http-api/src/test/resources/logback-test.xml
+++ b/fcrepo-http-api/src/test/resources/logback-test.xml
@@ -13,7 +13,7 @@
     <logger name="org.modeshape" additivity="false" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="org.apache.http.client" additivity="false" level="DEBUG">
+    <logger name="org.infinispan" additivity="false" level="WARN">
         <appender-ref ref="STDOUT"/>
     </logger>
     <root additivity="false" level="INFO">

--- a/fcrepo-http-api/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-http-api/src/test/resources/spring-test/rest.xml
@@ -7,7 +7,7 @@
     http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
   <bean class="org.fcrepo.session.SessionFactory"/>
-
+  
   <!-- Mints PIDs-->
   <bean class="org.fcrepo.identifiers.UUIDPidMinter"/>
 

--- a/fcrepo-http-api/src/test/resources/web.xml
+++ b/fcrepo-http-api/src/test/resources/web.xml
@@ -38,7 +38,7 @@
 		<servlet-class>com.sun.jersey.spi.spring.container.servlet.SpringServlet</servlet-class>
 		<init-param>
 			<param-name>com.sun.jersey.config.property.packages</param-name>
-			<param-value>org.fcrepo.api, org.fcrepo.responses, org.fcrepo.exceptionhandlers</param-value>
+			<param-value>org.fcrepo.api, org.fcrepo.responses, org.fcrepo.exceptionhandlers, org.fcrepo.session</param-value>
 		</init-param>
 		<init-param>
 			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/AbstractResource.java
@@ -19,12 +19,10 @@ import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
-import com.google.common.eventbus.EventBus;
-import com.hp.hpl.jena.query.Dataset;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.riot.WebContent;
-import org.fcrepo.api.rdf.HttpTripleUtil;
 import org.fcrepo.api.rdf.HttpGraphSubjects;
+import org.fcrepo.api.rdf.HttpTripleUtil;
 import org.fcrepo.exception.InvalidChecksumException;
 import org.fcrepo.identifiers.PidMinter;
 import org.fcrepo.rdf.GraphSubjects;
@@ -38,6 +36,9 @@ import org.fcrepo.utils.NamespaceTools;
 import org.modeshape.jcr.api.JcrTools;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.common.eventbus.EventBus;
+import com.hp.hpl.jena.query.Dataset;
 
 /**
  * Abstract superclass for Fedora JAX-RS Resources, providing convenience fields
@@ -81,10 +82,10 @@ public abstract class AbstractResource {
     @Autowired
     protected DatastreamService datastreamService;
 
-    @Autowired(required=false)
+    @Autowired(required = false)
     private HttpTripleUtil httpTripleUtil;
 
-    @Autowired(required=false)
+    @Autowired(required = false)
     protected EventBus eventBus;
 
     /**
@@ -108,11 +109,12 @@ public abstract class AbstractResource {
     @PostConstruct
     public void initialize() throws RepositoryException {
 
-        final Session session = sessions.getSession();
-        NamespaceTools.getNamespaceRegistry(session).registerNamespace(
+        final Session testSession = sessions.getSession();
+        NamespaceTools.getNamespaceRegistry(testSession).registerNamespace(
                 TEST_NS_PREFIX, TEST_NS_URI);
-        session.save();
-        session.logout();
+        testSession.save();
+        testSession.logout();
+
     }
 
     /**
@@ -166,11 +168,12 @@ public abstract class AbstractResource {
                 result = objectService.createObject(session, path);
 
                 if (requestBodyStream != null &&
-                            requestContentType != null &&
-                            requestContentType.toString().equals(
-                                                                        WebContent.contentTypeSPARQLUpdate)) {
-                    result.updatePropertiesDataset(new HttpGraphSubjects(pathsRelativeTo,
-                                                                                uriInfo), IOUtils.toString(requestBodyStream));
+                        requestContentType != null &&
+                        requestContentType.toString().equals(
+                                WebContent.contentTypeSPARQLUpdate)) {
+                    result.updatePropertiesDataset(new HttpGraphSubjects(
+                            pathsRelativeTo, uriInfo), IOUtils
+                            .toString(requestBodyStream));
                 }
 
                 break;
@@ -181,8 +184,8 @@ public abstract class AbstractResource {
 
                 final Node node =
                         datastreamService.createDatastreamNode(session, path,
-                                                                      contentType.toString(), requestBodyStream,
-                                                                      checksumType, checksum);
+                                contentType.toString(), requestBodyStream,
+                                checksumType, checksum);
                 result = new Datastream(node);
                 break;
             default:
@@ -193,9 +196,13 @@ public abstract class AbstractResource {
         return result;
     }
 
-    protected void addResponseInformationToDataset(final FedoraResource resource, final Dataset dataset, final UriInfo uriInfo, GraphSubjects subjects) throws RepositoryException {
+    protected void addResponseInformationToDataset(
+            final FedoraResource resource, final Dataset dataset,
+            final UriInfo uriInfo, final GraphSubjects subjects)
+            throws RepositoryException {
         if (httpTripleUtil != null) {
-            httpTripleUtil.addHttpComponentModelsForResource(dataset, resource, uriInfo, subjects);
+            httpTripleUtil.addHttpComponentModelsForResource(dataset, resource,
+                    uriInfo, subjects);
         }
     }
 
@@ -262,7 +269,6 @@ public abstract class AbstractResource {
     public void setDatastreamService(final DatastreamService datastreamService) {
         this.datastreamService = datastreamService;
     }
-
 
     /**
      * Set the Event Bus, used primary for testing without spring

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/api/rdf/HttpTripleUtil.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/api/rdf/HttpTripleUtil.java
@@ -1,7 +1,12 @@
 package org.fcrepo.api.rdf;
 
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.rdf.model.Model;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.ws.rs.core.UriInfo;
+
 import org.fcrepo.FedoraResource;
 import org.fcrepo.rdf.GraphSubjects;
 import org.slf4j.Logger;
@@ -10,11 +15,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
 
-import javax.jcr.RepositoryException;
-import javax.ws.rs.core.UriInfo;
-import java.util.Map;
-
-import static org.slf4j.LoggerFactory.getLogger;
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * Utility for injecting HTTP-contextual data into a Dataset

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/api/rdf/UriAwareResourceModelFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/api/rdf/UriAwareResourceModelFactory.java
@@ -1,11 +1,12 @@
 package org.fcrepo.api.rdf;
 
-import com.hp.hpl.jena.rdf.model.Model;
+import javax.jcr.RepositoryException;
+import javax.ws.rs.core.UriInfo;
+
 import org.fcrepo.FedoraResource;
 import org.fcrepo.rdf.GraphSubjects;
 
-import javax.jcr.RepositoryException;
-import javax.ws.rs.core.UriInfo;
+import com.hp.hpl.jena.rdf.model.Model;
 
 /**
  * Helper to generate an RDF model for a FedoraResource that (likely) creates relations

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/responses/GraphStoreStreamingOutput.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/responses/GraphStoreStreamingOutput.java
@@ -12,11 +12,12 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
+import org.slf4j.Logger;
+
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 import com.hp.hpl.jena.update.GraphStore;
-import org.slf4j.Logger;
 
 public class GraphStoreStreamingOutput implements StreamingOutput {
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/responses/HtmlProvider.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/responses/HtmlProvider.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
@@ -44,6 +43,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.query.Dataset;

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/responses/RdfSerializationUtils.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/responses/RdfSerializationUtils.java
@@ -18,9 +18,9 @@ import org.slf4j.Logger;
 
 import com.hp.hpl.jena.graph.Node;
 import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.sparql.core.Quad;
 import com.hp.hpl.jena.sparql.util.Context;
 import com.hp.hpl.jena.sparql.util.Symbol;
-import com.hp.hpl.jena.sparql.core.Quad;
 
 public class RdfSerializationUtils {
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/session/InjectableSession.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/session/InjectableSession.java
@@ -1,0 +1,59 @@
+
+package org.fcrepo.session;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Throwables.propagate;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.SecurityContext;
+
+import org.slf4j.Logger;
+
+import com.sun.jersey.spi.inject.Injectable;
+
+public class InjectableSession implements Injectable<Session> {
+
+    private SessionFactory sessionFactory;
+
+    private SecurityContext secContext;
+
+    private HttpServletRequest request;
+
+    private static final Logger logger = getLogger(InjectableSession.class);
+
+    public InjectableSession(final SessionFactory sessionFactory,
+            final SecurityContext reqContext, final HttpServletRequest request) {
+        checkNotNull(sessionFactory, "SessionFactory cannot be null!");
+        checkNotNull(reqContext, "HttpRequestContext cannot be null!");
+        checkNotNull(request, "HttpServletRequest cannot be null!");
+        logger.debug(
+                "Initializing an InjectableSession with SessionFactory {}.",
+                sessionFactory);
+        this.sessionFactory = sessionFactory;
+        this.secContext = reqContext;
+        this.request = request;
+
+    }
+
+    @Override
+    public Session getValue() {
+        if (secContext.getUserPrincipal() != null) {
+            logger.debug("Returning authenticated Session.");
+            sessionFactory.getSession(secContext, request);
+        } else {
+            logger.debug("Returning unauthenticated Session.");
+            try {
+                return sessionFactory.getSession();
+            } catch (final RepositoryException e) {
+                propagate(e);
+            }
+        }
+        throw new RuntimeException(
+                "Couldn't generate an appropriate session from HTTP Request: " +
+                        request);
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/session/InjectedSession.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/session/InjectedSession.java
@@ -1,0 +1,18 @@
+
+package org.fcrepo.session;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+@Documented
+public @interface InjectedSession {
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/session/SessionFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/session/SessionFactory.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.SecurityContext;
 import org.modeshape.jcr.api.ServletCredentials;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 
 public class SessionFactory {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/session/SessionProvider.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/session/SessionProvider.java
@@ -1,0 +1,58 @@
+
+package org.fcrepo.session;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.sun.jersey.api.core.InjectParam;
+import com.sun.jersey.core.spi.component.ComponentContext;
+import com.sun.jersey.spi.inject.Injectable;
+import com.sun.jersey.spi.inject.PerRequestTypeInjectableProvider;
+
+@Provider
+public class SessionProvider extends
+        PerRequestTypeInjectableProvider<InjectedSession, Session> {
+
+    @Autowired
+    @InjectParam
+    SessionFactory sessionFactory;
+
+    @Context
+    private SecurityContext secContext;
+
+    @Context
+    private HttpServletRequest request;
+
+    private static final Logger logger = getLogger(SessionProvider.class);
+
+    public SessionProvider() {
+        super(Session.class);
+    }
+
+    @Override
+    public Injectable<Session> getInjectable(final ComponentContext ic,
+            final InjectedSession a) {
+        logger.trace("Returning new InjectableSession...");
+        return new InjectableSession(sessionFactory, secContext, request);
+    }
+
+    public void setSessionFactory(final SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    public void setSecContext(final SecurityContext secContext) {
+        this.secContext = secContext;
+    }
+
+    public void setRequest(final HttpServletRequest request) {
+        this.request = request;
+    }
+}

--- a/fcrepo-http-commons/src/test/java/javax/servlet/ServletException.java
+++ b/fcrepo-http-commons/src/test/java/javax/servlet/ServletException.java
@@ -8,8 +8,8 @@ public class ServletException extends Exception {
         super(mesg);
     }
 
-    public ServletException(final Exception mesg) {
-        super(mesg);
+    public ServletException(final Throwable e) {
+        super(e);
     }
 
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/api/rdf/HttpTripleUtilTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/api/rdf/HttpTripleUtilTest.java
@@ -1,25 +1,25 @@
 package org.fcrepo.api.rdf;
 
-import com.google.common.collect.ImmutableBiMap;
-import com.hp.hpl.jena.query.Dataset;
-import com.hp.hpl.jena.query.DatasetFactory;
-import com.hp.hpl.jena.rdf.model.ModelFactory;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.ws.rs.core.UriInfo;
+
 import org.fcrepo.FedoraResource;
 import org.fcrepo.rdf.GraphSubjects;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 
-import javax.jcr.RepositoryException;
-import javax.ws.rs.core.UriInfo;
-
-import java.util.Map;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import com.google.common.collect.ImmutableBiMap;
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.query.DatasetFactory;
+import com.hp.hpl.jena.rdf.model.ModelFactory;
 
 public class HttpTripleUtilTest {
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/session/InjectableSessionTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/session/InjectableSessionTest.java
@@ -1,0 +1,50 @@
+
+package org.fcrepo.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.SecurityContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class InjectableSessionTest {
+
+    InjectableSession testObj;
+
+    Repository mockRepo;
+
+    Session mockSession;
+
+    @Before
+    public void setUp() throws RepositoryException {
+        mockSession = mock(Session.class);
+        mockRepo = mock(Repository.class);
+        final SessionFactory mockSessionFactory = mock(SessionFactory.class);
+        mockSessionFactory.setRepository(mockRepo);
+        when(mockSessionFactory.getSession()).thenReturn(mockSession);
+        final SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        final HttpServletRequest mockHttpServletRequest =
+                mock(HttpServletRequest.class);
+        when(
+                mockSessionFactory.getSession(mockSecurityContext,
+                        mockHttpServletRequest)).thenReturn(mockSession);
+        testObj =
+                new InjectableSession(mockSessionFactory, mockSecurityContext,
+                        mockHttpServletRequest);
+
+    }
+
+    @Test
+    public void testGetValue() {
+        assertEquals("Didn't get the Session we expected!", mockSession,
+                testObj.getValue());
+    }
+
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/session/SessionProviderTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/session/SessionProviderTest.java
@@ -1,0 +1,59 @@
+
+package org.fcrepo.session;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.SecurityContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.jersey.core.spi.component.ComponentContext;
+import com.sun.jersey.spi.inject.Injectable;
+
+public class SessionProviderTest {
+
+    SessionProvider testObj;
+
+    Repository mockRepo;
+
+    Session mockSession;
+
+    @Before
+    public void setUp() throws RepositoryException {
+        mockSession = mock(Session.class);
+        mockRepo = mock(Repository.class);
+        final SessionFactory mockSessionFactory = mock(SessionFactory.class);
+        mockSessionFactory.setRepository(mockRepo);
+        when(mockSessionFactory.getSession()).thenReturn(mockSession);
+        final SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        final HttpServletRequest mockHttpServletRequest =
+                mock(HttpServletRequest.class);
+        when(
+                mockSessionFactory.getSession(mockSecurityContext,
+                        mockHttpServletRequest)).thenReturn(mockSession);
+
+        testObj = new SessionProvider();
+        testObj.setSessionFactory(mockSessionFactory);
+        testObj.setSecContext(mockSecurityContext);
+        testObj.setRequest(mockHttpServletRequest);
+
+    }
+
+    @Test
+    public void testGetInjectable() {
+        final ComponentContext con = mock(ComponentContext.class);
+        final InjectedSession in = mock(InjectedSession.class);
+        final Injectable<Session> inj = testObj.getInjectable(con, in);
+        assertNotNull("Didn't get an Injectable<Session>!", inj);
+        assertTrue("Didn't get an InjectableSession!", InjectableSession.class
+                .isAssignableFrom(inj.getClass()));
+    }
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/test/util/ContainerWrapper.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/test/util/ContainerWrapper.java
@@ -3,7 +3,6 @@ package org.fcrepo.test.util;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/webxml/WebAppConfig.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/webxml/WebAppConfig.java
@@ -19,7 +19,6 @@ import org.fcrepo.webxml.bind.ServletMapping;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 
 @XmlRootElement(namespace="http://java.sun.com/xml/ns/javaee", name="web-app")
 public class WebAppConfig extends Displayable {


### PR DESCRIPTION
49205649

The follow-on ticket for this will be for Frank Asseg or someone else to alter FedoraTransactions so that it no longer maintains the state of the transaction store inside the endpoint itself. fasseg is aware of this problem and has a solution in mind.
