### PR TITLE
Fixed the HierarchyConverter to produce a consistency result;

### DIFF
--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/identifiers/HierarchyConverter.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/identifiers/HierarchyConverter.java
@@ -36,10 +36,11 @@ import org.slf4j.Logger;
 import com.google.common.base.Function;
 
 /**
- * Injects and extracts segments of hierarchy before the last segment of a
- * multi-part identifier to ensure efficient performance of the JCR.
+ * Injects and extracts segments of hierarchy in a multi-part identifier
+ * to ensure efficient performance of the JCR.
  *
  * @author ajs6f
+ * @date Mar 26, 2014
  * @author lsitu
  * @date May 9, 2014
  */
@@ -109,7 +110,7 @@ public class HierarchyConverter extends InternalIdentifierConverter {
                 jcrPathSegments.addAll(0, hierarchySegments);
             }
         }
-        String pathConverted = on(separator).join(jcrPathSegments);
+        final String pathConverted = on(separator).join(jcrPathSegments);
         log.trace("Converted incoming identifier \"{}\" to \"{}\".", flat, pathConverted);
         return "/" + pathConverted;
     }
@@ -161,9 +162,9 @@ public class HierarchyConverter extends InternalIdentifierConverter {
             //Don't forget the fcr:content segment for content files
             pathSegments.add(FCR_CONTENT);
         }
-        String parthConverted = on(separator).join(pathSegments);
-        log.trace("Converted outgoing identifier \"{}\" to \"{}\".", hierarchical, parthConverted);
-        return "/" + parthConverted;
+        final String pathConverted = on(separator).join(pathSegments);
+        log.trace("Converted outgoing identifier \"{}\" to \"{}\".", hierarchical, pathConverted);
+        return "/" + pathConverted;
     }
 
     private List<String> createHierarchySegments(final String path) {

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/identifiers/HierarchyConverterTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/identifiers/HierarchyConverterTest.java
@@ -163,6 +163,17 @@ public class HierarchyConverterTest {
     }
 
     @Test
+    public void testOutgoingDoubleSlashPattern() {
+        testTranslator.setLevels(3);
+        testTranslator.setLength(1);
+        String hirarchy = testTranslator.reverse().convert(testId);
+        String outgoingPath = "a/b/c/" + hirarchy;
+        String result = testTranslator.convert(outgoingPath);
+        log.debug("Outgoing path {} converted to transparent path {}.", outgoingPath, result);
+        assertEquals("Should not have altered the outgoing double slash!", "/" + testId, result);
+    }
+
+    @Test
     public void testContentPaths() {
         testTranslator.setLevels(0);
         testTranslator.setLength(1);


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/71140570
I think the HeirarchyConverter is in good shade to produce a consistency result for all path segments now. For the path that are shorter that the default level of the auto hierarchy, it will return it intact, and a slash is appended to the front of the result to make it consistent with the current UUIDPathMinter pattern at this time.
