### PR TITLE
fixed fcrepo for modeshape 3.7.1

### DIFF
--- a/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesPEP.java
+++ b/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesPEP.java
@@ -55,7 +55,7 @@ public class BasicRolesPEP extends AbstractRolesPEP {
                 LOGGER.debug("Denying writer role permission to perform an action on an ACL node.");
                 return false;
             } else {
-                LOGGER.debug("Granting writer role permission to perform any action on a non-ACL nodes.");
+                LOGGER.debug("Granting writer role permission to perform any action on a non-ACL node.");
                 return true;
             }
         }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
@@ -28,10 +28,12 @@ import static org.fcrepo.kernel.utils.FedoraTypesUtils.property2values;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.security.AccessControlException;
 import java.util.Iterator;
+
+import javax.jcr.AccessDeniedException;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+
 import org.fcrepo.kernel.rdf.GraphSubjects;
 import org.fcrepo.kernel.rdf.impl.mappings.PropertyToTriple;
 import org.fcrepo.kernel.rdf.impl.mappings.ZippingIterator;
@@ -91,7 +93,7 @@ public class PropertiesRdfContext extends NodeRdfContext {
             if (node().hasNode(JCR_CONTENT)) {
                 contentNode = node().getNode(JCR_CONTENT);
             }
-        } catch (final AccessControlException e) {
+        } catch (final AccessDeniedException e) {
             LOGGER.trace("Access denied to content node", e);
         }
         if (contentNode != null) {


### PR DESCRIPTION
fixes uncaught AccessDeniedException when detailing a protected jcr:content node. This exception has changed in modeshape 3.7.1. MS used to throw a AccessControlException here, but it has been fixed to align with the spec.
