### PR TITLE
Include source and JavaDoc artifacts for builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -940,6 +940,30 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
Generates sources.jar and javadoc.jar (i.e., fcrepo-webhooks-4.0.0-alpha-4-SNAPSHOT-sources.jar) for each module during the package phase.  mvn clean install will build these artifacts when run at either project or module level.
