### PR TITLE
Removed the calls to getAuthenticatedSession in FedoraVersions and FedoraUnnamedObjects

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraUnnamedObjects.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraUnnamedObjects.java
@@ -68,21 +68,19 @@ public class FedoraUnnamedObjects extends AbstractResource {
 
         logger.debug("Attempting to ingest with path: {}", path);
 
-        final Session session = getAuthenticatedSession();
-
         try {
-            if (nodeService.exists(session, path)) {
+            if (nodeService.exists(this.session, path)) {
                 return Response.status(SC_CONFLICT).entity(
                         path + " is an existing resource").build();
             }
 
             final FedoraResource resource =
                     createObjectOrDatastreamFromRequestContent(
-                            FedoraNodes.class, session, path, mixin, uriInfo,
+                            FedoraNodes.class, this.session, path, mixin, uriInfo,
                             requestBodyStream, requestContentType,
                             checksumType, checksum);
 
-            session.save();
+            this.session.save();
             logger.debug("Finished creating {} with path: {}", mixin, path);
             return created(
                     uriInfo.getBaseUriBuilder().path(FedoraNodes.class).build(
@@ -90,7 +88,7 @@ public class FedoraUnnamedObjects extends AbstractResource {
                     .build();
 
         } finally {
-            session.logout();
+        	this.session.logout();
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/api/FedoraVersions.java
@@ -65,10 +65,9 @@ public class FedoraVersions extends AbstractResource {
         final Variant bestPossibleResponse =
                 request.selectVariant(POSSIBLE_RDF_VARIANTS);
 
-        final Session session = getAuthenticatedSession();
         try {
             final FedoraResource resource =
-                    nodeService.getObject(session, path);
+                    nodeService.getObject(this.session, path);
 
             return Response.ok(
                     new GraphStoreStreamingOutput(resource
@@ -77,7 +76,7 @@ public class FedoraVersions extends AbstractResource {
                             bestPossibleResponse.getMediaType())).build();
 
         } finally {
-            session.logout();
+            this.session.logout();
         }
 
     }
@@ -89,15 +88,14 @@ public class FedoraVersions extends AbstractResource {
     final String versionLabel) throws RepositoryException {
 
         final String path = toPath(pathList);
-        final Session session = getAuthenticatedSession();
         try {
             final FedoraResource resource =
-                    nodeService.getObject(session, path);
+                    nodeService.getObject(this.session, path);
             resource.addVersionLabel(versionLabel);
 
             return Response.noContent().build();
         } finally {
-            session.logout();
+        	this.session.logout();
         }
     }
 
@@ -112,10 +110,9 @@ public class FedoraVersions extends AbstractResource {
         LOGGER.trace("getting version profile for {} at version {}", path,
                 versionLabel);
 
-        final Session session = getAuthenticatedSession();
         try {
             final FedoraResource resource =
-                    nodeService.getObject(session, path, versionLabel);
+                    nodeService.getObject(this.session, path, versionLabel);
 
             if (resource == null) {
                 throw new WebApplicationException(status(NOT_FOUND).build());
@@ -126,7 +123,7 @@ public class FedoraVersions extends AbstractResource {
             }
 
         } finally {
-            session.logout();
+        	this.session.logout();
         }
 
     }


### PR DESCRIPTION
see https://www.pivotaltracker.com/story/show/51879771

The injected session is not used in these to classes, since the methods still used local variables set by AbstractResource.getAuthenticatedSession().
