### PR TITLE
Access control exception handling

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/AccessControlExceptionMapper.java
@@ -45,4 +45,15 @@ public class AccessControlExceptionMapper implements
         return status(FORBIDDEN).build();
     }
 
+    /**
+     * @param e
+     * @return
+     */
+    public Response toResponse(final java.security.AccessControlException e) {
+        logger.debug("AccessControlExceptionMapper intercepted exception: \n",
+                e);
+
+        return status(FORBIDDEN).build();
+    }
+
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Throwables.getStackTraceAsString;
 import static javax.ws.rs.core.Response.serverError;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import javax.jcr.security.AccessControlException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -47,6 +48,17 @@ public class WildcardExceptionMapper implements ExceptionMapper<Exception> {
                     "WebApplicationException intercepted by WildcardExceptionMapper: \n",
                     e);
             return ((WebApplicationException) e).getResponse();
+        }
+
+        if (java.security.AccessControlException.class.isAssignableFrom(e
+                .getClass())) {
+            return new AccessControlExceptionMapper()
+                    .toResponse((java.security.AccessControlException) e);
+        }
+
+        if (AccessControlException.class.isAssignableFrom(e.getClass())) {
+            return new AccessControlExceptionMapper()
+                    .toResponse((AccessControlException) e);
         }
 
         if (e.getCause() instanceof TransactionMissingException) {

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
@@ -32,10 +32,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.security.AccessControlException;
 import java.util.Iterator;
-
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
-
 import org.fcrepo.kernel.rdf.GraphSubjects;
 import org.fcrepo.kernel.rdf.impl.mappings.PropertyToTriple;
 import org.fcrepo.kernel.rdf.impl.mappings.ZippingIterator;


### PR DESCRIPTION
This provides handling for access denied exceptions. Treats protected jcr:content nodes as invisible for now, in the parent's graph representation. Other child nodes are already silently omitted. REST operations all return 403 when access is forbidden.
