### PR TITLE
Removed requirement for fedoraUser in auth'ed connections

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthenticationProvider.java
@@ -15,20 +15,20 @@
  */
 package org.fcrepo.auth.common;
 
-import org.modeshape.jcr.ExecutionContext;
-import org.modeshape.jcr.api.ServletCredentials;
-import org.modeshape.jcr.security.AuthenticationProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.jcr.Credentials;
-import javax.servlet.http.HttpServletRequest;
-
 import java.security.Principal;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.servlet.http.HttpServletRequest;
+
+import org.modeshape.jcr.ExecutionContext;
+import org.modeshape.jcr.api.ServletCredentials;
+import org.modeshape.jcr.security.AuthenticationProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Authenticates ModeShape logins where JAX-RS credentials are supplied. Capable
@@ -123,16 +123,11 @@ public class ServletContainerAuthenticationProvider implements
      * </p>
      * <ul>
      * <li>FEDORA_SERVLET_REQUEST will be assigned the ServletRequest instance
-     * associated with credentials if the authenticated user has the fedoraUser
-     * role.</li>
-     * <li>FEDORA_USER_PRINCIPAL will be assigned the authenticated user's
-     * principal if the authenticated user has the fedoraUser role, and the
-     * EVERYONE principal otherwise.</li>
+     * associated with credentials.</li>
      * <li>FEDORA_ALL_PRINCIPALS will be assigned the union of all principals
      * obtained from configured PrincipalProvider instances plus the
-     * authenticated user's principal if the authenticated user has the
-     * fedoraUser role; FEDORA_ALL_PRINCIPALS will be assigned the singleton set
-     * containing the EVERYONE principal otherwise.</li>
+     * authenticated user's principal; FEDORA_ALL_PRINCIPALS will be assigned
+     * the singleton set containing the EVERYONE principal otherwise.</li>
      * </ul>
      */
     @Override
@@ -140,7 +135,7 @@ public class ServletContainerAuthenticationProvider implements
             final String repositoryName, final String workspaceName,
             final ExecutionContext repositoryContext,
             final Map<String, Object> sessionAttributes) {
-        LOGGER.debug("in authenticate: {}; FAD: {}", credentials, fad);
+        LOGGER.debug("Trying to authenticate: {}; FAD: {}", credentials, fad);
 
         if (!(credentials instanceof ServletCredentials)) {
             return null;
@@ -156,8 +151,7 @@ public class ServletContainerAuthenticationProvider implements
                     userPrincipal.getName()));
         }
 
-        if (userPrincipal != null &&
-                servletRequest.isUserInRole(FEDORA_USER_ROLE)) {
+        if (userPrincipal != null) {
 
             sessionAttributes.put(
                     FedoraAuthorizationDelegate.FEDORA_SERVLET_REQUEST,

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticationProviderTest.java
@@ -26,6 +26,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.Credentials;
+import javax.jcr.Session;
+import javax.servlet.http.HttpServletRequest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -36,16 +46,6 @@ import org.modeshape.jcr.api.ServletCredentials;
 import org.modeshape.jcr.security.AdvancedAuthorizationProvider;
 import org.modeshape.jcr.security.AuthenticationProvider;
 import org.modeshape.jcr.value.Path;
-
-import javax.jcr.Credentials;
-import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
-
-import java.security.Principal;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author bbpennel
@@ -219,6 +219,9 @@ public class ServletContainerAuthenticationProviderTest {
                 .contains(ServletContainerAuthenticationProvider.EVERYONE));
         assertTrue("User principal must be present", resultPrincipals.contains(principal));
         assertTrue("Group Principal from factory must be present", resultPrincipals.contains(groupPrincipal));
+
+        // getInstance returns a static provider so zero out internal set
+        provider.setPrincipalProviders(new HashSet<PrincipalProvider>());
     }
 
     @Test
@@ -231,7 +234,7 @@ public class ServletContainerAuthenticationProviderTest {
 
         when(request.getUserPrincipal()).thenReturn(null);
 
-        evaluateDefaultAuthenticateCase(provider);
+        evaluateDefaultAuthenticateCase(provider, 1);
     }
 
     @Test
@@ -244,10 +247,11 @@ public class ServletContainerAuthenticationProviderTest {
 
         when(request.isUserInRole("unknownRole")).thenReturn(true);
 
-        evaluateDefaultAuthenticateCase(provider);
+        evaluateDefaultAuthenticateCase(provider, 2);
     }
 
-    private void evaluateDefaultAuthenticateCase(final ServletContainerAuthenticationProvider provider) {
+    private void evaluateDefaultAuthenticateCase(final ServletContainerAuthenticationProvider provider,
+            final int expected) {
         final ExecutionContext result = provider.authenticate(creds, "repo", "workspace", context, sessionAttributes);
 
         assertNotNull(result);
@@ -262,7 +266,7 @@ public class ServletContainerAuthenticationProviderTest {
         @SuppressWarnings("unchecked")
         final Set<Principal> resultPrincipals = (Set<Principal>) sessionAttributes.get(FEDORA_ALL_PRINCIPALS);
 
-        assertEquals(1, resultPrincipals.size());
+        assertEquals(expected, resultPrincipals.size());
         assertTrue("EVERYONE principal must be present", resultPrincipals
                 .contains(ServletContainerAuthenticationProvider.EVERYONE));
         assertEquals(ServletContainerAuthenticationProvider.EVERYONE_NAME, resultPrincipals.iterator().next().getName());


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70306268

Removed the requirement for fedoraUser, but left the hard-coded option there as a default configuration.  Now you can configure a Tomcat role in ContainerRolesPrincipalProvider, for instance, and the user with that role doesn't also have to be in the fedoraUser role (or you can have principal configured through an HTTP header from any configured user role, rather than just the fedoraUser one).

But, you do have to configure the any new role you want to use through BASIC auth in the web.xml file:

```
<auth-constraint>
  <role-name>fedoraUser</role-name>
  <role-name>fedoraAdmin</role-name>
  <role-name>my-new-tomcat-role</role-name>
</auth-constraint>
```

I was unable to find a way to make it more dynamic (not require that extra configuration -- which is what I was originally hoping for).  This might make continuing to use fedoraUser more attractive since it's pre-configured, but now there is an option to use another role if you want to configure it.

If this PR is accepted, a note should be added to https://www.pivotaltracker.com/story/show/70710348, noting this as something else to document.
