### PR TITLE
External datastream pattern

### DIFF
--- a/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
+++ b/fcrepo-kernel/src/main/resources/fedora-node-types.cnd
@@ -65,6 +65,9 @@
 	- fedorarelsext:isAnnotationOf (REFERENCE) multiple COPY
 	- fedorarelsext:HasAnnotation (REFERENCE) multiple COPY
 	- fedorarelsext:hasEquivalent (REFERENCE) multiple COPY
+    - fedorarelsext:hasExternalContent (URI) multiple COPY
+    - fedorarelsext:isExternalContentOf (URI) multiple COPY
+
 
 /*
  *  Dublin Core terms


### PR DESCRIPTION
- Adding hasExternalContent/isExternalContentOf properties
- Adding IT for linking from repo object to federated filesystem datastream

Fixes https://www.pivotaltracker.com/story/show/71324222
