### PR TITLE
Implemented TomcatRolesPrincipalProvider

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/TomcatRolesPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/TomcatRolesPrincipalProvider.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2013 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.auth.common;
+
+import static java.util.Collections.emptySet;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.servlet.http.HttpServletRequest;
+
+import org.modeshape.jcr.api.ServletCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class that uses the roles configured in Tomcat's MemoryUser as principals for
+ * access.
+ *
+ * @author <a href="mailto:ksclarke@gmail.com">Kevin S. Clarke</a>
+ */
+public class TomcatRolesPrincipalProvider implements PrincipalProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TomcatRolesPrincipalProvider.class);
+
+    private static final String MEMORY_USER = "org.apache.catalina.users.MemoryUser";
+
+    /*
+     * (non-Javadoc)
+     * @see
+     * org.fcrepo.auth.PrincipalProvider#getPrincipals(javax.jcr.Credentials)
+     */
+    @Override
+    public Set<Principal> getPrincipals(final Credentials credentials) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Checking for principals using {}", TomcatRolesPrincipalProvider.class.getSimpleName());
+        }
+
+        if (!(credentials instanceof ServletCredentials)) {
+            return emptySet();
+        }
+
+        final ServletCredentials servletCredentials = (ServletCredentials) credentials;
+        final HttpServletRequest request = servletCredentials.getRequest();
+
+        if (request == null) {
+            return emptySet();
+        }
+
+        final Principal principal = request.getUserPrincipal();
+        final Set<Principal> principals = new HashSet<>();
+
+        if (principal == null) {
+            return emptySet();
+        }
+
+        final Class<?> principalClass = principal.getClass();
+        final String className = principalClass.getName();
+
+        // Use reflection because we don't want to hard-code container specifics into the project.
+        if (className.equals(MEMORY_USER)) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Checking Catalina configured roles for '{}'", principal.getName());
+            }
+
+            try {
+                final Method method = principalClass.getMethod("getRoles");
+                @SuppressWarnings("unchecked")
+                final Iterator<Principal> iterator = (Iterator<Principal>) method.invoke(principal);
+
+                while (iterator.hasNext()) {
+                    principals.add(iterator.next());
+                }
+            } catch (final NoSuchMethodException e) {
+                LOGGER.error("Didn't find expected Catalina MemoryUser getRoles() method", e);
+                return emptySet();
+            } catch (final InvocationTargetException e) {
+                LOGGER.error("Wasn't able to invoke Catalina MemoryUser's getRoles() method", e);
+                return emptySet();
+            } catch (final IllegalAccessException e) {
+                LOGGER.error("Illegal access to Catalina MemoryUser's getRoles() method", e);
+                return emptySet();
+            } catch (final ClassCastException e) {
+                LOGGER.error("Could not cast the expected return type from Catalina MemoryUser's getRoles() method");
+                return emptySet();
+            }
+        } else {
+            return emptySet();
+        }
+
+        return principals;
+    }
+
+}

--- a/fcrepo-webapp/src/auth/webapp/WEB-INF/classes/spring/auth-repo.xml
+++ b/fcrepo-webapp/src/auth/webapp/WEB-INF/classes/spring/auth-repo.xml
@@ -28,6 +28,14 @@
       <ref bean="headerProvider"/>
     </util:set>
 
+    <!-- Optional PrincipalProvider that will use Tomcat's tomcat-users.xml roles for principals -->
+    <bean name="tomcatRolesProvider" class="org.fcrepo.auth.common.TomcatRolesPrincipalProvider">
+    </bean>
+
+    <util:set id="principalProviderSet">
+      <ref bean="tomcatRolesProvider"/>
+    </util:set>
+
     <bean name="fad" class="org.fcrepo.auth.roles.basic.BasicRolesAuthorizationDelegate"/>
 
     <bean name="authenticationProvider" class="org.fcrepo.auth.common.ServletContainerAuthenticationProvider">


### PR DESCRIPTION
Submitting this as a PR to start the conversation.  Not sure if this is enough or whether more is needed.

The use case as I understand it... we want to be able to configure roles in the Tomcat tomcat-users.xml file that will be treated as principals for access to resources.  A sample tomcat-users.xml file might look like:

```
<tomcat-users>
  <!-- Fedora roles -->
  <role rolename="fedoraAdmin"/>
  <role rolename="fedoraUser"/>

  <!-- AIC roles -->
  <role rolename="aic-scraper"/>

  <user username="fcindexer" password="thepasswd" roles="fedoraUser"/>
</tomcat-users>
```

With this TomcatRolesPrincipalProvider class, access to a FF4 object can be given to the aic-scraper role (as a principal):

```
{
  "aic-scraper" : [ "reader" ]
}
```

And the fcindexer will not be able to access the object.  When the aic-scraper role is added to the fcindexer user, though:

```
<user username="fcindexer" password="thepasswd" roles="fedoraUser,aic-scraper"/>
```

the fcindexer will then be able to access that object.

This is tested with Tomcat7... if my understanding of the needs of this ticket is correct, I can check to see what versions of Tomcat (6, etc.) are handled by it, or whether more code is needed to support them.

I'm also not quite sure how to write tests for this since it's a container specific thing (i.e., checks a Catalina class that won't be found in our Jetty dev environment).  As you can see in the code, reflection is used to avoid container specific dependencies.

Awaiting feedback for possible revisions... thanks.
