### PR TITLE
Use premis hasOriginalName (and hasSize) predicates on fedora:binary resources

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraContent.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraContent.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 
@@ -52,6 +53,7 @@ import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
+import com.sun.jersey.core.header.ContentDisposition;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpGraphSubjects;
 import org.fcrepo.http.commons.domain.Range;
@@ -95,11 +97,12 @@ public class FedoraContent extends AbstractResource {
     public Response create(@PathParam("path")
             final List<PathSegment> pathList,
             @HeaderParam("Slug") final String slug,
+            @HeaderParam("Content-Disposition") final String contentDisposition,
             @QueryParam("checksum") final String checksum,
             @HeaderParam("Content-Type") final MediaType requestContentType,
                     final InputStream requestBodyStream)
         throws IOException, InvalidChecksumException,
-                    RepositoryException, URISyntaxException {
+                   RepositoryException, URISyntaxException, ParseException {
         final MediaType contentType =
                 requestContentType != null ? requestContentType
                         : APPLICATION_OCTET_STREAM_TYPE;
@@ -140,9 +143,19 @@ public class FedoraContent extends AbstractResource {
                 checksumURI = null;
             }
 
+            final String originalFileName;
+
+            if (contentDisposition != null) {
+                final ContentDisposition disposition = new ContentDisposition(contentDisposition);
+                originalFileName = disposition.getFileName();
+            } else {
+                originalFileName = null;
+            }
+
+
             final Node datastreamNode =
                     datastreamService.createDatastreamNode(session, newDatastreamPath,
-                            contentType.toString(), requestBodyStream,
+                            contentType.toString(), originalFileName, requestBodyStream,
                             checksumURI);
 
             final HttpGraphSubjects subjects =
@@ -176,10 +189,12 @@ public class FedoraContent extends AbstractResource {
     @Timed
     public Response modifyContent(@PathParam("path") final List<PathSegment> pathList,
                                   @QueryParam("checksum") final String checksum,
+                                  @HeaderParam("Content-Disposition") final String contentDisposition,
                                   @HeaderParam("Content-Type") final MediaType requestContentType,
                                   final InputStream requestBodyStream,
-                                  @Context final Request request) throws RepositoryException,
-            IOException, InvalidChecksumException, URISyntaxException {
+                                  @Context final Request request)
+        throws RepositoryException, IOException, InvalidChecksumException, URISyntaxException, ParseException {
+
         try {
             final String path = toPath(pathList);
             final MediaType contentType =
@@ -215,10 +230,18 @@ public class FedoraContent extends AbstractResource {
                 checksumURI = null;
             }
 
+            final String originalFileName;
+
+            if (contentDisposition != null) {
+                final ContentDisposition disposition = new ContentDisposition(contentDisposition);
+                originalFileName = disposition.getFileName();
+            } else {
+                originalFileName = null;
+            }
 
             final Node datastreamNode =
                 datastreamService.createDatastreamNode(session, path,
-                    contentType.toString(), requestBodyStream, checksumURI);
+                    contentType.toString(), originalFileName, requestBodyStream, checksumURI);
 
             final boolean isNew = datastreamNode.isNew();
             session.save();
@@ -325,11 +348,19 @@ public class FedoraContent extends AbstractResource {
                     new HttpGraphSubjects(session, FedoraNodes.class,
                             uriInfo);
 
+            final ContentDisposition contentDisposition = ContentDisposition.type("attachment")
+                                                              .fileName(ds.getFilename())
+                                                              .creationDate(ds.getCreatedDate())
+                                                              .modificationDate(ds.getLastModifiedDate())
+                                                              .size(ds.getContentSize())
+                                                              .build();
+
             return builder.type(ds.getMimeType()).header(
                     "Link",
                     subjects.getGraphSubject(ds.getNode()) +
                             ";rel=\"meta\"").header("Accept-Ranges",
                     "bytes").cacheControl(cc).lastModified(date).tag(etag)
+                    .header("Content-Disposition", contentDisposition)
                     .build();
         } finally {
             session.logout();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraDatastreams.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraDatastreams.java
@@ -132,7 +132,7 @@ public class FedoraDatastreams extends AbstractResource {
                     src = (InputStream) obj;
                 }
                 datastreamService.createDatastreamNode(session, dsPath, part
-                        .getMediaType().toString(), src);
+                        .getMediaType().toString(), null, src);
                 pathsChanged.add(dsPath);
             }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
@@ -83,6 +83,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
+import com.sun.jersey.core.header.ContentDisposition;
 import com.sun.jersey.multipart.FormDataParam;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.riot.Lang;
@@ -377,6 +378,7 @@ public class FedoraNodes extends AbstractResource {
             final String mixin,
             @QueryParam("checksum")
             final String checksum,
+            @HeaderParam("Content-Disposition") final String contentDisposition,
             @HeaderParam("Content-Type")
             final MediaType requestContentType,
             @HeaderParam("Slug")
@@ -483,9 +485,17 @@ public class FedoraNodes extends AbstractResource {
                     result.replaceProperties(subjects, inputModel);
                 } else if (result instanceof Datastream) {
 
+                    final String originalFileName;
+
+                    if (contentDisposition != null) {
+                        final ContentDisposition disposition = new ContentDisposition(contentDisposition);
+                        originalFileName = disposition.getFileName();
+                    } else {
+                        originalFileName = null;
+                    }
+
                     datastreamService.createDatastreamNode(session,
-                            newObjectPath, contentTypeString,
-                            requestBodyStream, checksumURI);
+                            newObjectPath, contentTypeString, originalFileName, requestBodyStream, checksumURI);
 
                 }
             }
@@ -532,7 +542,7 @@ public class FedoraNodes extends AbstractResource {
                                                 @FormDataParam("file") final InputStream file
     ) throws Exception {
 
-        return createObject(pathList, mixin, null, null, slug, uriInfo, file);
+        return createObject(pathList, mixin, null, null, null, slug, uriInfo, file);
 
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraContentTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraContentTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.ParseException;
 import java.util.Date;
 
 import javax.jcr.Node;
@@ -105,7 +106,7 @@ public class FedoraContentTest {
 
     @Test
     public void testPutContent() throws RepositoryException, IOException,
-                                InvalidChecksumException, URISyntaxException {
+                                                InvalidChecksumException, URISyntaxException, ParseException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "testDS";
         final String dsContent = "asdf";
@@ -117,21 +118,21 @@ public class FedoraContentTest {
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class),
-                        eq(dsPath), anyString(), any(InputStream.class), eq((URI)null)))
+                        eq(dsPath), anyString(), eq("xyz"), any(InputStream.class), eq((URI)null)))
                 .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-            testObj.modifyContent(createPathList(pid, dsId), null, null,
+            testObj.modifyContent(createPathList(pid, dsId), null, "inline; filename=\"xyz\"", null,
                     dsContentStream, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
-                eq(dsPath), anyString(), any(InputStream.class), eq((URI)null));
+                eq(dsPath), anyString(), eq("xyz"), any(InputStream.class), eq((URI)null));
         verify(mockSession).save();
     }
 
     @Test
     public void testCreateContent() throws RepositoryException, IOException,
-                                   InvalidChecksumException, URISyntaxException {
+                                                   InvalidChecksumException, URISyntaxException, ParseException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "xyz";
         final String dsContent = "asdf";
@@ -143,24 +144,24 @@ public class FedoraContentTest {
         when(mockNodeService.exists(mockSession, dsPath)).thenReturn(false);
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class),
-                        eq(dsPath), anyString(), any(InputStream.class),
+                        eq(dsPath), anyString(), eq((String)null), any(InputStream.class),
                         eq((URI) null))).thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-            testObj.create(createPathList(pid, dsId), null, null, TEXT_PLAIN_TYPE,
+            testObj.create(createPathList(pid, dsId), null, null, null, TEXT_PLAIN_TYPE,
                     dsContentStream);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(mockSession, dsPath,
-                "text/plain", dsContentStream, null);
+                "text/plain", null, dsContentStream, null);
         verify(mockSession).save();
     }
 
     @Test
     public void testCreateContentAtMintedPath() throws RepositoryException,
