### PR TITLE
added system property for infinispan replication timeout in clustered configuration

### DIFF
--- a/fcrepo-jcr/src/main/resources/config/infinispan/clustered/infinispan.xml
+++ b/fcrepo-jcr/src/main/resources/config/infinispan/clustered/infinispan.xml
@@ -156,7 +156,7 @@
         updating nodes within the same process. If you're not sure, use pessimistic locking.
      -->
     <clustering mode="distribution">
-      <sync/>
+      <sync replTimeout="${fcrepo.ispn.replication.timeout:10000}" />
       <l1 enabled="false" lifespan="0" onRehash="false"/>
       <hash numOwners="${fcrepo.ispn.numOwners:2}" numSegments="40"/>
       <stateTransfer chunkSize="100" fetchInMemoryState="true"/>


### PR DESCRIPTION
Since I get a lot of these https://gist.github.com/fasseg/7467108 when ingest files larger than 10 MB on AWS. I would like to add a setting to increase the replication timeout for infinispan.
