### PR TITLE
Include transactions and workspace identifiers in HTTP Graph Subjects.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFieldSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFieldSearch.java
@@ -112,7 +112,7 @@ public class FedoraFieldSearch extends AbstractResource implements
 
             final Dataset dataset =
                     nodeService.searchRepository(new HttpGraphSubjects(
-                            FedoraNodes.class, uriInfo), searchResult, session,
+                            FedoraNodes.class, uriInfo, session), searchResult, session,
                             terms, limit, offset);
 
             final Model searchModel = createDefaultModel();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraFixity.java
@@ -61,7 +61,7 @@ public class FedoraFixity extends AbstractResource {
                     datastreamService.getDatastream(session, path);
 
             return datastreamService.getFixityResultsModel(
-                    new HttpGraphSubjects(FedoraNodes.class, uriInfo), ds);
+                    new HttpGraphSubjects(FedoraNodes.class, uriInfo, session), ds);
         } finally {
             session.logout();
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraNodes.java
@@ -106,7 +106,7 @@ public class FedoraNodes extends AbstractResource {
                         .lastModified(date).build());
             }
             final HttpGraphSubjects subjects =
-                    new HttpGraphSubjects(FedoraNodes.class, uriInfo);
+                    new HttpGraphSubjects(FedoraNodes.class, uriInfo, session);
             final Dataset propertiesDataset =
                     resource.getPropertiesDataset(subjects, offset, limit);
             addResponseInformationToDataset(resource, propertiesDataset,
@@ -206,7 +206,7 @@ public class FedoraNodes extends AbstractResource {
                         nodeService.getObject(session, path);
 
                 result.updatePropertiesDataset(new HttpGraphSubjects(
-                        FedoraNodes.class, uriInfo), IOUtils
+                        FedoraNodes.class, uriInfo, session), IOUtils
                         .toString(requestBodyStream));
                 final Problems problems = result.getDatasetProblems();
                 if (problems != null && problems.hasProblems()) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
@@ -73,7 +73,7 @@ public class FedoraVersions extends AbstractResource {
             return Response.ok(
                     new GraphStoreStreamingOutput(resource
                             .getVersionDataset(new HttpGraphSubjects(
-                                    FedoraNodes.class, uriInfo)),
+                                    FedoraNodes.class, uriInfo, session)),
                             bestPossibleResponse.getMediaType())).build();
 
         } finally {
@@ -122,7 +122,7 @@ public class FedoraVersions extends AbstractResource {
             } else {
 
                 return resource.getPropertiesDataset(new HttpGraphSubjects(
-                        FedoraNodes.class, uriInfo), 0, -1);
+                        FedoraNodes.class, uriInfo, session), 0, -1);
             }
 
         } finally {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoriesProperties.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoriesProperties.java
@@ -20,6 +20,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jena.riot.WebContent;
 import org.fcrepo.AbstractResource;
 import org.fcrepo.FedoraResource;
+import org.fcrepo.api.FedoraNodes;
+import org.fcrepo.api.rdf.HttpGraphSubjects;
 import org.fcrepo.session.InjectedSession;
 import org.modeshape.common.collection.Problems;
 import org.slf4j.Logger;
@@ -58,7 +60,7 @@ public class FedoraRepositoriesProperties extends AbstractResource {
                 final FedoraResource result =
                         nodeService.getObject(session, "/");
 
-                result.updatePropertiesDataset(IOUtils
+                result.updatePropertiesDataset(new HttpGraphSubjects(FedoraNodes.class, uriInfo, session), IOUtils
                         .toString(requestBodyStream));
                 final Problems problems = result.getDatasetProblems();
                 if (problems != null && problems.hasProblems()) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryWorkspace.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/repository/FedoraRepositoryWorkspace.java
@@ -1,0 +1,57 @@
+package org.fcrepo.api.repository;
+
+
+import com.google.common.collect.ImmutableMap;
+import org.fcrepo.AbstractResource;
+import org.fcrepo.api.FedoraNodes;
+import org.fcrepo.session.InjectedSession;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.net.MalformedURLException;
+
+@Component
+@Scope("prototype")
+@Path("/fcr:workspaces")
+public class FedoraRepositoryWorkspace extends AbstractResource {
+
+    @InjectedSession
+    protected Session session;
+
+
+    @GET
+    public Response getWorkspaces() throws RepositoryException {
+       return Response.ok(session.getWorkspace().getAccessibleWorkspaceNames()).build();
+    }
+
+    @POST
+    @Path("{path}")
+    public Response createWorkspace(@PathParam("path") final String path,
+                                    @Context final UriInfo uriInfo) throws RepositoryException, MalformedURLException {
+        final Workspace workspace = session.getWorkspace();
+        workspace.createWorkspace(path);
+
+        return Response.created(
+                                       uriInfo.getAbsolutePathBuilder()
+                                               .path(FedoraNodes.class)
+                                               .buildFromMap(ImmutableMap.of("path", path))
+        ).build();
+
+    }
+
+    public void setSession(final Session session) {
+        this.session = session;
+    }
+
+
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraContentTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraContentTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.Date;
 
 import javax.jcr.LoginException;
@@ -35,6 +36,7 @@ import org.fcrepo.test.util.TestHelpers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.modeshape.jcr.api.JcrConstants;
 
 public class FedoraContentTest {
 
@@ -66,7 +68,7 @@ public class FedoraContentTest {
 
     @Test
     public void testPutContent() throws RepositoryException, IOException,
-            InvalidChecksumException {
+                                                    InvalidChecksumException, URISyntaxException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "testDS";
         final String dsContent = "asdf";
@@ -74,6 +76,9 @@ public class FedoraContentTest {
         final InputStream dsContentStream = IOUtils.toInputStream(dsContent);
         final Node mockNode = mock(Node.class);
         when(mockNode.isNew()).thenReturn(true);
+        Node mockContentNode = mock(Node.class);
+        when(mockNode.getNode(JcrConstants.JCR_CONTENT)).thenReturn(mockContentNode);
+        when(mockContentNode.getPath()).thenReturn(dsPath + "/jcr:content");
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class),
@@ -91,7 +96,7 @@ public class FedoraContentTest {
 
     @Test
     public void testCreateContent() throws RepositoryException, IOException,
-                                                            InvalidChecksumException {
+                                                       InvalidChecksumException, URISyntaxException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "xyz";
         final String dsContent = "asdf";
@@ -100,10 +105,13 @@ public class FedoraContentTest {
         final Node mockNode = mock(Node.class);
 
         when(mockNode.isNew()).thenReturn(true);
+        Node mockContentNode = mock(Node.class);
+        when(mockNode.getNode(JcrConstants.JCR_CONTENT)).thenReturn(mockContentNode);
+        when(mockContentNode.getPath()).thenReturn(dsPath + "/jcr:content");
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
         when(
                     mockDatastreams.createDatastreamNode(any(Session.class),
-                                                                eq(dsPath), anyString(), any(InputStream.class)))
+                                                                eq(dsPath), anyString(), any(InputStream.class), eq((String)null), eq((String)null)))
                 .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
@@ -116,7 +124,7 @@ public class FedoraContentTest {
 
     @Test
     public void testCreateContentAtMintedPath() throws RepositoryException, IOException,
-                                                InvalidChecksumException {
+                                                                   InvalidChecksumException, URISyntaxException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "fcr:new";
         final String dsContent = "asdf";
@@ -128,10 +136,13 @@ public class FedoraContentTest {
         when(mockMinter.mintPid()).thenReturn("xyz");
         testObj.setPidMinter(mockMinter);
         when(mockNode.isNew()).thenReturn(true);
+        Node mockContentNode = mock(Node.class);
+        when(mockNode.getNode(JcrConstants.JCR_CONTENT)).thenReturn(mockContentNode);
+        when(mockContentNode.getPath()).thenReturn(dsPath + "/jcr:content");
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
         when(
                     mockDatastreams.createDatastreamNode(any(Session.class),
-                                                                eq(dsPath), anyString(), any(InputStream.class)))
+                                                                eq("/" + pid + "/xyz"), anyString(), any(InputStream.class), eq((String) null), eq((String)null)))
                 .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
@@ -145,7 +156,7 @@ public class FedoraContentTest {
 
     @Test
     public void testModifyContent() throws RepositoryException, IOException,
-            InvalidChecksumException {
+                                                       InvalidChecksumException, URISyntaxException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "testDS";
         final String dsContent = "asdf";

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraDatastreamsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraDatastreamsTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.util.Arrays;
@@ -77,7 +78,7 @@ public class FedoraDatastreamsTest {
 
     @Test
     public void testModifyDatastreams() throws RepositoryException,
-            IOException, InvalidChecksumException {
+                                                           IOException, InvalidChecksumException, URISyntaxException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId1 = "testDs1";
         final String dsId2 = "testDs2";
@@ -85,6 +86,9 @@ public class FedoraDatastreamsTest {
         atts.put(dsId1, "asdf");
         atts.put(dsId2, "sdfg");
         final MultiPart multipart = getStringsAsMultipart(atts);
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn("/FedoraDatastreamsTest1");
+        when(mockSession.getNode("/FedoraDatastreamsTest1")).thenReturn(mockNode);
         final Response actual =
                 testObj.modifyDatastreams(createPathList(pid), Arrays.asList(
                         dsId1, dsId2), multipart);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraIdentifiersTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraIdentifiersTest.java
@@ -14,6 +14,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.core.UriInfo;
@@ -45,6 +46,7 @@ public class FedoraIdentifiersTest {
         mockPidMinter = mock(PidMinter.class);
 
         mockSession = mockSession(testObj);
+        testObj.setSession(mockSession);
         uriInfo = getUriInfoImpl();
         testObj.setUriInfo(uriInfo);
 
@@ -65,6 +67,11 @@ public class FedoraIdentifiersTest {
 
         when(uriInfo.getAbsolutePath()).thenReturn(
                 new URI("http://localhost/fcrepo/fcr:pid"));
+
+
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn("/asdf:123");
+        when(mockSession.getNode("/asdf:123")).thenReturn(mockNode);
 
         final Dataset np = testObj.getNextPid(createPathList(""), 2, uriInfo);
 
@@ -91,6 +98,12 @@ public class FedoraIdentifiersTest {
 
         when(uriInfo.getAbsolutePath()).thenReturn(
                                                           new URI("http://localhost/fcrepo/objects/fcr:pid"));
+
+
+
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn("/objects/asdf:123");
+        when(mockSession.getNode("/objects/asdf:123")).thenReturn(mockNode);
 
         final Dataset np = testObj.getNextPid(createPathList("objects"), 2, uriInfo);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraImportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraImportTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -46,8 +47,13 @@ public class FedoraImportTest {
     public void testImportObject() throws Exception {
         final InputStream mockInputStream = mock(InputStream.class);
 
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn("/test/object");
+        when(mockSession.getNode("/test/object")).thenReturn(mockNode);
+
         testObj.importObject(createPathList("test", "object"), "fake-format",
                 mockInputStream);
+
         verify(mockSerializer).deserialize(mockSession, "/test/object",
                 mockInputStream);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraUnnamedObjectsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraUnnamedObjectsTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.core.Response;
@@ -55,14 +57,18 @@ public class FedoraUnnamedObjectsTest {
 
     @Test
     public void testIngestAndMint() throws RepositoryException, IOException,
-            InvalidChecksumException {
+                                                       InvalidChecksumException, URISyntaxException {
         final UUIDPidMinter mockMint = mock(UUIDPidMinter.class);
         testObj.setPidMinter(mockMint);
         when(mockMint.mintPid()).thenReturn("uuid-123");
 
         final FedoraObject mockObject = mock(FedoraObject.class);
-        when(mockObject.getPath()).thenReturn("/objects/uuid-123");
-        when(mockObjects.createObject(mockSession, "/objects/uuid-123"))
+        final String path = "/objects/uuid-123";
+        when(mockObject.getPath()).thenReturn(path);
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn(path);
+        when(mockObject.getNode()).thenReturn(mockNode);
+        when(mockObjects.createObject(mockSession, path))
                 .thenReturn(mockObject);
         final Response actual =
                 testObj.ingestAndMint(createPathList("objects"),
@@ -74,8 +80,8 @@ public class FedoraUnnamedObjectsTest {
         assertEquals(Response.Status.CREATED.getStatusCode(), actual
                 .getStatus());
         assertTrue(actual.getEntity().toString().endsWith("uuid-123"));
-        verify(mockObjects).createObject(mockSession, "/objects/uuid-123");
-        verify(mockNodeService).exists(mockSession, "/objects/uuid-123");
+        verify(mockObjects).createObject(mockSession, path);
+        verify(mockNodeService).exists(mockSession, path);
         verify(mockSession).save();
 
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoriesPropertiesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoriesPropertiesTest.java
@@ -1,6 +1,8 @@
 
 package org.fcrepo.api.repository;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +15,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import org.fcrepo.FedoraObject;
+import org.fcrepo.rdf.GraphSubjects;
 import org.fcrepo.services.NodeService;
 import org.fcrepo.test.util.TestHelpers;
 import org.junit.Before;
@@ -47,7 +50,7 @@ public class FedoraRepositoriesPropertiesTest {
 
         testObj.updateSparql(mockStream);
 
-        verify(mockObject).updatePropertiesDataset("my-sparql-statement");
+        verify(mockObject).updatePropertiesDataset(any(GraphSubjects.class), eq("my-sparql-statement"));
         verify(mockSession).save();
         verify(mockSession).logout();
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryImportTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/repository/FedoraRepositoryImportTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
+import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
@@ -43,6 +44,10 @@ public class FedoraRepositoryImportTest {
                 mock(FedoraObjectSerializer.class);
         when(mockSerializers.getSerializer("fake-format")).thenReturn(
                 mockSerializer);
+
+        Node mockNode = mock(Node.class);
+        when(mockNode.getPath()).thenReturn("/");
+        when(mockSession.getNode("/")).thenReturn(mockNode);
 
         testObj.importObject(createPathList(), "fake-format", mockInputStream);
         verify(mockSerializer).deserialize(mockSession, "/", mockInputStream);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraTransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraTransactionsIT.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.update.GraphStore;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -12,6 +14,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.fcrepo.Transaction;
 import org.fcrepo.Transaction.State;
 import org.fcrepo.services.TransactionService;
+import org.fcrepo.test.util.TestHelpers;
 import org.junit.Test;
 
 public class FedoraTransactionsIT extends AbstractResourceIT {
@@ -222,6 +225,12 @@ public class FedoraTransactionsIT extends AbstractResourceIT {
                 new HttpGet(serverAddress + "tx:" + tx.getId() + "/object-in-tx");
         resp = execute(getTx);
         assertEquals("Expected to find our object within the scope of the transaction", 200, resp.getStatusLine().getStatusCode());
+
+        final GraphStore graphStore = TestHelpers.parseTriples(resp.getEntity().getContent());
+        logger.debug(graphStore.toString());
+
+        assertTrue(graphStore.toDataset().asDatasetGraph().contains(Node.ANY, Node.createURI(serverAddress + "tx:" + tx.getId() + "/object-in-tx"), Node.ANY, Node.ANY));
+
 
          /* fetch the created tx from the endpoint */
         final HttpGet getObj =

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraWorkspacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraWorkspacesIT.java
@@ -1,0 +1,37 @@
+package org.fcrepo.integration.api;
+
+import com.hp.hpl.jena.update.GraphStore;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.fcrepo.test.util.TestHelpers;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Workspace;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class FedoraWorkspacesIT extends AbstractResourceIT {
+
+    @Test
+    public void shouldDemonstratePathsAndWorkspaces() throws IOException, RepositoryException {
+        final HttpPost httpCreateWorkspace = new HttpPost(serverAddress + "fcr:workspaces/some-workspace");
+        final HttpResponse createWorkspaceResponse = execute(httpCreateWorkspace);
+        assertEquals(201, createWorkspaceResponse.getStatusLine().getStatusCode());
+
+
+        final HttpPost httpPost = new HttpPost(serverAddress + "workspace:some-workspace/FedoraWorkspacesTest");
+        final HttpResponse response = execute(httpPost);
+        assertEquals(201, response.getStatusLine().getStatusCode());
+
+
+        final HttpGet httpGet = new HttpGet(serverAddress + "workspace:some-workspace/FedoraWorkspacesTest");
+        final HttpResponse profileResponse = execute(httpGet);
+        assertEquals(200, profileResponse.getStatusLine().getStatusCode());
+        final GraphStore graphStore = TestHelpers.parseTriples(profileResponse.getEntity().getContent());
+        logger.info(graphStore.toString());
+    }
+}

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/api/rdf/HttpGraphSubjectsTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/api/rdf/HttpGraphSubjectsTest.java
@@ -1,6 +1,8 @@
 package org.fcrepo.api.rdf;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 
@@ -8,6 +10,7 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Workspace;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -24,67 +27,76 @@ public class HttpGraphSubjectsTest {
 	private HttpGraphSubjects testObj;
 	
 	private String testPath = "/foo/bar";
-	
-	@Before
+    private Session mockSession;
+
+    @Before
 	public void setUp(){
 		UriInfo uris = getUriInfoImpl(testPath);
-		testObj = new HttpGraphSubjects(MockNodeController.class, uris);
+        mockSession = mock(Session.class);
+		testObj = new HttpGraphSubjects(MockNodeController.class, uris, mockSession);
 	}
 	
 	@Test
 	public void testGetGraphSubject() throws RepositoryException {
 		String expected = "http://localhost:8080/fcrepo/rest" + testPath;
-		Node mockNode = Mockito.mock(Node.class);
-		Mockito.when(mockNode.getPath()).thenReturn(testPath);
+		Node mockNode = mock(Node.class);
+		when(mockNode.getPath()).thenReturn(testPath);
+        Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
+        when(mockNode.getSession()).thenReturn(mockSession);
 		Resource actual = testObj.getGraphSubject(mockNode);
 		assertEquals(expected, actual.getURI());
-		Mockito.when(mockNode.getPath()).thenReturn(testPath + "/jcr:content");
+		when(mockNode.getPath()).thenReturn(testPath + "/jcr:content");
 		actual = testObj.getGraphSubject(mockNode);
 		assertEquals(expected + "/fcr:content", actual.getURI());
 	}
 
 	@Test
 	public void testGetNodeFromGraphSubject() throws PathNotFoundException, RepositoryException {
-		Session mockSession = Mockito.mock(Session.class);
-		Node mockNode = Mockito.mock(Node.class);
-		Mockito.when(mockSession.nodeExists(testPath)).thenReturn(true);
-		Mockito.when(mockSession.getNode(testPath)).thenReturn(mockNode);
+		Session mockSession = mock(Session.class);
+		Node mockNode = mock(Node.class);
+		when(mockSession.nodeExists(testPath)).thenReturn(true);
+		when(mockSession.getNode(testPath)).thenReturn(mockNode);
+        Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
 		// test a good subject
-		Resource mockSubject = Mockito.mock(Resource.class);
-		Mockito.when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath);
-		Mockito.when(mockSubject.isURIResource()).thenReturn(true);
+		Resource mockSubject = mock(Resource.class);
+		when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath);
+		when(mockSubject.isURIResource()).thenReturn(true);
 		Node actual = testObj.getNodeFromGraphSubject(mockSession, mockSubject);
 		Mockito.verify(mockSession).getNode(testPath);
 		assertEquals(mockNode, actual);
 		// test a bad subject
-		Mockito.when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest2" + testPath + "/bad");
+		when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest2" + testPath + "/bad");
 		actual = testObj.getNodeFromGraphSubject(mockSession, mockSubject);
 		assertEquals(null, actual);
 		// test a non-existent path
-		Mockito.when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath + "/bad");
+		when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath + "/bad");
 		actual = testObj.getNodeFromGraphSubject(mockSession, mockSubject);
 		assertEquals(null, actual);
 		// test a fcr:content path
-		Mockito.when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath + "/fcr:content");
+		when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest" + testPath + "/fcr:content");
 		actual = testObj.getNodeFromGraphSubject(mockSession, mockSubject);
 		Mockito.verify(mockSession).getNode(testPath + "/jcr:content");
 	}
 
 	@Test
 	public void testIsFedoraGraphSubject() {
-		Resource mockSubject = Mockito.mock(Resource.class);
-		Mockito.when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest/foo");
-		Mockito.when(mockSubject.isURIResource()).thenReturn(true);
+		Resource mockSubject = mock(Resource.class);
+		when(mockSubject.getURI()).thenReturn("http://localhost:8080/fcrepo/rest/foo");
+		when(mockSubject.isURIResource()).thenReturn(true);
 		boolean actual = testObj.isFedoraGraphSubject(mockSubject);
 		assertEquals(true, actual);
-		Mockito.when(mockSubject.getURI()).thenReturn("http://fedora/foo");
+		when(mockSubject.getURI()).thenReturn("http://fedora/foo");
 		actual = testObj.isFedoraGraphSubject(mockSubject);
 		assertEquals(false, actual);
 	}
 
 	private static UriInfo getUriInfoImpl(String path) {
 		// UriInfo ui = mock(UriInfo.class,withSettings().verboseLogging());
-		final UriInfo ui = Mockito.mock(UriInfo.class);
+		final UriInfo ui = mock(UriInfo.class);
 		final UriBuilder ub = new UriBuilderImpl();
 		ub.scheme("http");
 		ub.host("localhost");
@@ -97,11 +109,11 @@ public class HttpGraphSubjectsTest {
 		rb.port(8080);
 		rb.path("/fcrepo/rest" + path);
 
-		Mockito.when(ui.getRequestUri()).thenReturn(
+		when(ui.getRequestUri()).thenReturn(
 				URI.create("http://localhost:8080/fcrepo/rest" + path));
-		Mockito.when(ui.getBaseUri()).thenReturn(URI.create("http://localhost:8080/fcrepo"));
-		Mockito.when(ui.getBaseUriBuilder()).thenReturn(ub);
-		Mockito.when(ui.getAbsolutePathBuilder()).thenReturn(rb);
+		when(ui.getBaseUri()).thenReturn(URI.create("http://localhost:8080/fcrepo"));
+		when(ui.getBaseUriBuilder()).thenReturn(ub);
+		when(ui.getAbsolutePathBuilder()).thenReturn(rb);
 
 		return ui;
 	}

--- a/fcrepo-kernel/src/main/java/org/fcrepo/Transaction.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/Transaction.java
@@ -77,7 +77,7 @@ public class Transaction {
      * @todo Add Documentation.
      */
     public Session getSession() {
-        return TxAwareSession.newInstance(session);
+        return TxAwareSession.newInstance(session, id);
     }
 
     public Session getJcrSession() {

--- a/fcrepo-kernel/src/main/java/org/fcrepo/TxAwareSession.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/TxAwareSession.java
@@ -5,20 +5,24 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 
 public class TxAwareSession implements InvocationHandler {
+    private final String txId;
     private Session session;
 
-    public TxAwareSession(final Session session) {
+    public TxAwareSession(final Session session, final String txID) {
         this.session = session;
+        this.txId = txID;
     }
 
-    public static Session newInstance(final Session session) {
-        return (Session) java.lang.reflect.Proxy.newProxyInstance(session.getClass().getClassLoader(), new Class[] { Session.class }, new TxAwareSession(session));
+    public static Session newInstance(final Session session, final String txId) {
+        return (Session) java.lang.reflect.Proxy.newProxyInstance(session.getClass().getClassLoader(), new Class[] { TxSession.class }, new TxAwareSession(session, txId));
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (method.getName().equals("logout") || method.getName().equals("save")) {
             return null;
+        } else if (method.getName().equals("getTxId")) {
+            return txId;
         } else {
             return method.invoke(session, args);
         }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/TxSession.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/TxSession.java
@@ -1,0 +1,7 @@
+package org.fcrepo;
+
+import javax.jcr.Session;
+
+public interface TxSession extends Session {
+    String getTxId();
+}

--- a/fcrepo-kernel/src/main/java/org/fcrepo/rdf/GraphSubjects.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/rdf/GraphSubjects.java
@@ -41,4 +41,5 @@ public interface GraphSubjects {
      */
     boolean isFedoraGraphSubject(final Resource subject);
 
+    Resource getGraphSubject(String absPath) throws RepositoryException;
 }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/rdf/impl/DefaultGraphSubjects.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/rdf/impl/DefaultGraphSubjects.java
@@ -26,21 +26,25 @@ import com.hp.hpl.jena.rdf.model.ResourceFactory;
  */
 public class DefaultGraphSubjects implements GraphSubjects {
 
+
+    @Override
+    public Resource getGraphSubject(String absPath) throws RepositoryException {
+        if (absPath.endsWith(JcrConstants.JCR_CONTENT)) {
+            return ResourceFactory
+                           .createResource("info:fedora" +
+                                                   absPath.replace(JcrConstants.JCR_CONTENT,
+                                                                          FedoraJcrTypes.FCR_CONTENT));
+        } else {
+            return ResourceFactory.createResource("info:fedora" + absPath);
+        }
+    }
+
     /**
      * @todo Add Documentation.
      */
     @Override
     public Resource getGraphSubject(Node node) throws RepositoryException {
-        final String absPath = node.getPath();
-
-        if (absPath.endsWith(JcrConstants.JCR_CONTENT)) {
-            return ResourceFactory
-                .createResource("info:fedora" +
-                                absPath.replace(JcrConstants.JCR_CONTENT,
-                                                FedoraJcrTypes.FCR_CONTENT));
-        } else {
-            return ResourceFactory.createResource("info:fedora" + absPath);
-        }
+        return getGraphSubject(node.getPath());
     }
 
     /**

--- a/fcrepo-kernel/src/test/java/org/fcrepo/TxAwareSessionTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/TxAwareSessionTest.java
@@ -19,7 +19,7 @@ public class TxAwareSessionTest {
     @Before
     public void setUp() {
         mockSession = mock(Session.class);
-        testObj = TxAwareSession.newInstance(mockSession);
+        testObj = TxAwareSession.newInstance(mockSession, "txid");
 
 
     }


### PR DESCRIPTION
- use the graph subjects API extensively to create URIs
  for objects.
- add an API to create a graph subject for an object that may not
  exist yet (using the path instead of a node reference)
