### PR TITLE
make sure we send the right Location header back when POSTing binary content to create a new node

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/api/FedoraNodesTest.java
@@ -60,6 +60,7 @@ import com.hp.hpl.jena.graph.Node_ANY;
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
 import com.hp.hpl.jena.sparql.util.Context;
 import org.apache.commons.io.IOUtils;
+import org.fcrepo.Datastream;
 import org.fcrepo.FedoraObject;
 import org.fcrepo.FedoraResource;
 import org.fcrepo.exception.InvalidChecksumException;
@@ -222,10 +223,13 @@ public class FedoraNodesTest {
                 mockDatastreams.createDatastreamNode(any(Session.class),
                         eq(dsPath), anyString(), eq(dsContentStream),
                         any(URI.class))).thenReturn(mockNode);
+        Datastream mockDatastream = mock(Datastream.class);
+        when(mockDatastream.getNode()).thenReturn(mockNode);
+        when(mockDatastreams.createDatastream(mockSession, dsPath)).thenReturn(mockDatastream);
         when(mockNode.getPath()).thenReturn(dsPath);
         final Response actual =
                 testObj.createObject(createPathList(pid, dsId),
-                        FEDORA_DATASTREAM, null, null, null, getUriInfoImpl(),
+                        FEDORA_DATASTREAM, null, MediaType.APPLICATION_OCTET_STREAM_TYPE, null, getUriInfoImpl(),
                         dsContentStream);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams)

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/api/FedoraNodesIT.java
@@ -185,6 +185,27 @@ public class FedoraNodesIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testIngestWithBinary() throws Exception {
+        final HttpPost method = postObjMethod("");
+        method.addHeader("Content-Type", "application/octet-stream");
+        BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream("xyz".getBytes()));
+        method.setEntity(entity);
+        final HttpResponse response = client.execute(method);
+        final String content = EntityUtils.toString(response.getEntity());
+        final int status = response.getStatusLine().getStatusCode();
+        assertEquals("Didn't get a CREATED response! Got content:\n" + content,
+                        CREATED.getStatusCode(), status);
+        assertTrue("Response wasn't a PID", compile("[a-z]+").matcher(content)
+                                                .find());
+        final String location = response.getFirstHeader("Location").getValue();
+        assertNotEquals(serverAddress + "/objects", location);
+        assertTrue(location.endsWith("fcr:content"));
+        assertEquals("Object wasn't created!", OK.getStatusCode(),
+                        getStatus(new HttpGet(location)));
+    }
+
+    @Test
     public void testDeleteObject() throws Exception {
         assertEquals(CREATED.getStatusCode(),
                 getStatus(postObjMethod("FedoraObjectsTest3")));

--- a/fcrepo-kernel/src/main/java/org/fcrepo/services/DatastreamService.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/services/DatastreamService.java
@@ -86,6 +86,16 @@ public class DatastreamService extends RepositoryService {
     private static final Logger logger = getLogger(DatastreamService.class);
 
     /**
+     * Create a stub datastream without content
+     * @param session
+     * @param dsPath
+     * @return
+     * @throws RepositoryException
+     */
+    public Datastream createDatastream(final Session session, final String dsPath) throws RepositoryException {
+        return new Datastream(session, dsPath);
+    }
+    /**
      * Create a new Datastream node in the JCR store
      * 
      * @param session the jcr session to use
@@ -124,7 +134,7 @@ public class DatastreamService extends RepositoryService {
         final InputStream requestBodyStream, final URI checksum)
         throws RepositoryException, IOException, InvalidChecksumException {
 
-        final Datastream ds = new Datastream(session, dsPath);
+        final Datastream ds = createDatastream(session, dsPath);
         ds.setContent(requestBodyStream, contentType, checksum,
                 getStoragePolicyDecisionPoint());
         return ds.getNode();


### PR DESCRIPTION
Nothing about this PR is any good, but it fixes a problem with our REST API without too much refactoring. I'm open to suggestions for making it better (that don't involve refactoring *Services and the Datastream class)
