### PR TITLE
Adding check for existing destination for COPY, MOVE, PUT and POST w/slug

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
@@ -215,6 +215,17 @@ public class FedoraNodesIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testIngestWithRepeatedSlug() throws Exception {
+        final String pid = getRandomUniquePid();
+        final HttpPut put = new HttpPut(serverAddress + pid);
+        assertEquals(201, getStatus(put));
+
+        final HttpPost method = postObjMethod("");
+        method.addHeader("Slug", pid);
+        assertEquals(409, getStatus(method));
+    }
+
+    @Test
     public void testIngestWithBinary() throws Exception {
         final HttpPost method = postObjMethod("");
         method.addHeader("Content-Type", "application/octet-stream");
@@ -738,6 +749,16 @@ public class FedoraNodesIT extends AbstractResourceIT {
         }
         assertEquals(403, response.getStatusLine().getStatusCode());
 
+    }
+
+    @Test
+    public void testRepeatedPut() throws Exception {
+        final String pid = getRandomUniquePid();
+        final HttpPut firstPut = new HttpPut(serverAddress + pid);
+        assertEquals(201, getStatus(firstPut));
+
+        final HttpPut secondPut = new HttpPut(serverAddress + pid);
+        assertEquals(409, getStatus(secondPut));
     }
 
     @Test


### PR DESCRIPTION
See https://www.pivotaltracker.com/story/show/70965620 and https://www.pivotaltracker.com/story/show/71632224
- COPY/MOVE to a resource, PUT (w/o properties) and POST (w/slug) now return 409 Conflict if the resource exists.
- Adding ITs to check all of these.