-                                               IOException,
-                                               InvalidChecksumException,
-                                               URISyntaxException,
-                                               NoSuchFieldException {
+                                                               IOException,
+                                                               InvalidChecksumException,
+                                                               URISyntaxException,
+                                                               NoSuchFieldException, ParseException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsContent = "asdf";
         final String dsPath = "/" + pid;
@@ -173,15 +174,15 @@ public class FedoraContentTest {
         when(mockContentNode.getPath()).thenReturn(dsPath + "xyz/jcr:content");
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class), eq("/"
-                        + pid + "/xyz"), anyString(), any(InputStream.class),
+                        + pid + "/xyz"), anyString(), eq((String)null), any(InputStream.class),
                         eq((URI) null))).thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-            testObj.create(createPathList(pid), null, null, TEXT_PLAIN_TYPE,
+            testObj.create(createPathList(pid), null, null, null, TEXT_PLAIN_TYPE,
                     dsContentStream);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(mockSession,
-                "/" + pid + "/xyz", "text/plain", dsContentStream, null);
+                "/" + pid + "/xyz", "text/plain", null, dsContentStream, null);
         verify(mockSession).save();
     }
 
@@ -191,7 +192,7 @@ public class FedoraContentTest {
                                                            IOException,
                                                            InvalidChecksumException,
                                                            URISyntaxException,
-                                                           NoSuchFieldException {
+                                                           NoSuchFieldException, ParseException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsid = "slug";
         final String dsContent = "asdf";
@@ -204,21 +205,21 @@ public class FedoraContentTest {
         when(mockContentNode.getPath()).thenReturn(dsPath + "slug/jcr:content");
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class), eq("/"
-                                                                                + pid + "/slug"), anyString(), any(InputStream.class),
+                                                                                + pid + "/slug"), anyString(), eq((String)null), any(InputStream.class),
                                                         eq((URI) null))).thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-            testObj.create(createPathList(pid), dsid, null, TEXT_PLAIN_TYPE,
+            testObj.create(createPathList(pid), dsid, null, null, TEXT_PLAIN_TYPE,
                               dsContentStream);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(mockSession,
-                                                        "/" + pid + "/slug", "text/plain", dsContentStream, null);
+                                                        "/" + pid + "/slug", "text/plain", null, dsContentStream, null);
         verify(mockSession).save();
     }
 
     @Test
     public void testModifyContent() throws RepositoryException, IOException,
