### PR TITLE
Suspended support for update operations using the FedoraFileSystemConnec...

### DIFF
--- a/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
+++ b/fcrepo-connector-file/src/main/java/org/fcrepo/connector/file/FedoraFileSystemConnector.java
@@ -80,6 +80,10 @@ public class FedoraFileSystemConnector extends FileSystemConnector {
                            final NodeTypeManager nodeTypeManager) throws RepositoryException, IOException {
         super.initialize(registry, nodeTypeManager);
 
+        if (!isReadonly()) {
+            throw new RepositoryException("The " + getClass().getName() + " must have \"readonly\" set to true!");
+        }
+
         if (propertiesDirectoryPath != null) {
            propertiesDirectory = new File(propertiesDirectoryPath);
             if (!propertiesDirectory.exists() || !propertiesDirectory.isDirectory()) {

--- a/fcrepo-connector-file/src/test/java/org/fcrepo/connector/file/FedoraFileSystemConnectorTest.java
+++ b/fcrepo-connector-file/src/test/java/org/fcrepo/connector/file/FedoraFileSystemConnectorTest.java
@@ -34,6 +34,7 @@ import org.modeshape.jcr.value.basic.BasicSingleValueProperty;
 import org.slf4j.Logger;
 
 import javax.jcr.NamespaceRegistry;
+import javax.jcr.RepositoryException;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -131,9 +132,21 @@ public class FedoraFileSystemConnectorTest {
         setField(connector, "context", mockContext);
         setField(connector, "extraPropertiesStore", mockExtraPropertiesStore);
         setField(mockTranslator, "names", mockNameFactory);
+        setField(connector, "readonly", true);
         connector.initialize(mockRegistry, mockNodeTypeManager);
         mockContext.getNamespaceRegistry().register("fedora", "http://fedora.info/definitions/v4/repository#");
         mockContext.getNamespaceRegistry().register("premis", "http://www.loc.gov/premis/rdf/v1#");
+    }
+
+    @Test(expected = RepositoryException.class)
+    public void testThatReadOnlyIsRequired() throws IOException, RepositoryException {
+        final FedoraFileSystemConnector c = new FedoraFileSystemConnector();
+        setField(c, "directoryPath", directoryPath.toString());
+        setField(c, "translator", mockTranslator);
+        setField(c, "context", mockContext);
+        setField(c, "extraPropertiesStore", mockExtraPropertiesStore);
+        setField(mockTranslator, "names", mockNameFactory);
+        c.initialize(mockRegistry, mockNodeTypeManager);
     }
 
     @Test

--- a/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/BasicReadWriteFedoraFileSystemConnectorIT.java
+++ b/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/BasicReadWriteFedoraFileSystemConnectorIT.java
@@ -18,6 +18,7 @@ package org.fcrepo.integration.connector.file;
 import org.fcrepo.kernel.FedoraResource;
 import org.fcrepo.kernel.rdf.IdentifierTranslator;
 import org.fcrepo.kernel.rdf.impl.DefaultIdentifierTranslator;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.jcr.PathNotFoundException;
@@ -31,7 +32,20 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mike Durbin
+ *
+ * This class is ignored until non-'readonly' federations are supported.  At that time,
+ * include the following in the repository.json and remove the 'ignore' annotation.
+ *
+ *  "federated-directory" : {
+ *    "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
+ *    "directoryPath" : "${fcrepo.test.dir1:must-be-provided}",
+ *    "projections" : [ "default:/federated => /" ],
+ *    "contentBasedSha1" : "false",
+ *    "readonly" : false,
+ *    "extraPropertiesStorage" : "json"
+ *  },
  */
+@Ignore
 public class BasicReadWriteFedoraFileSystemConnectorIT extends AbstractFedoraFileSystemConnectorIT {
 
     @Override

--- a/fcrepo-connector-file/src/test/resources/config/testing/repository.json
+++ b/fcrepo-connector-file/src/test/resources/config/testing/repository.json
@@ -7,14 +7,6 @@
         "allowCreation" : true
     },
     "externalSources" : {
-        "federated-directory" : {
-            "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
-            "directoryPath" : "${fcrepo.test.dir1:must-be-provided}",
-            "projections" : [ "default:/federated => /" ],
-            "contentBasedSha1" : "false",
-            "readonly" : false,
-            "extraPropertiesStorage" : "json"
-        },
         "federated-directory-read-only" : {
             "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
             "directoryPath" : "${fcrepo.test.dir2:must-be-provided}",

--- a/fcrepo-http-api/src/test/resources/test_repository.json
+++ b/fcrepo-http-api/src/test/resources/test_repository.json
@@ -19,7 +19,7 @@
       "fileSystem" : {
         "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
         "directoryPath" : "target/test-classes/test-objects",
-        "readonly" : false,
+        "readonly" : true,
         "extraPropertiesStorage": "json",
         "cacheTtlSeconds" : 5,
         "projections" : [ "default:/files => /" ]

--- a/fcrepo-http-api/src/test/resources/test_repository_fs.json
+++ b/fcrepo-http-api/src/test/resources/test_repository_fs.json
@@ -19,7 +19,7 @@
       "fileSystem" : {
         "classname" : "org.fcrepo.connector.file.FedoraFileSystemConnector",
         "directoryPath" : "target/test-classes/test-objects",
-        "readonly" : false,
+        "readonly" : true,
         "extraPropertiesStorage": "json",
         "cacheTtlSeconds" : 5,
         "projections" : [ "default:/files => /" ]


### PR DESCRIPTION
...tor.

I had to change a few tests that relied upon created federation datastreams to use the pre-existing ones, but otherwise this was fairly straightforward.

I left all the read-write tests in place but @ignore'd them since this is something we may be able to support in the future.
