### PR TITLE
Treat protected properties as "internal"

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersionsIT.java
@@ -174,6 +174,7 @@ public class FedoraVersionsIT extends AbstractResourceIT {
         final GraphStore versionResults = getContent(serverAddress + objId + "/fcr:versions/label");
 
         logger.debug("Got version profile:");
+        assertTrue("Should find a title.", versionResults.contains(Node.ANY, Node.ANY, DC_TITLE.asNode(), Node.ANY));
         assertTrue("Should find the title from the last version tagged with the label \"label\"",
                 versionResults.contains(Node.ANY, Node.ANY, DC_TITLE.asNode(), NodeFactory.createLiteral("Second title")));
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/jcr/FedoraJcrTypes.java
@@ -54,4 +54,14 @@ public interface FedoraJcrTypes {
     String FROZEN_NODE = "nt:frozenNode";
 
     String FROZEN_MIXIN_TYPES = "jcr:frozenMixinTypes";
+
+    String JCR_UUID = "jcr:uuid";
+
+    String JCR_PRIMARY_TYPE = "jcr:primaryType";
+
+    String JCR_MIXIN_TYPES = "jcr:mixinTypes";
+
+    String [] EXPOSED_PROTECTED_JCR_TYPES
+        = new String[] { JCR_UUID, JCR_LASTMODIFIED, JCR_CREATED, JCR_CREATEDBY,
+                         JCR_PRIMARY_TYPE, JCR_MIXIN_TYPES };
 }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/PropertiesRdfContext.java
@@ -21,7 +21,6 @@ import static org.fcrepo.jcr.FedoraJcrTypes.ROOT;
 import static org.fcrepo.kernel.RdfLexicon.HAS_CONTENT;
 import static org.fcrepo.kernel.RdfLexicon.IS_CONTENT_OF;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.isInternalProperty;
-import static org.fcrepo.kernel.utils.FedoraTypesUtils.isVersionProperty;
 import static org.fcrepo.kernel.utils.FedoraTypesUtils.property2values;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -114,12 +113,10 @@ public class PropertiesRdfContext extends NodeRdfContext {
         throws RepositoryException {
         LOGGER.trace("Creating triples for node: {}", n);
         final UnmodifiableIterator<Property> nonBinaryProperties =
-            Iterators.filter(Iterators.filter(new PropertyIterator(n.getProperties()),
-                    not(isInternalProperty)), not(isVersionProperty));
+            Iterators.filter(new PropertyIterator(n.getProperties()), not(isInternalProperty));
 
         final UnmodifiableIterator<Property> nonBinaryPropertiesCopy =
-            Iterators.filter(Iterators.filter(new PropertyIterator(n.getProperties()),
-                    not(isInternalProperty)), not(isVersionProperty));
+            Iterators.filter(new PropertyIterator(n.getProperties()), not(isInternalProperty));
 
         return Iterators.concat(new ZippingIterator<>(
                 Iterators.transform(


### PR DESCRIPTION
My original thinking was to build a blacklist of properties to hide, but it turned out that it was easier to blacklist all PROTECTED properties with a whitelist of exceptions.

There's one caveat, which is jcr:frozenNodes... right now we just present that content when viewing an old version, but all of the properties are protected.  I've added special handling for this case.

This PR includes mostly integration tests to ensure that those properties don't show up.