-                                   InvalidChecksumException, URISyntaxException {
+                                                   InvalidChecksumException, URISyntaxException, ParseException {
         final String pid = "FedoraDatastreamsTest1";
         final String dsId = "testDS";
         final String dsContent = "asdf";
@@ -235,15 +236,15 @@ public class FedoraContentTest {
                         any(EntityTag.class))).thenReturn(null);
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class),
-                        eq(dsPath), anyString(), any(InputStream.class), eq(checksum)))
+                        eq(dsPath), anyString(), eq((String)null), any(InputStream.class), eq(checksum)))
                 .thenReturn(mockNode);
         when(mockDatastreams.exists(mockSession, dsPath)).thenReturn(true);
         final Response actual =
-            testObj.modifyContent(createPathList(pid, dsId), "urn:sha1:some-checksum", null,
+            testObj.modifyContent(createPathList(pid, dsId), "urn:sha1:some-checksum", null, null,
                     dsContentStream, mockRequest);
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
-                eq(dsPath), anyString(), any(InputStream.class), eq(checksum));
+                eq(dsPath), anyString(), eq((String)null), any(InputStream.class), eq(checksum));
         verify(mockSession).save();
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraDatastreamsTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraDatastreamsTest.java
@@ -138,10 +138,10 @@ public class FedoraDatastreamsTest {
                     dsId2), multipart);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
-                eq("/" + pid + "/" + dsId1), anyString(),
+                eq("/" + pid + "/" + dsId1), anyString(), eq((String)null),
                 any(InputStream.class));
         verify(mockDatastreams).createDatastreamNode(any(Session.class),
-                eq("/" + pid + "/" + dsId2), anyString(),
+                eq("/" + pid + "/" + dsId2), anyString(), eq((String)null),
                 any(InputStream.class));
         verify(mockSession).save();
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -180,7 +180,7 @@ public class FedoraNodesTest {
         when(mockNode.getPath()).thenReturn(path);
         final Response actual =
                 testObj.createObject(createPathList(pid), FEDORA_OBJECT, null,
-                        null, null, getUriInfoImpl(), null);
+                        null, null, null, getUriInfoImpl(), null);
         assertNotNull(actual);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         assertTrue(actual.getEntity().toString().endsWith(pid));
