### PR TITLE
Adding constant subject native SPARQL support through jcr/sql2 conversion.

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierTranslator.java
@@ -317,4 +317,9 @@ public class HttpIdentifierTranslator extends SpringContextAwareIdentifierTransl
 
     private static final List<InternalIdentifierConverter> minimalTranslationChain =
         singletonList((InternalIdentifierConverter) new NamespaceConverter());
+
+    @Override
+    public String getBaseUri() {
+        return uris.getBaseUri().toString();
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/rdf/IdentifierTranslator.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/rdf/IdentifierTranslator.java
@@ -57,4 +57,11 @@ public interface IdentifierTranslator {
      * @return Resource
      */
     Resource getContext();
+
+    /**
+     * Get baseUri that help for testing the constant subject SPARQLto jcr/sql2 conversion
+     * with the DefaultIdentifierTranslator and the HttpIdentifierTranslator
+     * @return
+     */
+    String getBaseUri();
 }

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/DefaultIdentifierTranslator.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/rdf/impl/DefaultIdentifierTranslator.java
@@ -85,4 +85,8 @@ public class DefaultIdentifierTranslator implements IdentifierTranslator {
         return subject.isURIResource() && subject.getURI().startsWith(RESOURCE_NAMESPACE);
     }
 
+    @Override
+    public String getBaseUri() {
+        return RESOURCE_NAMESPACE;
+    }
 }

