### PR TITLE
Update tests that extract RDF graphs from responses to:

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraDatastreamsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraDatastreamsIT.java
@@ -21,7 +21,6 @@ import static com.hp.hpl.jena.graph.NodeFactory.createURI;
 import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.compile;
 import static junit.framework.TestCase.assertFalse;
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -41,26 +40,15 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
     @Test
     public void testMultipleDatastreams() throws Exception {
-        final HttpPost createObjMethod =
-                postObjMethod("FedoraDatastreamsTest7");
-        assertEquals(201, getStatus(createObjMethod));
+        createObject("FedoraDatastreamsTest7");
 
-        final HttpPost createDS1Method =
-                postDSMethod("FedoraDatastreamsTest7", "ds1",
-                        "marbles for everyone");
-        assertEquals(201, getStatus(createDS1Method));
-        final HttpPost createDS2Method =
-                postDSMethod("FedoraDatastreamsTest7", "ds2",
-                        "marbles for no one");
-        assertEquals(201, getStatus(createDS2Method));
+        createDatastream("FedoraDatastreamsTest7", "ds1", "marbles for everyone");
+        createDatastream("FedoraDatastreamsTest7", "ds2", "marbles for no one");
 
         final HttpGet getDSesMethod =
                 new HttpGet(serverAddress + "FedoraDatastreamsTest7");
-        getDSesMethod.addHeader("Accept", "text/n3");
-        final HttpResponse response = client.execute(getDSesMethod);
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        final GraphStore result =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore result = getGraphStore(getDSesMethod);
+
         logger.debug("Received triples: \n{}", result.toString());
         final String subjectURI = serverAddress + "FedoraDatastreamsTest7";
 
@@ -72,14 +60,8 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
     @Test
     public void testModifyMultipleDatastreams() throws Exception {
-        final HttpPost objMethod = postObjMethod("FedoraDatastreamsTest8");
-
-        assertEquals(201, getStatus(objMethod));
-
-        final HttpPost createDSVOIDMethod =
-            postDSMethod("FedoraDatastreamsTest8", "ds_void",
-                    "marbles for everyone");
-        assertEquals(201, getStatus(createDSVOIDMethod));
+        createObject("FedoraDatastreamsTest8");
+        createDatastream("FedoraDatastreamsTest8", "ds_void", "marbles for everyone");
 
         final HttpPost post =
             new HttpPost(serverAddress
@@ -97,13 +79,9 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
         final HttpGet getDSesMethod =
             new HttpGet(serverAddress + "FedoraDatastreamsTest8");
-        getDSesMethod.addHeader("Accept", "text/n3");
-        final HttpResponse response = client.execute(getDSesMethod);
-        assertEquals(200, response.getStatusLine().getStatusCode());
+        final GraphStore result = getGraphStore(getDSesMethod);
 
         final String subjectURI = serverAddress + "FedoraDatastreamsTest8";
-        final GraphStore result =
-            parseTriples(response.getEntity().getContent());
         assertTrue("Didn't find the first datastream! ", result.contains(ANY,
                 createURI(subjectURI), ANY, createURI(subjectURI + "/ds1")));
         assertTrue("Didn't find the second datastream! ", result.contains(ANY,
@@ -115,9 +93,8 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
     @Test
     public void testRetrieveMultipartDatastreams() throws Exception {
+        createObject("FedoraDatastreamsTest9");
 
-        final HttpPost objMethod = postObjMethod("FedoraDatastreamsTest9");
-        assertEquals(201, getStatus(objMethod));
         final HttpPost post =
             new HttpPost(serverAddress
                     + "FedoraDatastreamsTest9/fcr:datastreams/");
@@ -149,9 +126,8 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
     @Test
     public void testRetrieveFIlteredMultipartDatastreams() throws Exception {
+        createObject("FedoraDatastreamsTest10");
 
-        final HttpPost objMethod = postObjMethod("FedoraDatastreamsTest10");
-        assertEquals(201, getStatus(objMethod));
         final HttpPost post =
             new HttpPost(serverAddress
                     + "FedoraDatastreamsTest10/fcr:datastreams");
@@ -183,13 +159,10 @@ public class FedoraDatastreamsIT extends AbstractResourceIT {
 
     @Test
     public void testBatchDeleteDatastream() throws Exception {
-        execute(postObjMethod("FedoraDatastreamsTest12"));
-        final HttpPost method1 =
-            postDSMethod("FedoraDatastreamsTest12", "ds1", "foo1");
-        assertEquals(201, getStatus(method1));
-        final HttpPost method2 =
-            postDSMethod("FedoraDatastreamsTest12", "ds2", "foo2");
-        assertEquals(201, getStatus(method2));
+        createObject("FedoraDatastreamsTest12");
+
+        createDatastream("FedoraDatastreamsTest12", "ds1", "foo1");
+        createDatastream("FedoraDatastreamsTest12", "ds2", "foo2");
 
         final HttpDelete dmethod =
             new HttpDelete(

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
@@ -20,18 +20,13 @@ import static com.hp.hpl.jena.graph.Node.ANY;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createPlainLiteral;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createTypedLiteral;
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.RdfLexicon.HAS_COMPUTED_CHECKSUM;
 import static org.fcrepo.kernel.RdfLexicon.HAS_COMPUTED_SIZE;
 import static org.fcrepo.kernel.RdfLexicon.HAS_FIXITY_STATE;
 import static org.fcrepo.kernel.RdfLexicon.IS_FIXITY_RESULT_OF;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
@@ -40,20 +35,14 @@ public class FedoraFixityIT extends AbstractResourceIT {
 
     @Test
     public void testCheckDatastreamFixity() throws Exception {
-        final HttpPost objMethod = postObjMethod("FedoraDatastreamsTest11");
-        assertEquals(201, getStatus(objMethod));
-        final HttpPost method1 =
-            postDSMethod("FedoraDatastreamsTest11", "zxc", "foo");
-        assertEquals(201, getStatus(method1));
-        final HttpGet method2 =
+        createObject("FedoraDatastreamsTest11");
+        createDatastream("FedoraDatastreamsTest11", "zxc", "foo");
+
+        final HttpGet method =
             new HttpGet(serverAddress
                     + "FedoraDatastreamsTest11/zxc/fcr:fixity");
-        method2.setHeader("Accept", "application/n3");
-        final HttpResponse response = execute(method2);
-        assertEquals(200, response.getStatusLine().getStatusCode());
-        final HttpEntity entity = response.getEntity();
-        final GraphStore graphStore = parseTriples(entity.getContent());
 
+        final GraphStore graphStore = getGraphStore(method);
         logger.info("Got triples {}", graphStore);
 
         assertTrue(graphStore.contains(ANY, ANY, IS_FIXITY_RESULT_OF.asNode(),

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraIdentifiersIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraIdentifiersIT.java
@@ -20,14 +20,12 @@ import static com.google.common.collect.Iterators.size;
 import static com.hp.hpl.jena.graph.Node.ANY;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.RdfLexicon.HAS_MEMBER_OF_RESULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 
@@ -46,11 +44,8 @@ public class FedoraIdentifiersIT extends AbstractResourceIT {
     @Test
     public void testGetNextHasAPid() throws IOException {
         final HttpPost method = new HttpPost(serverAddress + "fcr:pid");
-        method.setHeader("Accept", "application/n3");
-        final HttpResponse response = client.execute(method);
         logger.debug("Executed testGetNextHasAPid()");
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(method);
         assertTrue("Didn't find a single dang PID!", graphStore.contains(ANY,
                 ResourceFactory.createResource(serverAddress + "fcr:pid")
                         .asNode(), HAS_MEMBER_OF_RESULT.asNode(), ANY));
@@ -62,10 +57,8 @@ public class FedoraIdentifiersIT extends AbstractResourceIT {
         final HttpPost method =
                 new HttpPost(serverAddress + "fcr:pid?numPids=2");
         method.setHeader("Accept", "application/n3");
-        final HttpResponse response = client.execute(method);
         logger.debug("Executed testGetNextHasTwoPids()");
-        final GraphStore graphStore =
-                parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(method);
         assertEquals("Didn't find two dang PIDs!", 2, size(graphStore.find(ANY,
                 createResource(serverAddress + "fcr:pid").asNode(),
                 HAS_MEMBER_OF_RESULT.asNode(), ANY)));
@@ -82,11 +75,8 @@ public class FedoraIdentifiersIT extends AbstractResourceIT {
     @Test
     public void testGetNextHasAPidWithPath() throws IOException {
         final HttpPost method = new HttpPost(serverAddress + "fcr:pid");
-        method.setHeader("Accept", "application/n3");
-        final HttpResponse response = client.execute(method);
         logger.debug("Executed testGetNextHasAPidWithPath()");
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(method);
         assertTrue("Didn't find a single dang PID!", graphStore.contains(ANY,
                 createResource(serverAddress + "fcr:pid").asNode(),
                 HAS_MEMBER_OF_RESULT.asNode(), ANY));
@@ -97,11 +87,8 @@ public class FedoraIdentifiersIT extends AbstractResourceIT {
     public void testGetNextHasTwoPidsWithPath() throws IOException {
         final HttpPost method =
                 new HttpPost(serverAddress + "fcr:pid?numPids=2");
-        method.setHeader("Accept", "application/n3");
-        final HttpResponse response = client.execute(method);
         logger.debug("Executed testGetNextHasTwoPidsWithPath()");
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(method);
         assertEquals("Didn't find two dang PIDs!", 2, size(graphStore.find(ANY,
                 createResource(serverAddress + "fcr:pid").asNode(),
                 HAS_MEMBER_OF_RESULT.asNode(), ANY)));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNamespacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNamespacesIT.java
@@ -41,13 +41,7 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
     public void testGet() throws Exception {
 
         final HttpGet get = new HttpGet(serverAddress + "fcr:namespaces");
-        get.addHeader("Accept", "application/n-triples");
-        final HttpResponse response = execute(get);
-        final int status = response.getStatusLine().getStatusCode();
-        assertEquals(200, status);
-
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(get);
 
         logger.debug("Got store {}", graphStore);
         assertTrue("expected to find nt property in response", graphStore
@@ -70,13 +64,8 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
         execute(post);
 
         final HttpGet get = new HttpGet(serverAddress + "fcr:namespaces");
-        get.addHeader("Accept", "application/n-triples");
-        final HttpResponse response = execute(get);
-        final int status = response.getStatusLine().getStatusCode();
-        assertEquals(200, status);
 
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(get);
 
         logger.debug("Got store {}", graphStore);
         assertTrue("expected to find our new property in response", graphStore
@@ -115,7 +104,7 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
         assertEquals(200, status);
 
         final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+            parseTriples(response.getEntity());
 
         logger.debug("Got store {}", graphStore);
         assertTrue("expected to find our updated property in response",
@@ -148,13 +137,7 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
         execute(post);
 
         final HttpGet get = new HttpGet(serverAddress + "fcr:namespaces");
-        get.addHeader("Accept", "application/n-triples");
-        final HttpResponse response = execute(get);
-        final int status = response.getStatusLine().getStatusCode();
-        assertEquals(200, status);
-
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(get);
 
         logger.debug("Got store {}", graphStore);
         assertTrue("expected to find our updated property in response",
@@ -187,13 +170,7 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
         execute(post);
 
         final HttpGet get = new HttpGet(serverAddress + "fcr:namespaces");
-        get.addHeader("Accept", "application/n-triples");
-        final HttpResponse response = execute(get);
-        final int status = response.getStatusLine().getStatusCode();
-        assertEquals(200, status);
-
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(get);
 
         logger.debug("Got store {}", graphStore);
         assertFalse("should not find deleted property in response", graphStore

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodeTypesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodeTypesIT.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -42,12 +41,7 @@ public class FedoraNodeTypesIT  extends AbstractResourceIT {
 
         final HttpGet httpGet = new HttpGet(serverAddress + "/fcr:nodetypes");
 
-        final HttpResponse result = client.execute(httpGet);
-
-        assertEquals(200, result.getStatusLine().getStatusCode());
-
-        final GraphStore graphStore =
-            parseTriples(result.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(httpGet);
 
         assertTrue(graphStore.contains(Node.ANY, NodeFactory.createURI(RdfLexicon.RESTAPI_NAMESPACE + "resource"), RDF.type.asNode(), RDFS.Class.asNode()));
         assertTrue(graphStore.contains(Node.ANY, NodeFactory.createURI(RdfLexicon.RESTAPI_NAMESPACE + "object"), RDF.type.asNode(), RDFS.Class.asNode()));
@@ -69,10 +63,7 @@ public class FedoraNodeTypesIT  extends AbstractResourceIT {
 
         final HttpGet httpGet = new HttpGet(serverAddress + "/fcr:nodetypes");
 
-        final HttpResponse result = client.execute(httpGet);
-
-        final GraphStore graphStore =
-            parseTriples(result.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(httpGet);
 
         assertTrue(graphStore.contains(Node.ANY, NodeFactory.createURI("info:local#object"), RDFS.subClassOf.asNode(), NodeFactory.createURI(RdfLexicon.RESTAPI_NAMESPACE + "object")));
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
@@ -17,7 +17,6 @@
 package org.fcrepo.integration.http.api;
 
 import static java.util.UUID.randomUUID;
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -70,17 +69,11 @@ public class FedoraWorkspacesIT extends AbstractResourceIT {
         assertEquals(201, createWorkspaceResponse.getStatusLine()
                 .getStatusCode());
 
-        final HttpPost httpPost =
-            new HttpPost(serverAddress + "workspace:" + workspace + "/" + pid);
-        final HttpResponse response = execute(httpPost);
-        assertEquals(201, response.getStatusLine().getStatusCode());
+        createObject("workspace:" + workspace + "/" + pid);
 
         final HttpGet httpGet =
             new HttpGet(serverAddress + "workspace:" + workspace + "/" + pid);
-        httpGet.setHeader("Accept", "application/n3");
-        final HttpResponse profileResponse = execute(httpGet);
-        assertEquals(200, profileResponse.getStatusLine().getStatusCode());
-        final GraphStore graphStore =
-            parseTriples(profileResponse.getEntity().getContent());
+        final GraphStore graphStore = getGraphStore(httpGet);
+        logger.info(graphStore.toString());
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ldp/LdprIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ldp/LdprIT.java
@@ -27,7 +27,6 @@ import static org.apache.jena.riot.WebContent.contentTypeNTriples;
 import static org.apache.jena.riot.WebContent.contentTypeRDFJSON;
 import static org.apache.jena.riot.WebContent.contentTypeRDFXML;
 import static org.apache.jena.riot.WebContent.contentTypeTurtle;
-import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -58,12 +57,9 @@ public class LdprIT extends AbstractResourceIT {
     @Test
     public void testProvidesRDFRepresentation() throws IOException {
         final HttpGet testMethod = new HttpGet(serverAddress + "");
-        final HttpResponse response = client.execute(testMethod);
-        assertEquals("text/turtle", response.getFirstHeader("Content-Type")
-                .getValue());
+        testMethod.addHeader("Accept", "text/turtle");
 
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent(), "TTL");
+        final GraphStore graphStore = getGraphStore(testMethod);
 
         assertTrue(graphStore.contains(ANY, createResource(serverAddress)
    .asNode(), ANY, ANY));
@@ -77,12 +73,9 @@ public class LdprIT extends AbstractResourceIT {
     @Test
     public void testShouldHaveAtLeastOneRdfType() throws IOException {
         final HttpGet testMethod = new HttpGet(serverAddress + "");
-        final HttpResponse response = client.execute(testMethod);
-        assertEquals("text/turtle", response.getFirstHeader("Content-Type")
-                .getValue());
+        testMethod.addHeader("Accept", "text/turtle");
 
-        final GraphStore graphStore =
-            parseTriples(response.getEntity().getContent(), "TTL");
+        final GraphStore graphStore = getGraphStore(testMethod);
 
         assertTrue(graphStore.contains(ANY, createResource(serverAddress)
                 .asNode(), type.asNode(), ANY));

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
@@ -18,6 +18,9 @@ package org.fcrepo.http.commons.test.util;
 
 import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
 import static java.net.URI.create;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.apache.jena.riot.WebContent.contentTypeToLang;
 import static org.fcrepo.kernel.utils.ContentDigest.asURI;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -45,6 +48,7 @@ import javax.jcr.nodetype.NodeTypeIterator;
 import javax.jcr.nodetype.NodeTypeManager;
 import javax.jcr.query.Query;
 import javax.jcr.query.QueryResult;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -52,7 +56,9 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
+import org.apache.jena.riot.Lang;
 import org.fcrepo.http.commons.AbstractResource;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.kernel.Datastream;
 import org.fcrepo.kernel.FedoraObject;
 import org.fcrepo.kernel.identifiers.UUIDPidMinter;
@@ -232,6 +238,17 @@ public abstract class TestHelpers {
         return mockDs;
     }
 
+    private static String getRdfSerialization(final HttpEntity entity) {
+        final MediaType mediaType = MediaType.valueOf(entity.getContentType().getValue());
+        final Lang lang = contentTypeToLang(mediaType.toString());
+        assertNotNull("Entity is not an RDF serialization", lang);
+        return lang.getName();
+    }
+
+    public static GraphStore parseTriples(final HttpEntity entity) throws IOException {
+        return parseTriples(entity.getContent(), getRdfSerialization(entity));
+    }
+
     public static GraphStore parseTriples(final InputStream content) {
         return parseTriples(content, "N3");
     }
@@ -243,7 +260,6 @@ public abstract class TestHelpers {
         model.read(content, "", contentType);
 
         return GraphStoreFactory.create(model);
-
     }
 
     /**


### PR DESCRIPTION
- validate it receives RDF
- select an appropriate RDF serialization for the Content-Type
- consistently fetch the graph using test helpers
