### PR TITLE
Fix for test failures due to JaCoCo permgen errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,14 @@ $ cd fcrepo-webapp
 $ MAVEN_OPTS="-Xmx512m" mvn jetty:run
 ```
 
+### Jacoco Properties
+The Properties passed to the JVM used by the JaCoCo code coverage plugin can be set via 
+`jacoco.agent.it.arg` for integration tests  and `jacoco.agent.ut.arg` for unit tests:
+
+```bash
+$ MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=1024m" mvn -Djacoco.agent.it.arg="-XX:MaxPermSize=1024m -Xmx1024m" -Djacoco.agent.ut.arg="-XX:MaxPermSize=256m -Xmx1024m"  clean install
+```
+
+
 That's it! Your Fedora repository is up and running at: [http://localhost:8080/rest/](http://localhost:8080/rest/)
 

--- a/pom.xml
+++ b/pom.xml
@@ -897,7 +897,7 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>${jacoco.agent.it.arg}</argLine>
+          <argLine>-XX:MaxPermSize=128m ${jacoco.agent.it.arg}</argLine>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
- added a default value of 256m for the permgen size for the integration test plugin
- documented JaCoCo properties in the README
