### PR TITLE
Test that all of the supported RDF response types work

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFieldSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFieldSearch.java
@@ -19,7 +19,6 @@ import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static com.hp.hpl.jena.vocabulary.RDF.nil;
 import static com.hp.hpl.jena.vocabulary.RDF.type;
-import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import static javax.ws.rs.core.MediaType.TEXT_HTML;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.status;
@@ -136,7 +135,7 @@ public class FedoraFieldSearch extends AbstractResource implements
      */
     @GET
     @Timed
-    @Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, APPLICATION_XML, TEXT_PLAIN, TURTLE_X})
+    @Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, TURTLE_X})
     public Dataset searchSubmitRdf(@QueryParam(QUERY_PARAM) final String terms,
             @QueryParam(OFFSET_PARAM) @DefaultValue("0") final long offset,
             @QueryParam(LIMIT_PARAM) @DefaultValue("25") final int limit,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -165,6 +165,13 @@ public abstract class AbstractResourceIT {
         return result;
     }
 
+    protected String getContentType(final HttpUriRequest method)
+        throws ClientProtocolException, IOException {
+        final HttpResponse response = execute(method);
+        final int result = response.getStatusLine().getStatusCode();
+        assertEquals(OK.getStatusCode(), result);
+        return response.getFirstHeader("Content-Type").getValue();
+    }
 
     protected GraphStore getGraphStore(final HttpClient client, final HttpUriRequest method) throws IOException {
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFieldSearchIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFieldSearchIT.java
@@ -19,6 +19,14 @@ import static com.hp.hpl.jena.graph.Node.ANY;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createResource;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createTypedLiteral;
 import static com.hp.hpl.jena.vocabulary.RDF.nil;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
+import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
+import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.RdfLexicon.HAS_MEMBER_OF_RESULT;
 import static org.fcrepo.kernel.RdfLexicon.NEXT_PAGE;
 import static org.fcrepo.kernel.RdfLexicon.PAGE_OF;
@@ -40,7 +48,6 @@ import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
 
-@Ignore("Destined for death.")
 public class FedoraFieldSearchIT extends AbstractResourceIT {
 
     @Test
@@ -119,7 +126,18 @@ public class FedoraFieldSearchIT extends AbstractResourceIT {
         assertTrue(graphStore.contains(ANY, createResource(
                 serverAddress + "fcr:search?q=testobj&offset=0&limit=1")
                 .asNode(), NEXT_PAGE.asNode(), nil.asNode()));
+    }
 
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        String responseTypes[] = {TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, TURTLE_X};
+        for (final String type : responseTypes) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + "fcr:search?q=testtype");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
@@ -23,9 +23,11 @@ import static org.fcrepo.kernel.RdfLexicon.HAS_FIXITY_RESULT;
 import static org.fcrepo.kernel.RdfLexicon.HAS_FIXITY_STATE;
 import static org.fcrepo.kernel.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.RdfLexicon.HAS_SIZE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.http.client.methods.HttpGet;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
@@ -57,5 +59,20 @@ public class FedoraFixityIT extends AbstractResourceIT {
                         .asNode()));
         assertTrue(graphStore.contains(ANY, ANY, HAS_SIZE.asNode(),
                 createTypedLiteral(3).asNode()));
+    }
+
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        final String pid = getRandomUniquePid();
+        createObject(pid);
+        createDatastream(pid, "zxc", "foo");
+
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + pid + "/zxc/fcr:fixity");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraIdentifiersIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraIdentifiersIT.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 
 import org.apache.http.client.methods.HttpPost;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import com.hp.hpl.jena.rdf.model.ResourceFactory;
@@ -92,4 +93,15 @@ public class FedoraIdentifiersIT extends AbstractResourceIT {
                 HAS_MEMBER_OF_RESULT.asNode(), ANY)));
 
     }
+
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpPost method =
+                    new HttpPost(serverAddress + "fcr:identifier");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
+     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLocksIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLocksIT.java
@@ -30,6 +30,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.jcr.FedoraJcrTypes;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -320,7 +321,7 @@ public class FedoraLocksIT extends AbstractResourceIT implements FedoraJcrTypes 
         createObject(pid);
         final String lockToken = getLockToken(lockObject(pid));
 
