### PR TITLE
Fixed the NPE bug to support the SPARQL str function, and throw NotImplementedException for comparing subject variable value

### DIFF
--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/JQLConverterIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/JQLConverterIT.java
@@ -225,6 +225,22 @@ public class JQLConverterIT {
     }
 
     @Test
+    public void testStrFuncFilter() throws RepositoryException {
+        final String sparql = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n" +
+                "SELECT ?subject ?title\n" +
+                "WHERE   { ?subject dc:title ?title\n" +
+                "    FILTER (str(?title) = \"SPARQL\")\n" +
+                "}";
+        final JQLConverter testObj = new JQLConverter(session, subjects, sparql);
+        assertEquals("SELECT [fedoraResource_subject].[jcr:path] AS subject, " +
+                "[fedoraResource_subject].[dc:title] AS title FROM [fedora:resource] AS " +
+                "[fedoraResource_subject] WHERE ([fedoraResource_subject].[dc:title] " +
+                "IS NOT NULL AND [fedoraResource_subject].[dc:title] = 'SPARQL')",
+                     testObj.getStatement());
+
+    }
+
+    @Test
     public void testStrstartsFilter() throws RepositoryException {
         final String sparql = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/>\n" +
                 "SELECT  ?title \n" +


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/71073904

I think I've fixed the NPE bug and added the str() function support for filter queries. However, the filter query will work for literal values only but not subject reference, and I've let it thrown the NotImplementedException when a SPARQL is trying to compare subject reference as literal values.
