### PR TITLE
Adding a "${jms.host}" variable to make jms more easily configurable as

### DIFF
--- a/fcrepo-webapp/src/main/resources/spring/jms.xml
+++ b/fcrepo-webapp/src/main/resources/spring/jms.xml
@@ -13,7 +13,7 @@
 
   <bean id="connectionFactory"
     class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker"
-    p:brokerURL="vm://localhost:${jms.port:61616}?create=false"/>
+    p:brokerURL="vm://${jms.host:localhost}:${jms.port:61616}?create=false"/>
 
   <bean name="jmsBroker" class="org.apache.activemq.xbean.BrokerFactoryBean"
     p:config="classpath:/config/activemq.xml" p:start="true"/>


### PR DESCRIPTION
I've added the jms.host variable to make JMS more configurable that we can pass it it when starting the fcrepo instances. This will help start multiple fcrepo instances with one build. 
