### PR TITLE
Added basic version creation on all REST API updates commands.

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/FedoraResponseCodesIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/FedoraResponseCodesIT.java
@@ -63,8 +63,12 @@ public class FedoraResponseCodesIT extends AbstractResourceIT {
                 postObjMethod("FedoraDatastreamsTest2Permit");
 
         assertEquals(201, getStatus(objMethod));
-        final HttpPost method =
-                postDSMethod("FedoraDatastreamsTest2Permit", "zxc", "foo");
+        final HttpPost obj2Method = postObjMethod(
+                "FedoraDatastreamsTest2Permit/FedoraDatastreamsTest2Deny");
+        assertEquals(201, getStatus(obj2Method));
+        final HttpPost method = postDSMethod(
+                "FedoraDatastreamsTest2Permit/FedoraDatastreamsTest2Deny",
+                "zxc", "foo");
         final HttpResponse response = client.execute(method);
         assertEquals(403, response.getStatusLine().getStatusCode());
     }
@@ -90,7 +94,7 @@ public class FedoraResponseCodesIT extends AbstractResourceIT {
     public void testDeniedAddDeepDatastream() throws Exception {
         final HttpPost method =
                 postDSMethod(
-                        "FedoraDatastreamsTest2_permit/does_permit/not_permit/exist_permit/yet_permit",
+                        "FedoraDatastreamsTest2_permit/does_permit/not_permit/exist_permit/yet_permit/allowed_child",
                         "zxc", "foo");
         final HttpResponse response = client.execute(method);
         assertEquals(403, response.getStatusLine().getStatusCode());
@@ -111,11 +115,11 @@ public class FedoraResponseCodesIT extends AbstractResourceIT {
     @Test
     public void testDeniedPutDatastream() throws Exception {
         final HttpPost objMethod =
-                postObjMethod("FedoraDatastreamsTestPut_permit");
+                postObjMethod("FedoraDatastreamsTestPut_permit/allowed_child");
         assertEquals(201, getStatus(objMethod));
         final HttpPut method =
-                putDSMethod("FedoraDatastreamsTestPut_permit", "zxc",
-                        "foo");
+                putDSMethod("FedoraDatastreamsTestPut_permit/allowed_child",
+                        "zxc", "foo");
         final HttpResponse response = client.execute(method);
         assertEquals(403, response.getStatusLine().getStatusCode());
     }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixPEP.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/PermitRootAndPathEndsWithPermitSuffixPEP.java
@@ -67,7 +67,14 @@ public class PermitRootAndPathEndsWithPermitSuffixPEP implements
             return absPath.getParent().getLastSegment().getName()
                     .getLocalName().toLowerCase().endsWith("permit");
         }
-        return false;
+
+        // due to the fact that versioning creates version nodes under the
+        // created node, for the test implementation we should allow actions
+        // on nodes whose parents end with "permit".
+        return (!absPath.getParent().isRoot() && absPath.getParent()
+                .getLastSegment().getName().getLocalName().toLowerCase()
+                .endsWith("permit"));
+
     }
 
     /*

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraContent.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraContent.java
@@ -108,7 +108,6 @@ public class FedoraContent extends AbstractResource {
         final String newDatastreamPath;
         final String path = toPath(pathList);
 
-
         if (nodeService.exists(session, path)) {
             final String pid;
 
@@ -151,6 +150,7 @@ public class FedoraContent extends AbstractResource {
                             uriInfo);
 
             session.save();
+            versionService.checkpoint(session, path);
             return created(
                     new URI(subjects.getGraphSubject(
                             datastreamNode.getNode(JCR_CONTENT)).getURI()))
@@ -211,6 +211,7 @@ public class FedoraContent extends AbstractResource {
                             contentType.toString(), requestBodyStream);
             final boolean isNew = datastreamNode.isNew();
             session.save();
+            versionService.checkpoint(session, path);
 
             if (isNew) {
                 final HttpGraphSubjects subjects =

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
@@ -266,7 +266,6 @@ public class FedoraNodes extends AbstractResource {
         try {
 
             if (requestBodyStream != null) {
-
                 final FedoraResource resource =
                         nodeService.getObject(session, path);
 
@@ -302,6 +301,7 @@ public class FedoraNodes extends AbstractResource {
                 }
 
                 session.save();
+                versionService.checkpoint(session, path);
 
                 return status(SC_NO_CONTENT).build();
             } else {
@@ -338,7 +338,6 @@ public class FedoraNodes extends AbstractResource {
         try {
             final FedoraResource resource =
                 nodeService.getObject(session, path);
-
             final Date date = resource.getLastModifiedDate();
             final Date roundedDate = new Date();
 
@@ -373,6 +372,7 @@ public class FedoraNodes extends AbstractResource {
             }
 
             session.save();
+            versionService.checkpoint(session, path);
 
             return status(SC_NO_CONTENT).build();
         } finally {
@@ -509,6 +509,7 @@ public class FedoraNodes extends AbstractResource {
             }
 
             session.save();
+            versionService.checkpoint(session, newObjectPath);
 
             logger.debug("Finished creating {} with path: {}", mixin, newObjectPath);
 
@@ -601,6 +602,7 @@ public class FedoraNodes extends AbstractResource {
 
             nodeService.copyObject(session, toPath(path), destination);
             session.save();
+            versionService.checkpoint(session, destination);
             return created(new URI(destinationUri)).build();
         } catch (final ItemExistsException e) {
             return status(SC_PRECONDITION_FAILED).entity("Destination resource already exists").build();
@@ -641,6 +643,7 @@ public class FedoraNodes extends AbstractResource {
 
             nodeService.moveObject(session, toPath(path), destination);
             session.save();
+            versionService.checkpoint(session, destination);
             return created(new URI(destinationUri)).build();
         } catch (final ItemExistsException e) {
             return status(SC_PRECONDITION_FAILED).entity("Destination resource already exists").build();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraContentTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraContentTest.java
@@ -44,6 +44,8 @@ import java.util.Date;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.version.VersionManager;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
@@ -54,6 +56,7 @@ import org.fcrepo.kernel.exception.InvalidChecksumException;
 import org.fcrepo.kernel.identifiers.PidMinter;
 import org.fcrepo.kernel.services.DatastreamService;
 import org.fcrepo.kernel.services.NodeService;
+import org.fcrepo.kernel.services.VersionService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -67,6 +70,9 @@ public class FedoraContentTest {
 
     @Mock
     private NodeService mockNodeService;
+
+    @Mock
+    private VersionService mockVersions;
 
     @Mock
     private Session mockSession;
@@ -87,8 +93,14 @@ public class FedoraContentTest {
         setField(testObj, "datastreamService", mockDatastreams);
         setField(testObj, "nodeService", mockNodeService);
         setField(testObj, "uriInfo", getUriInfoImpl());
+        setField(testObj, "versionService", mockVersions);
         mockSession = mockSession(testObj);
         setField(testObj, "session", mockSession);
+        final Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
+        final VersionManager mockVM = mock(VersionManager.class);
+        when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraDatastreamsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraDatastreamsTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
@@ -49,6 +50,8 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.version.VersionManager;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
@@ -59,6 +62,8 @@ import org.fcrepo.kernel.FedoraResource;
 import org.fcrepo.kernel.exception.InvalidChecksumException;
 import org.fcrepo.kernel.services.DatastreamService;
 import org.fcrepo.kernel.services.NodeService;
+import org.fcrepo.kernel.services.VersionService;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -77,6 +82,9 @@ public class FedoraDatastreamsTest {
 
     @Mock
     private NodeService mockNodes;
+
+    @Mock
+    private VersionService mockVersions;
 
     @Mock
     private Node mockDsNode;
@@ -102,8 +110,14 @@ public class FedoraDatastreamsTest {
         setField(testObj, "datastreamService", mockDatastreams);
         setField(testObj, "nodeService", mockNodes);
         setField(testObj, "uriInfo", getUriInfoImpl());
+        setField(testObj, "versionService", mockVersions);
         mockSession = mockSession(testObj);
         setField(testObj, "session", mockSession);
+        final Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
+        final VersionManager mockVM = mock(VersionManager.class);
+        when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -55,6 +55,8 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.ValueFactory;
+import javax.jcr.Workspace;
+import javax.jcr.version.VersionManager;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
@@ -70,6 +72,7 @@ import org.fcrepo.kernel.rdf.GraphSubjects;
 import org.fcrepo.kernel.services.DatastreamService;
 import org.fcrepo.kernel.services.NodeService;
 import org.fcrepo.kernel.services.ObjectService;
+import org.fcrepo.kernel.services.VersionService;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -78,6 +81,7 @@ import org.mockito.Mock;
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.sparql.util.Context;
+
 
 public class FedoraNodesTest {
 
@@ -88,6 +92,9 @@ public class FedoraNodesTest {
 
     @Mock
     private NodeService mockNodes;
+
+    @Mock
+    private VersionService mockVersions;
 
     @Mock
     private Node mockNode;
@@ -129,12 +136,18 @@ public class FedoraNodesTest {
         testObj = new FedoraNodes();
         setField(testObj, "datastreamService", mockDatastreams);
         setField(testObj, "nodeService", mockNodes);
+        setField(testObj, "versionService", mockVersions);
         this.uriInfo = getUriInfoImpl();
         setField(testObj, "uriInfo", uriInfo);
         setField(testObj, "pidMinter", mockPidMinter);
         setField(testObj, "objectService", mockObjects);
         mockSession = mockSession(testObj);
         setField(testObj, "session", mockSession);
+        final Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(mockSession.getWorkspace()).thenReturn(mockWorkspace);
+        final VersionManager mockVM = mock(VersionManager.class);
+        when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
     }
 
     @Test

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -52,6 +52,7 @@ import org.fcrepo.kernel.rdf.GraphSubjects;
 import org.fcrepo.kernel.services.DatastreamService;
 import org.fcrepo.kernel.services.NodeService;
 import org.fcrepo.kernel.services.ObjectService;
+import org.fcrepo.kernel.services.VersionService;
 import org.modeshape.jcr.api.JcrTools;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,6 +96,12 @@ public abstract class AbstractResource {
      */
     @Autowired
     protected DatastreamService datastreamService;
+
+    /**
+     * The fcrepo version service
+     */
+    @Autowired
+    protected VersionService versionService;
 
     @Autowired(required = false)
     private HttpTripleUtil httpTripleUtil;

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/services/VersionService.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/services/VersionService.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.services;
+
+import org.fcrepo.kernel.Transaction;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * This service exposes management of node versioning.  Instead of invoking
+ * the JCR VersionManager methods, this provides a level of indirection that
+ * allows for special handling of features built on top of JCR such as user
+ * transactions.
+ * @author Mike Durbin
+ */
+
+@Component
+public class VersionService extends RepositoryService {
+
+    private static final Logger logger = getLogger(VersionService.class);
+
+    @Autowired
+    TransactionService txService;
+
+    /**
+     * Creates a version checkpoint for the given path.  This is the equivalent
+     * of VersionManager#checkpoint(path), except that it is aware of
+     * TxSessions and queues these operations accordingly.
+     *
+     * @param session
+     * @param absPath the absolute path to the node for whom a new version is
+     *                to be minted
+     * @throws RepositoryException
+     */
+    public void checkpoint(final Session session, String absPath) throws RepositoryException {
+        String txId = TransactionService.getCurrentTransactionId(session);
+        if (txId != null) {
+            Transaction tx = txService.getTransaction(txId);
+            tx.addPathToVersion(absPath);
+        } else {
+            session.getWorkspace().getVersionManager().checkpoint(absPath);
+        }
+    }
+}

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/services/VersionServiceTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/services/VersionServiceTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.services;
+
+import org.fcrepo.kernel.Transaction;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.version.VersionManager;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * @author Mike Durbin
+ */
+public class VersionServiceTest {
+
+
+    VersionService testObj;
+
+    private TransactionService txService;
+
+    @Before
+    public void setup() throws Exception {
+        txService = new TransactionService();
+        initMocks(this);
+        testObj = new VersionService();
+        testObj.txService = txService;
+    }
+
+    @Test
+    public void testCheckpoint() throws Exception {
+        Session s = mock(Session.class);
+        final Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(s.getWorkspace()).thenReturn(mockWorkspace);
+        final VersionManager mockVM = mock(VersionManager.class);
+        when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
+
+        // request a version be created
+        testObj.checkpoint(s, "/example");
+
+        // ensure that it was
+        verify(mockVM, only()).checkpoint("/example");
+    }
+
+    @Test
+    public void testDeferredCheckpoint() throws Exception {
+        Session s = mock(Session.class);
+        final Workspace mockWorkspace = mock(Workspace.class);
+        when(mockWorkspace.getName()).thenReturn("default");
+        when(s.getWorkspace()).thenReturn(mockWorkspace);
+        final VersionManager mockVM = mock(VersionManager.class);
+        when(mockWorkspace.getVersionManager()).thenReturn(mockVM);
+
+        // start a transaction
+        Transaction t = txService.beginTransaction(s);
+        s = t.getSession();
+
+        // request a version be created
+        testObj.checkpoint(s, "/example");
+
+        // ensure that no version was created (because the transaction is still open)
+        verify(mockVM, never()).checkpoint("/example");
+
+        // close the transaction
+        txService.commit(t.getId());
+
+        // ensure that the version was made
+        verify(mockVM, only()).checkpoint("/example");
+    }
+}


### PR DESCRIPTION
The changes to fcrepo-auth-common (which appear first in the diff below) are to compensate for the fact that version creation makes new child objects whose names are out of our control and that test was based around the names of nodes.  I've updated that test to retain its spirit but still work in the case where version nodes are created.  I've also added an issue to look into a more intuitive and comprehensive approach for minimizing the confusion associated with this behavior.
