### PR TITLE
resolves issue where user with 'writer' role can't list ACL

### DIFF
--- a/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegate.java
@@ -48,6 +48,10 @@ public class BasicRolesAuthorizationDelegate extends AbstractRolesAuthorizationD
         }
         if (roles.contains("writer")) {
             if (absPath.contains(AUTHZ_DETECTION)) {
+                if (roles.contains("reader") && actions.length == 1 && "read".equals(actions[0])) {
+                    LOGGER.debug("Granting reader role permission to perform a read action.");
+                    return true;
+                }
                 LOGGER.debug("Denying writer role permission to perform an action on an ACL node.");
                 return false;
             }

--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/integration/AbstractBasicRolesIT.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/integration/AbstractBasicRolesIT.java
@@ -124,6 +124,12 @@ public abstract class AbstractBasicRolesIT extends AbstractRolesIT {
         objI.setPath("testparent3/testchild3b");
         test_objs.add(objI);
 
+        final RolesFadTestObjectBean objJ = new RolesFadTestObjectBean();
+        objJ.setPath("testparent4");
+        objJ.addACL("exampleWriterReader", "reader");
+        objJ.addACL("exampleWriterReader", "writer");
+        test_objs.add(objJ);
+
         return test_objs;
 
     }

--- a/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/integration/BasicRolesWriterIT.java
+++ b/fcrepo-auth-roles-basic/src/test/java/org/fcrepo/auth/roles/basic/integration/BasicRolesWriterIT.java
@@ -549,4 +549,10 @@ public class BasicRolesWriterIT extends AbstractBasicRolesIT {
                 .getStatusCode(), canAddACL("examplewriter", "/", "everyone",
                         "admin", true));
     }
+
+    @Test
+    public void testWriterReaderCanReadACL() throws ClientProtocolException, IOException {
+        assertEquals("Writer-reader should be allowed to read ACL permissions", OK.getStatusCode(), canGetRoles(
+                "exampleWriterReader", "testparent4", true));
+    }
 }

--- a/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
+++ b/fcrepo-auth-roles-common/src/test/java/org/fcrepo/auth/roles/common/integration/AbstractRolesIT.java
@@ -52,6 +52,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 /**
  * @author Gregory Jansen
@@ -487,7 +489,12 @@ public abstract class AbstractRolesIT {
 
         for (final Map<String, String> entries : principals_and_roles) {
             for (final Map.Entry<String, String> entry : entries.entrySet()) {
-                acls.put(entry.getKey(), singletonList(entry.getValue()));
+                final String key = entry.getKey();
+                if (acls.containsKey(key)) {
+                    acls.get(key).add(entry.getValue());
+                } else {
+                    acls.put(key, new ArrayList<String>(Arrays.asList(new String[] { entry.getValue() })));
+                }
             }
         }
         return makeJson(acls);


### PR DESCRIPTION
Fix for https://www.pivotaltracker.com/story/show/68547530 (Unable to list ACL if user includes "writer" role)

Added integration test, gave writer who also has read privs the ability to read the ACLs, and changed an underlying class in the test framework to allow tests using users with multiple roles.
