### PR TITLE
Fixed relativePath in BOMs' parent configs

### DIFF
--- a/fcrepo-boms/fcrepo-jcr-bom/pom.xml
+++ b/fcrepo-boms/fcrepo-jcr-bom/pom.xml
@@ -4,6 +4,7 @@
     <artifactId>fcrepo</artifactId>
     <groupId>org.fcrepo</groupId>
     <version>4.0.0-alpha-6-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/fcrepo-boms/fcrepo4-bom/pom.xml
+++ b/fcrepo-boms/fcrepo4-bom/pom.xml
@@ -4,6 +4,7 @@
     <artifactId>fcrepo</artifactId>
     <groupId>org.fcrepo</groupId>
     <version>4.0.0-alpha-6-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
BOMs were building fine in environments where the project had been built before, but were failing to build in completely newly cloned projects.  I added 'relativePath' configs to the configurations of the 'parent' projects in the BOM's POMs and this fixes the problem.

Fixes: https://www.pivotaltracker.com/story/show/72004538
