### PR TITLE
Updated repository root RDF to use standard vocabulary sd:endpoint to point at the fcr:sparql service.

### DIFF
--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/RdfLexicon.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/RdfLexicon.java
@@ -78,6 +78,12 @@ public final class RdfLexicon {
     public static final String LDP_NAMESPACE = "http://www.w3.org/ns/ldp#";
 
     /**
+     * SPARQL service description namespace.
+     */
+    public static final String SPARQL_SD_NAMESPACE =
+            "http://www.w3.org/ns/sparql-service-description#";
+
+    /**
      * The namespaces that the repository manages internally.
      */
     public static final Set<String> managedNamespaces = of(RESTAPI_NAMESPACE,
@@ -254,7 +260,7 @@ public final class RdfLexicon {
     public static final Property NOT_IMPLEMENTED =
             createProperty(REPOSITORY_NAMESPACE + "notImplemented");
     public static final Property HAS_SPARQL_ENDPOINT =
-        createProperty(RESTAPI_NAMESPACE + "sparql");
+        createProperty(SPARQL_SD_NAMESPACE + "endpoint");
 
     public static final Set<Property> otherServiceProperties = of(
             HAS_SERIALIZATION, HAS_VERSION_HISTORY, HAS_FIXITY_SERVICE,


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/72619838
The root rdf output will be changed to use the sd:endpoint as follows now:
<rdf:Description rdf:about="http://localhost:8080/rest/">
<endpoint xmlns="http://www.w3.org/ns/sparql-service-description#" rdf:resource="http://localhost:8080/rest/fcr:sparql"/>
...
/rdf:Description
