### PR TITLE
allow FederaUser read action for root

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/FedoraUserSecurityContext.java
@@ -145,6 +145,11 @@ public class FedoraUserSecurityContext implements SecurityContext,
             return actions.length == 1 && "read".equals(actions[0]);
         }
 
+        //this permission is required for root access
+        if (absPath.isRoot()) {
+            return actions.length == 1 && "read".equals(actions[0]);
+        }
+
         // delegate
         if (fad != null) {
             return fad.hasPermission(context.getSession(), absPath, actions);

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/FedoraUserSecurityContextTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/FedoraUserSecurityContextTest.java
@@ -137,17 +137,30 @@ public class FedoraUserSecurityContextTest {
         final FedoraUserSecurityContext context =
                 new FedoraUserSecurityContext(principal, fad);
 
-        assertFalse("Granted permission with no action on root", context
+        assertFalse("Granted permission with no action on null path", context
                 .hasPermission(null, null, new String[] {}));
 
-        assertFalse("Granted write permission on root", context.hasPermission(
+        assertFalse("Granted write permission on null path", context.hasPermission(
                 null, null, new String[] {"write"}));
 
-        assertTrue("Failed to granted read permission on root", context
+        assertTrue("Failed to grant read permission on null path", context
                 .hasPermission(null, null, new String[] {"read"}));
 
-        assertFalse("Granted write permission on root", context.hasPermission(
+        assertFalse("Granted write permission on null path", context.hasPermission(
                 null, null, new String[] {"read", "write"}));
+
+        Path rootPath = Path.ROOT_PATH;
+        assertFalse("Granted permission with no action on root", context
+                .hasPermission(null, rootPath, new String[] {}));
+
+        assertFalse("Granted write permission on root", context.hasPermission(
+                null, rootPath, new String[] {"write"}));
+
+        assertTrue("Failed to granted read permission on root", context
+                .hasPermission(null, rootPath, new String[] {"read"}));
+
+        assertFalse("Granted write permission on root", context.hasPermission(
+                null, rootPath, new String[] {"read", "write"}));
 
         when(fad.hasPermission(any(Session.class), any(Path.class), any(String[].class))).thenReturn(true);
 


### PR DESCRIPTION
with auth on there was no access to root as there are no roles associated with it, added logic to pass this condition

"root/  (default content roles, i.e. no roles for anyone)"
from
https://wiki.duraspace.org/display/FF/Authentication+and+Authorization
