### PR TITLE
Normalize xml-apis version

### DIFF
--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -146,6 +146,12 @@
       <artifactId>junit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.4.01</version>
+    </dependency>
+
     <!-- test gear -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -177,6 +183,10 @@
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Also, instead of putting the .js files under /images, how does /static/js sound?
http://stackoverflow.com/questions/13729326/where-do-javascript-files-go-in-a-maven-webapp-archetype
