### PR TITLE
Rejected access to jcr:content from the web ui for NOT_FOUND (status 404)

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
@@ -154,6 +154,12 @@ public class FedoraNodes extends AbstractResource {
                      @Context final Request request,
                      @Context final HttpServletResponse servletResponse,
                      @Context final UriInfo uriInfo) throws RepositoryException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("HEAD request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
+
         final String path = toPath(pathList);
         LOGGER.trace("Getting head for: {}", path);
 
@@ -192,6 +198,13 @@ public class FedoraNodes extends AbstractResource {
             @Context final Request request,
             @Context final HttpServletResponse servletResponse,
             @Context final UriInfo uriInfo) throws RepositoryException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("MOVE request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
+
+
         final String path = toPath(pathList);
         LOGGER.trace("Getting profile for: {}", path);
 
@@ -349,6 +362,11 @@ public class FedoraNodes extends AbstractResource {
             final InputStream requestBodyStream,
             @Context final Request request, @Context final HttpServletResponse servletResponse)
         throws RepositoryException, IOException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("PATCH request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         final String path = toPath(pathList);
         LOGGER.debug("Attempting to update path: {}", path);
@@ -413,6 +431,12 @@ public class FedoraNodes extends AbstractResource {
             @Context final Request request,
             @Context final HttpServletResponse servletResponse) throws RepositoryException, ParseException,
             IOException, InvalidChecksumException, URISyntaxException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("PUT request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
+
         final String path = toPath(pathList);
         LOGGER.debug("Attempting to replace path: {}", path);
         try {
@@ -495,6 +519,11 @@ public class FedoraNodes extends AbstractResource {
             final UriInfo uriInfo, final InputStream requestBodyStream)
         throws RepositoryException, ParseException, IOException,
                    InvalidChecksumException, URISyntaxException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("POST request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         String pid;
         final String newObjectPath;
@@ -694,6 +723,11 @@ public class FedoraNodes extends AbstractResource {
                                                 @Context final UriInfo uriInfo,
                                                 @FormDataParam("file") final InputStream file
     ) throws RepositoryException, URISyntaxException, InvalidChecksumException, ParseException, IOException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("POST request with multipart attachment with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         final MediaType effectiveContentType = file == null ? null : MediaType.APPLICATION_OCTET_STREAM_TYPE;
         return createObject(pathList, mixin, null, null, effectiveContentType, slug, servletResponse, uriInfo, file);
@@ -712,6 +746,11 @@ public class FedoraNodes extends AbstractResource {
     public Response deleteObject(@PathParam("path")
             final List<PathSegment> pathList,
             @Context final Request request) throws RepositoryException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("DELETE request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         try {
 
@@ -755,6 +794,11 @@ public class FedoraNodes extends AbstractResource {
     public Response copyObject(@PathParam("path") final List<PathSegment> path,
                                @HeaderParam("Destination") final String destinationUri)
         throws RepositoryException, URISyntaxException {
+        if (checkPathJcrContent(path)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("COPY request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         try {
 
@@ -801,6 +845,11 @@ public class FedoraNodes extends AbstractResource {
                                @HeaderParam("Destination") final String destinationUri,
                                @Context final Request request)
         throws RepositoryException, URISyntaxException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("MOVE request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
 
         try {
 
@@ -854,8 +903,37 @@ public class FedoraNodes extends AbstractResource {
     public Response options(@PathParam("path") final List<PathSegment> pathList,
                             @Context final HttpServletResponse servletResponse)
         throws RepositoryException {
+        if (checkPathJcrContent(pathList)) {
+            final String requestPath = uriInfo.getPath();
+            LOGGER.trace("OPTIONS request with jcr namespace is not allowed: {} ", requestPath);
+            responseNotFound();
+        }
+
         addOptionsHttpHeaders(servletResponse);
         return status(OK).build();
     }
 
+    /**
+     * Method to check for any jcr namespace element in the path
+     */
+    public static boolean checkPathJcrContent(final List<PathSegment> pathList) {
+        final int pathSize = pathList.size();
+        if (pathList == null || pathSize == 0) {
+            return false;
+        }
+        final PathSegment pathSegment = pathList.get(pathSize - 1);
+        final String[] tokens = pathSegment.getPath().split(":");
+        if (tokens.length == 2 && tokens[0].equalsIgnoreCase("jcr")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Send response not found
+     * @param path
+     */
+    public static void responseNotFound() {
+        throw new WebApplicationException(notFound().build());
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraNodesTest.java
@@ -50,6 +50,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
@@ -63,6 +64,7 @@ import javax.jcr.version.VersionManager;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -587,5 +589,17 @@ public class FedoraNodesTest {
 
         final Response response = testObj.head( createPathList(pid), mockRequest, mockResponse, mockUriInfo);
         assertEquals(SC_OK, response.getStatus());
+    }
+
+    @Test
+    public void testCheckJcrNamespace() {
+        final List<PathSegment> pathList = createPathList("anypath");
+        pathList.add(createPathList("jcr:path").get(0));
+        assertTrue(FedoraNodes.checkPathJcrContent(pathList));
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void testResonseNotFound() {
+        FedoraNodes.responseNotFound();
     }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/71412046
I think the major issue is that the FedoraNodes.java allows the access to any methods in the class with no path restriction. I've added functions to reject all access ended with jcr:content for status not found. Now we'll see the jersey 404 error message if a user try to access any resources with jcr:content.
