### PR TITLE
Added form request (application/x-www-form-urlencoded) support for sparql end point; refactored the rest api codes for sparql.

### DIFF
--- a/fcrepo-transform/src/main/java/org/fcrepo/transform/http/FedoraSparql.java
+++ b/fcrepo-transform/src/main/java/org/fcrepo/transform/http/FedoraSparql.java
@@ -16,6 +16,7 @@
 package org.fcrepo.transform.http;
 
 import com.codahale.metrics.annotation.Timed;
+import com.google.common.base.Strings;
 import com.hp.hpl.jena.query.ResultSet;
 import org.apache.commons.io.IOUtils;
 import org.apache.velocity.Template;
@@ -37,12 +38,12 @@ import org.springframework.stereotype.Component;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
@@ -183,20 +184,12 @@ public class FedoraSparql extends AbstractResource {
             contentTypeResultsXML, contentTypeResultsBIO, contentTypeTurtle,
             contentTypeN3, contentTypeNTriples, contentTypeRDFXML})
     public Response runSparqlQuery(
-            final MultivaluedMap<String, String> formParams,
-            @Context final Request request)
+            @FormParam("query") final String query,
+            @Context final Request request, @Context final UriInfo uriInfo)
                     throws IOException, RepositoryException {
-        String query = null;
-        if (formParams.size() == 1) {
-            // The only parameter is the SPARQL query. This will be flexible
-            // to accept SPARQL in any query names.
-            query = formParams.getFirst(formParams.keySet().iterator().next());
-        } else {
-            // the default parameter "query" for submitting the SPARQL
-            query = formParams.getFirst("query");
-        }
+
         LOGGER.trace("POST SPARQL query with {}: {}", contentTypeHTMLForm, query);
-        if (query == null || query.length() == 0) {
+        if (Strings.isNullOrEmpty(query)) {
             return status(BAD_REQUEST)
                     .entity("SPARQL must not be null. Please submit a query with parameter 'query'.")
                     .build();

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/transform/http/FedoraSparqlIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/transform/http/FedoraSparqlIT.java
@@ -220,13 +220,10 @@ public class FedoraSparqlIT  extends AbstractResourceIT {
         return content;
     }
 
-    private String getFormRequestResponseContent(final String sparql) throws IOException {
-        return getFormRequestResponseContent(sparql, null);
-    }
 
-    private String getFormRequestResponseContent(final String sparql, final String paramName)
+    private String getFormRequestResponseContent(final String sparql)
             throws IOException {
-        final HttpPost request = getFormRequest (sparql, paramName);
+        final HttpPost request = getFormRequest (sparql, "query");
 
         final HttpResponse response = client.execute(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
@@ -342,21 +339,5 @@ public class FedoraSparqlIT  extends AbstractResourceIT {
         badRequest = getFormRequest(sparql, null);
         response = client.execute(badRequest);
         assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusLine().getStatusCode());
-    }
-
-    @Test
-    public void testFormRequestWithDummyParamName() throws IOException {
-        final String sparql = "PREFIX  dc:  <http://purl.org/dc/elements/1.1/> " +
-                "SELECT ?subject WHERE { ?subject dc:title \"xyz\"}";
-
-        final String content = getFormRequestResponseContent(sparql, "dummyName");
-        final ResultSet resultSet = ResultSetFactory.fromTSV(IOUtils.toInputStream(content));
-
-
-        assertTrue(resultSet.hasNext());
-
-        assertEquals("subject", resultSet.getResultVars().get(0));
-
-        assertEquals(serverAddress + "/abc", resultSet.next().get("subject").toString());
     }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/72619228

We should be able to submit sparql with form request (application/x-www-form-urlencoded) now.  The original support for contentTypeSPARQLQuery is changed to the default content type since I see the sparql integration tests depend on it. 
I made the form request to accept any parameters for the sparql at this time if there are only have one parameter in the form, but assume parameter "query" is the required parameter for the sparql and raise a error to prompt for it if the query is not found. Please let me know if you have other thoughts.
