### PR TITLE
update PropertyRdfContext serialization to include all BINARY properties...

### DIFF
--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
@@ -23,7 +23,7 @@ import static org.fcrepo.jcr.FedoraJcrTypes.ROOT;
 import static org.fcrepo.kernel.RdfLexicon.HAS_CONTENT;
 import static org.fcrepo.kernel.RdfLexicon.HAS_LOCATION;
 import static org.fcrepo.kernel.RdfLexicon.IS_CONTENT_OF;
-import static org.fcrepo.kernel.utils.FedoraTypesUtils.isBinaryProperty;
+import static org.fcrepo.kernel.utils.FedoraTypesUtils.isBinaryContentProperty;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.property2values;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -135,11 +135,11 @@ public class PropertiesRdfContext extends NodeRdfContext {
         LOGGER.debug("Creating triples for node: {}", n);
         final UnmodifiableIterator<Property> nonBinaryProperties =
             Iterators.filter(new PropertyIterator(n.getProperties()),
-                    not(isBinaryProperty));
+                    not(isBinaryContentProperty));
 
         final UnmodifiableIterator<Property> nonBinaryPropertiesCopy =
             Iterators.filter(new PropertyIterator(n.getProperties()),
-                    not(isBinaryProperty));
+                    not(isBinaryContentProperty));
 
         return Iterators.concat(new ZippingIterator<>(
                 Iterators.transform(

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/utils/FedoraTypesUtils.java
@@ -29,6 +29,8 @@ import static org.fcrepo.jcr.FedoraJcrTypes.FEDORA_DATASTREAM;
 import static org.fcrepo.jcr.FedoraJcrTypes.FEDORA_OBJECT;
 import static org.fcrepo.jcr.FedoraJcrTypes.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.utils.JcrRdfTools.getRDFNamespaceForJcrNamespace;
+import static org.modeshape.jcr.api.JcrConstants.JCR_DATA;
+import static org.modeshape.jcr.api.JcrConstants.JCR_PATH;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Collection;
@@ -49,12 +51,10 @@ import javax.jcr.query.RowIterator;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 
-import org.fcrepo.jcr.FedoraJcrTypes;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
-import org.modeshape.jcr.api.JcrConstants;
 import org.modeshape.jcr.api.Namespaced;
 import org.slf4j.Logger;
 
@@ -198,17 +198,17 @@ public abstract class FedoraTypesUtils {
         };
 
     /**
-     * Check if a JCR property is a binary property or not
+     * Check if a JCR property is a binary jcr:data property
      */
-    public static Predicate<Property> isBinaryProperty =
+    public static Predicate<Property> isBinaryContentProperty =
         new Predicate<Property>() {
 
             @Override
             public boolean apply(final Property p) {
                 checkArgument(p != null,
-                        "null is neither binary nor not binary!");
+                                 "null is neither binary nor not binary!");
                 try {
-                    return p.getType() == BINARY;
+                    return p.getType() == BINARY && p.getName().equals(JCR_DATA);
                 } catch (final RepositoryException e) {
                     throw propagate(e);
                 }
@@ -384,8 +384,8 @@ public abstract class FedoraTypesUtils {
                 session.getWorkspace().getQueryManager();
 
             final String querystring =
-                "SELECT [" + JcrConstants.JCR_PATH + "] FROM ["
-                        + FedoraJcrTypes.FEDORA_OBJECT + "]";
+                "SELECT [" + JCR_PATH + "] FROM ["
+                        + FEDORA_OBJECT + "]";
 
             final QueryResult queryResults =
                 queryManager.createQuery(querystring, JCR_SQL2).execute();

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/utils/FedoraTypesUtilsTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/utils/FedoraTypesUtilsTest.java
@@ -28,6 +28,7 @@ import static org.fcrepo.kernel.utils.FedoraTypesUtils.getPredicateForProperty;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.getRepositoryCount;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.getRepositorySize;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.getVersionHistory;
+import static org.fcrepo.kernel.utils.FedoraTypesUtils.isBinaryContentProperty;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.isFedoraDatastream;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.isFedoraObject;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.isFedoraResource;
@@ -53,6 +54,7 @@ import java.util.TimeZone;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
+import javax.jcr.PropertyType;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -75,6 +77,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.modeshape.jcr.JcrValueFactory;
+import org.modeshape.jcr.api.JcrConstants;
 import org.modeshape.jcr.api.Namespaced;
 
 import com.google.common.base.Predicate;
@@ -172,6 +175,26 @@ public class FedoraTypesUtilsTest {
             test.apply(mockYes);
             fail("Unexpected completion after RepositoryException!");
         } catch (final RuntimeException e) {} // expected
+    }
+
+    @Test
+    public void testIsBinaryContentProperty() throws RepositoryException {
+        when(mockProperty.getType()).thenReturn(PropertyType.BINARY);
+        when(mockProperty.getName()).thenReturn(JcrConstants.JCR_DATA);
+        assertTrue(isBinaryContentProperty.apply(mockProperty));
+    }
+
+    @Test
+    public void testIsNotBinaryContentProperty() throws RepositoryException {
+        when(mockProperty.getType()).thenReturn(PropertyType.STRING);
+        assertFalse(isBinaryContentProperty.apply(mockProperty));
+    }
+
+    @Test
+    public void testContentButNotBinaryContentProperty() throws RepositoryException {
+        when(mockProperty.getType()).thenReturn(PropertyType.STRING);
+        when(mockProperty.getName()).thenReturn(JcrConstants.JCR_DATA);
+        assertFalse(isBinaryContentProperty.apply(mockProperty));
     }
 
     @Test


### PR DESCRIPTION
..., except BINARY properties that are jcr:data (which should be retrieved as streams, not serialized in the graph)

Fixes https://www.pivotaltracker.com/story/show/60613502