-        for (final String type : POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
             final HttpGet method =
                     new HttpGet(serverAddress + pid + "/" + FCR_LOCK);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNamespacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNamespacesIT.java
@@ -30,6 +30,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.BasicHttpEntity;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
@@ -179,4 +180,14 @@ public class FedoraNamespacesIT extends AbstractResourceIT {
                         createPlainLiteral("abc").asNode()));
     }
 
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + "fcr:namespaces");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodeTypesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodeTypesIT.java
@@ -21,6 +21,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.BasicHttpEntity;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -75,4 +76,15 @@ public class FedoraNodeTypesIT  extends AbstractResourceIT {
                 subClassOf.asNode(), createURI(RESTAPI_NAMESPACE + "object")));
 
     }
+
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + "fcr:nodetypes");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
+     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
@@ -1130,6 +1130,19 @@ public class FedoraNodesIT extends AbstractResourceIT {
         return values;
     }
 
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        final String pid = getRandomUniquePid();
+        createObject(pid);
+
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + pid);
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
+     }
 
     private void validateHTML(final String path) throws Exception {
         final HttpGet getMethod = new HttpGet(serverAddress + path);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
@@ -46,6 +46,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.util.EntityUtils;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import com.hp.hpl.jena.graph.Node;
@@ -424,6 +425,39 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         assertTrue("Node is expected to have versionable mixin.",
                 updatedObjectProperties.contains(Node.ANY, createResource(serverAddress + pid).asNode(),
                 NodeFactory.createURI(RDF_TYPE), NodeFactory.createURI(MIX_NAMESPACE + "versionable")));
+    }
+
+    @Test
+    public void testIndexResponseContentTypes() throws Exception {
+        final String pid = getRandomUniquePid();
+        createObject(pid);
+        addMixin( pid, MIX_NAMESPACE + "versionable" );
+
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + pid + "/fcr:versions");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
+    }
+
+    @Test
+    public void testGetVersionResponseContentTypes() throws Exception {
+        final String pid = getRandomUniquePid();
+        final String versionName = "v1";
+
+        createObject(pid);
+        addMixin( pid, MIX_NAMESPACE + "versionable" );
+        postObjectVersion(pid, versionName);
+
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + pid + "/fcr:versions/" + versionName);
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
     }
 
     private void testDatastreamContentUpdatesCreateNewVersions(final String objName, final String dsName) throws IOException {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraWorkspacesIT.java
@@ -29,6 +29,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.junit.Test;
 
 import com.hp.hpl.jena.update.GraphStore;
@@ -104,5 +105,16 @@ public class FedoraWorkspacesIT extends AbstractResourceIT {
         assertEquals(404, deleteWorkspaceResponse.getStatusLine()
                               .getStatusCode());
 
+    }
+
+    @Test
+    public void testResponseContentTypes() throws Exception {
+        for (final String type : RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING) {
+            final HttpGet method =
+                    new HttpGet(serverAddress + "fcr:workspaces");
+
+            method.addHeader("Accept", type);
+            assertEquals(type, getContentType(method));
+        }
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
@@ -77,6 +77,8 @@ public abstract class RDFMediaType extends MediaType {
             TURTLE_TYPE, N3_TYPE, N3_ALT2_TYPE, RDF_XML_TYPE, NTRIPLES_TYPE, APPLICATION_XML_TYPE, TEXT_PLAIN_TYPE,
             TURTLE_X_TYPE).add().build();
 
+    public static final String POSSIBLE_RDF_RESPONSE_VARIANTS_STRING[] = {
+        TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, APPLICATION_XML, TURTLE_X };
 
     public static final String TSV = contentTypeTextTSV;
 


### PR DESCRIPTION
The fcr:search endpoint in the code claimed to be able to return application/xml but jena doesn't support serializing Dataset to that content type.  The wiki REST documentation claims other types (application/n3 and application/rdf+json) are supported but they run into the same problem.  These tests check that the supported return types actually can be returned.  The wiki REST documentation needs to be updated to reflect the reality proven by these tests.  Fixes https://github.com/futures/fcrepo4/issues/320.
