### PR TITLE
ModeShape upgrade to 3.6, including necessary change to test PEP

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixPEP.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixPEP.java
@@ -56,6 +56,12 @@ public class PermitRootAndPathEndsWithPermitSuffixPEP implements
             return true;
         }
 
+        // allow anywhere the last path segment is "jcr:content"
+        if (absPath.getLastSegment().getName().getLocalName().toLowerCase()
+                .equals("content")) {
+            return true;
+        }
+
         // allow properties to be set under parent nodes that end with "permit"
         if (actions.length == 1 && "set_property".equals(actions[0])) {
             return absPath.getParent().getLastSegment().getName()

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <jgroups.version>3.3.1.Final</jgroups.version>
     <logback.version>1.0.13</logback.version>
     <metrics.version>3.0.0</metrics.version>
-    <modeshape.version>3.5.0.Final</modeshape.version>
+    <modeshape.version>3.6.0.Final</modeshape.version>
     <sesame.version>2.7.2</sesame.version>
     <slf4j.version>1.7.5</slf4j.version>
     <spring.version>3.2.3.RELEASE</spring.version>


### PR DESCRIPTION
fixes minor issue with test PEP, such that simulated PEP still returns expected responses for test.
