### PR TITLE
Return a 404 Not Found when deleting a workspace that doesn't exist.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspaces.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspaces.java
@@ -49,6 +49,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import com.google.common.collect.ImmutableSet;
+import com.sun.jersey.api.NotFoundException;
 import org.fcrepo.http.api.FedoraNodes;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpGraphSubjects;
@@ -162,6 +164,11 @@ public class FedoraRepositoryWorkspaces extends AbstractResource {
     public Response deleteWorkspace(@PathParam("path") final String path) throws RepositoryException {
         try {
             final Workspace workspace = session.getWorkspace();
+
+            if (!ImmutableSet.copyOf(workspace.getAccessibleWorkspaceNames()).contains(path)) {
+                throw new NotFoundException();
+            }
+
             workspace.deleteWorkspace(path);
 
             return noContent().build();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspacesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspacesTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import com.sun.jersey.api.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -126,8 +127,16 @@ public class FedoraRepositoryWorkspacesTest {
 
     @Test
     public void testDeleteWorkspace() throws Exception {
+        when(mockWorkspace.getAccessibleWorkspaceNames()).thenReturn(new String[] { "xxx" });
         final Response response = workspaces.deleteWorkspace("xxx");
         verify(mockWorkspace).deleteWorkspace("xxx");
         assertEquals(204, response.getStatus());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testDeleteMissingWorkspace() throws Exception {
+        when(mockWorkspace.getAccessibleWorkspaceNames()).thenReturn(new String[] { "yyy" });
+        final Response response = workspaces.deleteWorkspace("xxx");
+        assertEquals(404, response.getStatus());
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
@@ -34,6 +34,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
+import org.w3c.dom.ElementTraversal;
 
 public class FedoraWorkspacesIT extends AbstractResourceIT {
 
@@ -97,6 +98,18 @@ public class FedoraWorkspacesIT extends AbstractResourceIT {
             execute(httpDeleteWorkspace);
 
         assertEquals(204, deleteWorkspaceResponse.getStatusLine()
+                              .getStatusCode());
+
+    }
+
+    @Test
+    public void shouldBe404WhenDeletingJunkWorkspace() throws IOException {
+        final HttpDelete httpDeleteWorkspace = new HttpDelete(serverAddress + "fcr:workspaces/junk");
+
+        final HttpResponse deleteWorkspaceResponse =
+            execute(httpDeleteWorkspace);
+
+        assertEquals(404, deleteWorkspaceResponse.getStatusLine()
                               .getStatusCode());
 
     }


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/61002838