@@ -200,7 +200,7 @@ public class FedoraNodesTest {
         when(mockObject.getNode()).thenReturn(mockNode);
         when(mockNode.getPath()).thenReturn(path);
         final Response actual =
-            testObj.createObject(createPathList(pid), FEDORA_OBJECT, null,
+            testObj.createObject(createPathList(pid), FEDORA_OBJECT, null, null,
                                     null, null, getUriInfoImpl(), null);
         assertNotNull(actual);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
@@ -220,7 +220,7 @@ public class FedoraNodesTest {
         when(mockObject.getNode()).thenReturn(mockNode);
         when(mockNode.getPath()).thenReturn(path);
         final Response actual =
-            testObj.createObject(createPathList(pid), FEDORA_OBJECT, null,
+            testObj.createObject(createPathList(pid), FEDORA_OBJECT, null, null,
                                     null, "some-slug", getUriInfoImpl(), null);
         assertNotNull(actual);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
@@ -241,7 +241,7 @@ public class FedoraNodesTest {
 
         when(
                 mockDatastreams.createDatastreamNode(any(Session.class),
-                        eq(dsPath), anyString(), eq(dsContentStream),
+                        eq(dsPath), anyString(), eq((String)null), eq(dsContentStream),
                         any(URI.class))).thenReturn(mockNode);
         final Datastream mockDatastream = mock(Datastream.class);
         when(mockDatastream.getNode()).thenReturn(mockNode);
@@ -249,14 +249,44 @@ public class FedoraNodesTest {
         when(mockNode.getPath()).thenReturn(dsPath);
         final Response actual =
                 testObj.createObject(createPathList(pid, dsId),
-                        FEDORA_DATASTREAM, null, APPLICATION_OCTET_STREAM_TYPE, null, getUriInfoImpl(),
+                        FEDORA_DATASTREAM, null, null, APPLICATION_OCTET_STREAM_TYPE, null, getUriInfoImpl(),
                         dsContentStream);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(mockDatastreams)
                 .createDatastreamNode(any(Session.class), eq(dsPath),
-                        anyString(), any(InputStream.class), any(URI.class));
+                        anyString(), eq((String)null), any(InputStream.class), any(URI.class));
         verify(mockSession).save();
     }
+
+    @Test
+    public void testCreateDatastreamWithContentDisposition() throws Exception {
+        final String pid = "FedoraDatastreamsTest1";
+        final String dsId = "testDS";
+        final String dsContent = "asdf";
+        final String dsPath = "/" + pid + "/" + dsId;
+        final InputStream dsContentStream = IOUtils.toInputStream(dsContent);
+        when(mockNode.getSession()).thenReturn(mockSession);
+
+
+        when(
+                mockDatastreams.createDatastreamNode(any(Session.class),
+                                                        eq(dsPath), anyString(), eq("xyz.jpg"), eq(dsContentStream),
+                                                        any(URI.class))).thenReturn(mockNode);
+        final Datastream mockDatastream = mock(Datastream.class);
+        when(mockDatastream.getNode()).thenReturn(mockNode);
+        when(mockDatastreams.createDatastream(mockSession, dsPath)).thenReturn(mockDatastream);
+        when(mockNode.getPath()).thenReturn(dsPath);
+        final Response actual =
+            testObj.createObject(createPathList(pid, dsId),
+                                    FEDORA_DATASTREAM, null, "inline; filename=\"xyz.jpg\"", APPLICATION_OCTET_STREAM_TYPE, null, getUriInfoImpl(),
+                                    dsContentStream);
+        assertEquals(CREATED.getStatusCode(), actual.getStatus());
+        verify(mockDatastreams)
+            .createDatastreamNode(any(Session.class), eq(dsPath),
+                                     anyString(), eq("xyz.jpg"), any(InputStream.class), any(URI.class));
+        verify(mockSession).save();
+    }
+
 
     @Test
     public void testDeleteObject() throws RepositoryException {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/AbstractResource.java
@@ -223,7 +223,7 @@ public abstract class AbstractResource {
 
                 final Node node =
                         datastreamService.createDatastreamNode(session, path,
-                                contentType.toString(), requestBodyStream,
+                                contentType.toString(), null, requestBodyStream,
                                 checksum);
                 result = new Datastream(node);
                 break;

--- a/fcrepo-jcr/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
+++ b/fcrepo-jcr/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
@@ -37,7 +37,9 @@ public interface FedoraJcrTypes {
 
     String JCR_CREATEDBY = "jcr:createdBy";
 
-    String CONTENT_SIZE = "fedora:size";
+    String PREMIS_FILE_NAME = "premis:hasOriginalName";
+
+    String CONTENT_SIZE = "premis:hasSize";
 
     String CONTENT_DIGEST = "fedora:digest";
 

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/Datastream.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/Datastream.java
@@ -120,11 +120,14 @@ public class Datastream extends FedoraResource implements FedoraJcrTypes {
     /**
      * Sets the content of this Datastream.
      *
+     *
      * @param content
+     * @param originalFileName
      * @throws RepositoryException
      */
     public void setContent(final InputStream content, final String contentType,
-        final URI checksum, final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
+                           final URI checksum, final String originalFileName,
+                           final StoragePolicyDecisionPoint storagePolicyDecisionPoint)
         throws RepositoryException, InvalidChecksumException {
 
         final Node contentNode =
@@ -138,6 +141,9 @@ public class Datastream extends FedoraResource implements FedoraJcrTypes {
             contentNode.setProperty(JCR_MIME_TYPE, contentType);
         }
 
+        if (originalFileName != null) {
+            contentNode.setProperty(PREMIS_FILE_NAME, originalFileName);
+        }
 
         LOGGER.debug("Created content node at path: {}", contentNode.getPath());
 
@@ -192,7 +198,7 @@ public class Datastream extends FedoraResource implements FedoraJcrTypes {
      */
     public void setContent(final InputStream content) throws InvalidChecksumException,
                                                        RepositoryException {
-        setContent(content, null, null, null);
+        setContent(content, null, null, null, null);
     }
 
     /**
@@ -270,6 +276,19 @@ public class Datastream extends FedoraResource implements FedoraJcrTypes {
     public long getSize() throws RepositoryException {
         return getNodePropertySize(node) + getContentSize();
 
+    }
+
+    /**
+     * Return the file name for the binary content
+     * @return
+     * @throws RepositoryException
+     */
+    public String getFilename() throws RepositoryException {
+        if (node.hasNode(JCR_CONTENT) && node.getNode(JCR_CONTENT).hasProperty(PREMIS_FILE_NAME)) {
+            return node.getNode(JCR_CONTENT).getProperty(PREMIS_FILE_NAME).getString();
+        } else {
+            return getDsId();
+        }
     }
 
     private void decorateContentNode(final Node contentNode)

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/RdfLexicon.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/RdfLexicon.java
@@ -52,6 +52,15 @@ public final class RdfLexicon {
     public static final String RESTAPI_NAMESPACE =
             "http://fedora.info/definitions/v4/rest-api#";
 
+
+    /**
+     * REST API namespace "fedora", used for internal API links and node
+     * paths.
+     * Was "info:fedora/".
+     **/
+    public static final String PREMIS_NAMESPACE =
+        "http://www.loc.gov/premis/rdf/v1#";
+
     /**
      * The namespaces that the repository manages internally.
      */
@@ -220,11 +229,13 @@ public final class RdfLexicon {
             createProperty(REPOSITORY_NAMESPACE + "hasLocation");
     public static final Property HAS_MIME_TYPE =
             createProperty(REPOSITORY_NAMESPACE + "mimeType");
+    public static final Property HAS_ORIGINAL_NAME =
+            createProperty(PREMIS_NAMESPACE + "hasOriginalName");
     public static final Property HAS_SIZE =
-            createProperty(REPOSITORY_NAMESPACE + "hasSize");
+            createProperty(PREMIS_NAMESPACE + "hasSize");
 
     public static final Set<Property> contentProperties = of(HAS_CONTENT,
-            IS_CONTENT_OF, HAS_LOCATION, HAS_MIME_TYPE, HAS_SIZE);
+            IS_CONTENT_OF, HAS_LOCATION, HAS_MIME_TYPE, HAS_ORIGINAL_NAME, HAS_SIZE);
 
 
     // VERSIONING

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/services/DatastreamService.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/services/DatastreamService.java
@@ -105,34 +105,37 @@ public class DatastreamService extends RepositoryService {
      */
     public Node createDatastreamNode(final Session session,
             final String dsPath, final String contentType,
+            final String originalFileName,
             final InputStream requestBodyStream) throws RepositoryException,
             IOException, InvalidChecksumException {
 
         return createDatastreamNode(session, dsPath, contentType,
-                requestBodyStream, null);
+                                       originalFileName, requestBodyStream, null);
     }
 
     /**
      * Create a new Datastream node in the JCR store
      *
+     *
      * @param session the jcr session to use
      * @param dsPath the absolute path to put the datastream
      * @param contentType the mime-type for the requestBodyStream
+     * @param originalFileName the original file name for the input stream
      * @param requestBodyStream binary payload for the datastream
-     * @param checksum the digest for the binary payload (as urn:sha1:xyz)
-     * @return
+     * @param checksum the digest for the binary payload (as urn:sha1:xyz)   @return
      * @throws RepositoryException
      * @throws IOException
      * @throws InvalidChecksumException
      */
     public Node createDatastreamNode(final Session session,
-        final String dsPath, final String contentType,
-        final InputStream requestBodyStream, final URI checksum)
+                                     final String dsPath, final String contentType,
+                                     final String originalFileName, final InputStream requestBodyStream,
+                                     final URI checksum)
         throws RepositoryException, IOException, InvalidChecksumException {
 
         final Datastream ds = createDatastream(session, dsPath);
         ds.setContent(requestBodyStream, contentType, checksum,
-                getStoragePolicyDecisionPoint());
+                         originalFileName, getStoragePolicyDecisionPoint());
         return ds.getNode();
     }
 

--- a/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
@@ -24,6 +24,7 @@
 <fedora = 'http://fedora.info/definitions/v4/rest-api#'>
 <fedorarelsext = 'http://fedora.info/definitions/v4/rels-ext#'>
 <rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+<premis = 'http://www.loc.gov/premis/rdf/v1#'>
 
 <test = 'info:fedora/test/'>
 
@@ -102,5 +103,6 @@
  * Some content that can have a checksum
  */
 [fedora:binary] mixin
-  - fedora:size (LONG) COPY
+  - premis:hasOriginalName (STRING)
+  - premis:hasSize (LONG) COPY
   - fedora:digest (URI) COPY

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/DatastreamIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/DatastreamIT.java
@@ -55,7 +55,7 @@ public class DatastreamIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamObject/testDatastreamNode1",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()));
         session.save();
         session.logout();
@@ -75,7 +75,7 @@ public class DatastreamIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamObject/testDatastreamNode1",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()));
 
         session.save();
@@ -97,7 +97,7 @@ public class DatastreamIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamObject/testDatastreamNode2",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()));
 
         session.save();
@@ -123,7 +123,7 @@ public class DatastreamIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamObject/testDatastreamNode3",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()));
 
         session.save();
@@ -151,7 +151,7 @@ public class DatastreamIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamObject/testDatastreamNode4",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()), ContentDigest.asURI("SHA-1",
                         "3da541559918a808c2402bba5012f6c60b27661c"));
 
@@ -168,4 +168,26 @@ public class DatastreamIT extends AbstractIT {
         assertEquals("asdf", contentString);
     }
 
+    @Test
+    public void testDatastreamFileName() throws IOException,
+                                                    RepositoryException,
+                                                    InvalidChecksumException {
+        final Session session = repo.login();
+        objectService.createObject(session, "/testDatastreamObject");
+        datastreamService.createDatastreamNode(session,
+                                                  "/testDatastreamObject/testDatastreamNode5",
+                                                  "application/octet-stream",
+                                                  "xyz.jpg",
+                                                  new ByteArrayInputStream("asdf".getBytes()));
+
+        session.save();
+
+        final Datastream ds =
+            datastreamService.getDatastream(session,
+                                               "/testDatastreamObject/testDatastreamNode5");
+        final String filename = ds.getFilename();
+
+        assertEquals("xyz.jpg", filename);
+
+    }
 }

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/FedoraResourceIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/FedoraResourceIT.java
@@ -29,6 +29,7 @@ import static javax.jcr.PropertyType.LONG;
 import static org.fcrepo.kernel.RdfLexicon.DC_TITLE;
 import static org.fcrepo.kernel.RdfLexicon.HAS_CHILD;
 import static org.fcrepo.kernel.RdfLexicon.HAS_PRIMARY_IDENTIFIER;
+import static org.fcrepo.kernel.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.RdfLexicon.RELATIONS_NAMESPACE;
 import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.RdfLexicon.RESTAPI_NAMESPACE;
@@ -229,7 +230,7 @@ public class FedoraResourceIT extends AbstractIT {
         objectService.createObject(session, "/testDatastreamGraphParent");
 
         datastreamService.createDatastreamNode(session, "/testDatastreamGraph",
-                "text/plain", new ByteArrayInputStream("123456789test123456789"
+                "text/plain", null, new ByteArrayInputStream("123456789test123456789"
                         .getBytes()));
 
         final FedoraResource object =
@@ -284,7 +285,7 @@ public class FedoraResourceIT extends AbstractIT {
         o = createLiteral("text/plain");
         assertTrue(datasetGraph.contains(ANY, s, p, o));
 
-        p = createURI(RESTAPI_NAMESPACE + "size");
+        p = HAS_SIZE.asNode();
         o = createLiteral("22", createTypedLiteral(22L).getDatatype());
         assertTrue(datasetGraph.contains(ANY, s, p, o));
 

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/DatastreamServiceIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/DatastreamServiceIT.java
@@ -16,6 +16,7 @@
 
 package org.fcrepo.integration.kernel.services;
 
+import static org.fcrepo.jcr.FedoraJcrTypes.PREMIS_FILE_NAME;
 import static org.jgroups.util.Util.assertEquals;
 import static org.jgroups.util.Util.assertTrue;
 import static org.junit.Assert.assertNotEquals;
@@ -56,7 +57,7 @@ public class DatastreamServiceIT extends AbstractIT {
     public void testCreateDatastreamNode() throws Exception {
         Session session = repository.login();
         datastreamService.createDatastreamNode(session, "/testDatastreamNode",
-                "application/octet-stream", new ByteArrayInputStream("asdf"
+                "application/octet-stream", null, new ByteArrayInputStream("asdf"
                         .getBytes()));
         session.save();
         session.logout();
@@ -69,13 +70,28 @@ public class DatastreamServiceIT extends AbstractIT {
     }
 
     @Test
+    public void testCreateDatastreamNodeWithfilename() throws Exception {
+        Session session = repository.login();
+        datastreamService.createDatastreamNode(session, "/testDatastreamNode",
+                                                  "application/octet-stream", "xyz.jpg", new ByteArrayInputStream("asdf"
+                                                                                                           .getBytes()));
+        session.save();
+        session.logout();
+        session = repository.login();
+
+        assertTrue(session.getRootNode().hasNode("testDatastreamNode"));
+        assertEquals("xyz.jpg", session.getNode("/testDatastreamNode").getNode(JCR_CONTENT).getProperty(PREMIS_FILE_NAME).getString());
+        session.logout();
+    }
+
+    @Test
     public void testGetDatastreamContentInputStream() throws Exception {
         Session session = repository.login();
         final InputStream is = new ByteArrayInputStream("asdf".getBytes());
         objectService.createObject(session, "/testDatastreamServiceObject");
         datastreamService.createDatastreamNode(session,
                 "/testDatastreamServiceObject/" + "testDatastreamNode",
-                "application/octet-stream", is);
+                "application/octet-stream", null, is);
 
         session.save();
         session.logout();
@@ -94,7 +110,7 @@ public class DatastreamServiceIT extends AbstractIT {
         objectService.createObject(session, "/testLLObject");
         datastreamService.createDatastreamNode(session,
                 "/testLLObject/testRepositoryContent",
-                "application/octet-stream", new ByteArrayInputStream(
+                "application/octet-stream", null, new ByteArrayInputStream(
                         "0123456789".getBytes()));
 
         session.save();

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/LowLevelStorageServiceIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/LowLevelStorageServiceIT.java
@@ -61,7 +61,7 @@ public class LowLevelStorageServiceIT {
         objectService.createObject(session, "/testLLObject");
         datastreamService.createDatastreamNode(session,
                 "/testLLObject/testRepositoryContent", "image/tiff",
-                new ByteArrayInputStream(
+                null, new ByteArrayInputStream(
                         "0123456789987654321012345678900987654321".getBytes()));
 
         session.save();

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/ObjectServiceIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/services/ObjectServiceIT.java
@@ -63,7 +63,7 @@ public class ObjectServiceIT extends AbstractIT {
 
         datastreamService.createDatastreamNode(session,
                 "testObjectServiceNode", "application/octet-stream",
-                new ByteArrayInputStream("asdf".getBytes()));
+                null, new ByteArrayInputStream("asdf".getBytes()));
         session.save();
         session.logout();
 
@@ -124,7 +124,7 @@ public class ObjectServiceIT extends AbstractIT {
         final Session session = repository.login();
 
         datastreamService.createDatastreamNode(session,
-                "testObjectServiceNode0", "application/octet-stream",
+                "testObjectServiceNode0", "application/octet-stream", null,
                 new ByteArrayInputStream("asdfx".getBytes()));
         session.save();
 
@@ -142,7 +142,7 @@ public class ObjectServiceIT extends AbstractIT {
         final Session session = repository.login();
 
         datastreamService.createDatastreamNode(session,
-                "testObjectServiceNode1", "application/octet-stream",
+                "testObjectServiceNode1", "application/octet-stream", null,
                 new ByteArrayInputStream("asdfy".getBytes()));
         session.save();
 

--- a/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/utils/SelfHealingIT.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/integration/kernel/utils/SelfHealingIT.java
@@ -158,11 +158,11 @@ public class SelfHealingIT {
 
         datastreamService.createDatastreamNode(session,
                 "/testSelfHealingObject/testDatastreamNode4",
-                "application/octet-stream", new ByteArrayInputStream(contentA
+                "application/octet-stream", null, new ByteArrayInputStream(contentA
                         .getBytes()), shaA);
         datastreamService.createDatastreamNode(session,
                 "/testSelfHealingObject/testDatastreamNode5",
-                "application/octet-stream", new ByteArrayInputStream(contentB
+                "application/octet-stream", null, new ByteArrayInputStream(contentB
                         .getBytes()), shaB);
 
         session.save();

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/DatastreamTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/DatastreamTest.java
@@ -135,6 +135,27 @@ public class DatastreamTest implements FedoraJcrTypes {
         testObj.setContent(mockStream);
     }
 
+    @Test
+    public void testSetContentWithFilename() throws RepositoryException,
+                                            InvalidChecksumException {
+        final org.modeshape.jcr.api.Binary mockBin =
+            mock(org.modeshape.jcr.api.Binary.class);
+        final InputStream mockStream = mock(InputStream.class);
+        final Node mockContent = getContentNodeMock(8);
+        when(mockDsNode.getNode(JCR_CONTENT)).thenReturn(mockContent);
+        when(mockDsNode.getSession()).thenReturn(mockSession);
+        when(mockSession.getValueFactory()).thenReturn(mockVF);
+        when(mockVF.createBinary(any(InputStream.class), any(String.class)))
+            .thenReturn(mockBin);
+        final Property mockData = mock(Property.class);
+        when(mockContent.canAddMixin(FEDORA_BINARY)).thenReturn(true);
+        when(mockContent.setProperty(JCR_DATA, mockBin)).thenReturn(mockData);
+        when(mockContent.getProperty(JCR_DATA)).thenReturn(mockData);
+        when(mockData.getBinary()).thenReturn(mockBin);
+        testObj.setContent(mockStream, null, null, "xyz", null);
+        verify(mockContent).setProperty(PREMIS_FILE_NAME, "xyz");
+    }
+
     @Test(expected = InvalidChecksumException.class)
     public void testSetContentWithChecksumMismatch()
         throws RepositoryException, InvalidChecksumException,
@@ -153,7 +174,7 @@ public class DatastreamTest implements FedoraJcrTypes {
         when(mockContent.setProperty(JCR_DATA, mockBin)).thenReturn(mockData);
         when(mockContent.getProperty(JCR_DATA)).thenReturn(mockData);
         when(mockData.getBinary()).thenReturn(mockBin);
-        testObj.setContent(mockStream, null, new URI("urn:sha1:xyz"), null);
+        testObj.setContent(mockStream, null, new URI("urn:sha1:xyz"), null, null);
     }
 
     @Test

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/services/DatastreamServiceTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/services/DatastreamServiceTest.java
@@ -136,10 +136,11 @@ public class DatastreamServiceTest implements FedoraJcrTypes {
 
         final Node actual =
                 testObj.createDatastreamNode(mockSession, testPath,
-                        MOCK_CONTENT_TYPE, mockIS);
+                        MOCK_CONTENT_TYPE, "xyz.jpg", mockIS);
         assertEquals(mockNode, actual);
 
         verify(mockContent).setProperty(JCR_DATA, mockBinary);
+        verify(mockContent).setProperty(PREMIS_FILE_NAME, "xyz.jpg");
     }
 
     @Test

--- a/fcrepo-storage-policy/src/test/java/org/fcrepo/storage/policy/TiffStoragePolicyStorageIT.java
+++ b/fcrepo-storage-policy/src/test/java/org/fcrepo/storage/policy/TiffStoragePolicyStorageIT.java
@@ -101,12 +101,14 @@ public class TiffStoragePolicyStorageIT {
         datastreamService.createDatastreamNode(session,
                                                "/testCompositeObject/content",
                                                "application/octet-stream",
+                                                null,
                                                data);
         data = new ByteArrayInputStream("87acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a701687acec17cd9dcd20a716cc2cf67417b71c8a7016".getBytes());
         datastreamService
             .createDatastreamNode(session,
                                   "/testCompositeObject/tiffContent",
                                   "image/tiff",
+                                  null,
                                   data);
 
         session.save();


### PR DESCRIPTION
Expose the premis:hasOriginalName propertyfrom the HTTP API using
the Content-Disposition ("filename") header for both fcr:content
and a POST with a binary payload.

Expose originalFileName throughout the kernel's Datastream API.

Fixes https://www.pivotaltracker.com/story/show/61500736
