### PR TITLE
Changed bundling to jar

### DIFF
--- a/fcrepo-kernel/pom.xml
+++ b/fcrepo-kernel/pom.xml
@@ -18,7 +18,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-kernel-api</artifactId>
       <version>${project.version}</version>
-      <type>bundle</type>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>


### PR DESCRIPTION
# 
- Changed the bundling for the fcrepo-kernel-api dep to jar so that
  depending projects dont have to import the bundle-plugin