--- a/fcrepo-transform/src/main/java/org/fcrepo/transform/sparql/JQLConverter.java
+++ b/fcrepo-transform/src/main/java/org/fcrepo/transform/sparql/JQLConverter.java
@@ -84,6 +84,7 @@ public class JQLConverter {
     private QueryObjectModel getQuery() throws RepositoryException {
         final QueryManager queryManager = session.getWorkspace().getQueryManager();
         final JQLQueryVisitor jqlVisitor = new JQLQueryVisitor(session, jcrTools, queryManager);
+        jqlVisitor.setIdentifierTranslator(subjects);
         query.visit(jqlVisitor);
         return jqlVisitor.getQuery();
     }

--- a/fcrepo-transform/src/main/java/org/fcrepo/transform/sparql/JQLQueryVisitor.java
+++ b/fcrepo-transform/src/main/java/org/fcrepo/transform/sparql/JQLQueryVisitor.java
@@ -58,6 +58,7 @@ import com.hp.hpl.jena.sparql.syntax.ElementUnion;
 import com.hp.hpl.jena.sparql.syntax.ElementVisitor;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.fcrepo.kernel.rdf.IdentifierTranslator;
 import org.fcrepo.kernel.rdf.JcrRdfTools;
 import org.fcrepo.transform.exception.JQLParsingException;
 import org.modeshape.common.collection.Collections;
@@ -68,6 +69,7 @@ import org.slf4j.Logger;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Value;
+import javax.jcr.query.InvalidQueryException;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.qom.Column;
 import javax.jcr.query.qom.Constraint;
@@ -135,6 +137,7 @@ public class JQLQueryVisitor implements QueryVisitor, ElementVisitor, ExprVisito
     private Map<String, Source> joins;
     private Map<String, String> joinTypes;
     private Map<String, JoinCondition> joinConditions;
+    private IdentifierTranslator subjects;
 
     /**
      * Create a new query
@@ -545,9 +548,7 @@ public class JQLQueryVisitor implements QueryVisitor, ElementVisitor, ExprVisito
                     throw new NotImplementedException("Element path with constant subject and variable predicate");
 
                 } else if (object.isVariable()) {
-                    throw new NotImplementedException(
-                            "Element path with constant subject and predicate, and a variable object");
-
+                    convertConstantSubjectElementBlock(subject, predicate, object, defaultModel);
                 } else {
                     throw new NotImplementedException("Element path with constant subject/predicate/object");
                 }
@@ -555,6 +556,78 @@ public class JQLQueryVisitor implements QueryVisitor, ElementVisitor, ExprVisito
             }
         } catch (final RepositoryException e) {
             throw propagate(e);
+        }
+    }
+
+    private void convertConstantSubjectElementBlock(final Node subject,
+            final Node predicate, final Node object, final Model model)
+                    throws RepositoryException {
+
+        final String subjectUri = subject.getURI().toString();
+
+        // Go through the IdentifierConverter for potential transparent hierarchy path conversion.
+        final String path = subjects.getPathFromSubject(model.createResource(subjectUri));
+
+        final String subjectSelector = "fedoraResource_" + path.replace("/", "_");
+
+        joins.put(subjectUri, queryFactory.selector(FEDORA_RESOURCE, subjectSelector));
+
+        // Trick to add constraint for the constant subject through the jcr internal property jcr:path
+        addPathConstraint(subjectSelector, model, path);
+
+        if (predicate.isVariable()) {
+            throw new NotImplementedException("Element path may not contain a variable predicate");
+        }
+
+        final Column objectColumn;
+        final String propertyName = jcrTools.getPropertyNameFromPredicate(
+                model.createProperty(predicate.getURI()));
+        final int propertyType = jcrTools.getPropertyType(FEDORA_RESOURCE, propertyName);
+
+        if (propertyName.equals("rdf:type") && object.isURI()) {
+            final String mixinName = jcrTools.getPropertyNameFromPredicate(model
+                    .createProperty(object.getURI()));
+
+            if (session.getWorkspace().getNodeTypeManager().hasNodeType(mixinName)) {
+                final String selectorName = "ref_type_" + mixinName.replace(":", "_");
+
+                joins.put(selectorName, queryFactory.selector(mixinName, selectorName));
+
+                joinTypes.put(selectorName, JCR_JOIN_TYPE_INNER);
+                joinConditions.put(selectorName, queryFactory.sameNodeJoinCondition(subject.getURI(),
+                        selectorName, "."));
+                return;
+            }
+        }
+
+
+        if ((propertyType == REFERENCE || propertyType == WEAKREFERENCE || propertyType == URI)
+                && variables.containsKey(object.getName()))  {
+
+            objectColumn = variables.get(object.getName());
+
+            final String joinPropertyName;
+
+            if (propertyType == URI) {
+                joinPropertyName = getReferencePropertyName(propertyName);
+            } else {
+                joinPropertyName = propertyName;
+            }
+
+            joinConditions.put(object.getName(), queryFactory.equiJoinCondition(
+                    subjectSelector, joinPropertyName, objectColumn.getSelectorName(), "jcr:uuid"));
+        } else {
+            objectColumn = queryFactory.column(subjectSelector, propertyName, object.getName());
+
+            variables.put(object.getName(), objectColumn);
+
+            if (resultsVars.contains(object.getName())) {
+                columns.add(objectColumn);
+            }
+        }
+
+        if (!inOptional) {
+            appendConstraint(queryFactory.propertyExistence(subjectSelector, propertyName));
         }
     }
 
@@ -846,4 +919,32 @@ public class JQLQueryVisitor implements QueryVisitor, ElementVisitor, ExprVisito
             constraint = queryFactory.and(constraint, c);
         }
     }
+
+    /*
+     * jcr:path property constraint for a constant subject
+     */
+    private void addPathConstraint(final String selector, final Model model, final String path)
+        throws InvalidQueryException, RepositoryException {
+        final PropertyValue fieldPath = queryFactory.propertyValue(selector, "jcr:path");
+        final Value jcrValuePath = jcrTools.createValue(model.createLiteral(path),
+                jcrTools.getPropertyType(FEDORA_RESOURCE, "jcr:path"));
+        final Literal literalPath = queryFactory.literal(jcrValuePath);
+        appendConstraint(queryFactory.comparison(fieldPath, JCR_OPERATOR_EQUAL_TO, literalPath));
+    }
+
+    /**
+     * Get identifier translator
+     */
+    public IdentifierTranslator getIdentifierTranslator() {
+        return subjects;
+    }
+
+    /**
+     * Set identifier translator
+     * @param subjects
+     */
+    public void setIdentifierTranslator(final IdentifierTranslator subjects) {
+        this.subjects = subjects;
+    }
+
 }

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/JQLConverterIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/JQLConverterIT.java
@@ -284,4 +284,64 @@ public class JQLConverterIT {
 
         assertEquals(expectedQuery.replaceAll("ns001", namespacePrefix), statement);
     }
