### PR TITLE
Fixed the SPARQL node type deletion bug to return a clear error message from the backend.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraNodes.java
@@ -99,6 +99,7 @@ import com.hp.hpl.jena.rdf.model.StmtIterator;
 import com.sun.jersey.multipart.FormDataParam;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.jena.riot.Lang;
 import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierTranslator;
@@ -382,15 +383,15 @@ public class FedoraNodes extends AbstractResource {
                 LOGGER.info(
                         "Found these problems updating the properties for {}: {}",
                         path, problems);
-                String error = "";
+                final StringBuilder error = new StringBuilder();
                 final StmtIterator sit = problems.listStatements();
                 while (sit.hasNext()) {
                     final String message = getMessage(sit.next());
-                    if (message != null && error.indexOf(message) < 0) {
-                        error += message + " \n" ;
+                    if (StringUtils.isNotEmpty(message) && error.indexOf(message) < 0) {
+                        error.append(message + " \n");
                     }
                 }
-                return status(FORBIDDEN).entity(error.length() > 0 ? error : problems.toString())
+                return status(FORBIDDEN).entity(error.length() > 0 ? error.toString() : problems.toString())
                         .build();
             }
 
@@ -877,7 +878,7 @@ public class FedoraNodes extends AbstractResource {
     private String getMessage(final Statement stmt) {
         final Literal literal = stmt.getLiteral();
         if (literal != null) {
-            return stmt.getPredicate().getURI().toString() + ": " + literal.getString();
+            return stmt.getPredicate().getURI() + ": " + literal.getString();
         }
         return null;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/JcrPropertyStatementListener.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/JcrPropertyStatementListener.java
@@ -28,6 +28,7 @@ import javax.jcr.Session;
 import javax.jcr.Value;
 
 import com.hp.hpl.jena.rdf.model.AnonId;
+import org.apache.commons.lang.StringUtils;
 import org.fcrepo.kernel.RdfLexicon;
 import org.fcrepo.kernel.rdf.IdentifierTranslator;
 import org.fcrepo.kernel.impl.rdf.JcrRdfTools;
@@ -219,7 +220,7 @@ public class JcrPropertyStatementListener extends StatementListener {
                                     s.getPredicate().getURI(),
                                     e);
                             String errorMessage = e.getMessage();
-                            if (errorMessage != null || errorMessage.length() > 0) {
+                            if (StringUtils.isNotBlank(errorMessage)) {
                                 errorMessage = errorPrefix + " '" + mixinName +
                                         "': \n" + e.getClass().getName() + ": " + errorMessage;
                             } else {
@@ -235,7 +236,7 @@ public class JcrPropertyStatementListener extends StatementListener {
                     LOGGER.trace("Unable to resolve registered namespace for resource {}: {}", mixinResource, e);
 
                     String errorMessage = e.getMessage();
-                    if (errorMessage != null || errorMessage.length() > 0) {
+                    if (StringUtils.isNotBlank(errorMessage)) {
                         errorMessage = errorPrefix + " " +
                                 e.getClass().getName() + ": "  + errorMessage;
                     } else {


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/72805066

I think I've fixed it to return a clear error message for deleting a not assigned registered node type now. Attached is the screen shot with the error message:
![screen shot 2014-07-11 at 9 46 25 am](https://cloud.githubusercontent.com/assets/2430784/3555873/5b7c3f56-091c-11e4-9336-d7061e7a55bf.png)