+
+    @Test
+    public void testConstantSubjectQuery() throws RepositoryException {
+        final String path = "/foo";
+        final String selector = "fedoraResource_" + path.replace("/", "_");
+        final String baseUri = subjects.getBaseUri();
+        final String subjectUri =
+                (baseUri.endsWith("/") ? baseUri.substring(0, baseUri.length() - 1) : baseUri) + path;
+        final String sparql = "PREFIX fcrepo: <http://fedora.info/definitions/v4/repository#> "
+                + "select ?date where { <" + subjectUri + "> fcrepo:created ?date }";
+        final String expectedQuery =
+                "SELECT [" + selector + "].[jcr:created] AS date " +
+                        "FROM [fedora:resource] AS [" + selector + "] " +
+                        "WHERE ([" + selector + "].[jcr:path] = '" + path + "' AND " +
+                        "[" + selector + "].[jcr:created] IS NOT NULL)";
+        final JQLConverter testObj  = new JQLConverter(session, subjects, sparql);
+
+        assertEquals(expectedQuery, testObj.getStatement());
+    }
+
+    @Test
+    public void testConstantSubjectSimpleReferenceQuery() throws RepositoryException {
+        final String path = "/foo";
+        final String selector = "fedoraResource_" + path.replace("/", "_");
+        final String baseUri = subjects.getBaseUri();
+        final String subjectUri = (baseUri.endsWith("/") ? baseUri.substring(0, baseUri.length() - 1) : baseUri) + path;
+        final String sparql =
+                "PREFIX fedorarelsext: <http://fedora.info/definitions/v4/rels-ext#> " +
+                "SELECT ?part WHERE { <" + subjectUri + "> fedorarelsext:hasPart ?part }";
+        final String expectedQuery =
+                "SELECT [" + selector + "].[fedorarelsext:hasPart] AS part " +
+                        "FROM [fedora:resource] AS [" + selector + "] " +
+                        "WHERE ([" + selector + "].[jcr:path] = '" + path + "' AND " +
+                        "[" + selector + "].[fedorarelsext:hasPart] IS NOT NULL)";
+        final JQLConverter testObj  = new JQLConverter(session, subjects, sparql);
+        assertEquals(expectedQuery, testObj.getStatement());
+
+    }
+
+    @Test
+    public void testConstantSubjectReferenceQuery() throws RepositoryException {
+        final String path = "/foo";
+        final String selector = "fedoraResource_" + path.replace("/", "_");
+        final String baseUri = subjects.getBaseUri();
+        final String subjectUri =
+                (baseUri.endsWith("/") ? baseUri.substring(0, baseUri.length() - 1) : baseUri) + path;
+        final String sparql = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>" +
+                "PREFIX fedorarelsext: <http://fedora.info/definitions/v4/rels-ext#>" +
+                "SELECT ?title WHERE { <" + subjectUri + "> fedorarelsext:hasPart ?part . " +
+                "?part dc:title ?title }";
+        final String expectedQuery =
+                "SELECT [fedoraResource_part].[dc:title] AS title FROM [fedora:resource] AS " +
+                        "[" + selector + "] LEFT OUTER JOIN [fedora:resource] AS [fedoraResource_part] ON " +
+                        "[" + selector + "].[fedorarelsext:hasPart] = [fedoraResource_part].[jcr:uuid] " +
+                        "WHERE (([" + selector + "].[jcr:path] = '" + path + "' AND " +
+                        "[" + selector + "].[fedorarelsext:hasPart] IS NOT NULL) AND " +
+                        "[fedoraResource_part].[dc:title] IS NOT NULL)";
+        final JQLConverter testObj  = new JQLConverter(session, subjects, sparql);
+        assertEquals(expectedQuery, testObj.getStatement());
+    }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/71322140

The following SPARQL with constant subject pattern supported: 
PREFIX fcrepo: http://fedora.info/definitions/v4/repository#
select ?date where { http://localhost:8080/rest/foo fcrepo:created ?date }

PREFIX fedorarelsext: http://fedora.info/definitions/v4/rels-ext# 
select ?part where { http://localhost:8080/rest/foo fedorarelsext:hasPart ?part}

PREFIX dc: http://purl.org/dc/elements/1.1/ 
PREFIX fedorarelsext: http://fedora.info/definitions/v4/rels-ext# 
select ?title where { http://localhost:8080/rest/foo fedorarelsext:hasPart ?part . ?part  dc:title ?title}
