### PR TITLE
Added buttons/forms to the object page for locks creation and viewing.

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -110,6 +110,7 @@ WHERE { }
 
 #if ($writable == true)
 #set ($serializations = $rdf.find($nodeany, $topic, $helpers.asNode($rdfLexicon.HAS_SERIALIZATION), $nodeany))
+#set ($isLockable = $helpers.isRdfResource($rdf, $topic, $rdfLexicon.MIX_NAMESPACE, "lockable"))
 
 #if($serializations.hasNext())
 <form id="action_import" action="fcr:import" method="POST">
@@ -158,6 +159,28 @@ WHERE { }
     <button type="submit" class="btn btn-primary">Start Transaction</button>
     <hr />
 </form>
+#end
+
+#if($isLockable)
+    #set ($lockUrl = $helpers.getLockUrl($rdf, $topic))
+    #set ($viewDisplay = "none")
+    #set ($createDisplay = "block")
+    #if ($lockUrl && $lockUrl.length() > 0)
+        #set ($viewDisplay = "block")
+        #set ($createDisplay = "none")
+    #end
+    <div class="actions collapse visible-lg visible-md" id="div_lock">
+        <h3>Locks</h3>
+        <div class="form-group" id="div_view_lock" style="display:$viewDisplay">
+            <div class="control-label">Item is Locked!</div>
+            <button type="button" id="btn_view_lock" class="btn btn-primary" onClick="javascript:viewLock('$lockUrl');">View Lock</button>
+        </div>
+        <div class="form-group" id="div_create_lock" style="display:$createDisplay">
+            <div class="control-label"><input type="checkbox" id="deep_id" name="deep"/> Is Deep</div>
+            <button type="button" id="btn_create_lock" class="btn btn-primary" onClick="javascript:createLock();">Create Lock</button>
+        </div>     
+        <hr />
+    </div>
 #end
 #end
 

--- a/fcrepo-http-api/src/main/resources/views/common.js
+++ b/fcrepo-http-api/src/main/resources/views/common.js
@@ -242,6 +242,32 @@ function deleteItem()
     return false;
 }
 
+function createLock()
+{
+    var uri = $('#main').attr('resource');
+    var isDeep = false;
+    if ($('#deep_id').prop('checked'))
+        isDeep = true;
+    $.ajax({
+    	type: "POST",
+    	url: uri + "/fcr:lock?deep=" + isDeep,
+    	success: function() {
+    		$('#div_create_lock').hide();
+    		$('#div_view_lock').show();
+        }
+    }).fail( ajaxErrorHandler);
+}
+
+function viewLock(lockUrl)
+{
+	$('#div_view_lock').hide();
+	if (!lockUrl || lockUrl.length === 0) {
+        var uri = $('#main').attr('resource');
+        lockUrl = uri + "/fcr:lock";
+    }
+	window.location.href = lockUrl;
+}
+
 function updateFile()
 {
     var update_file = document.getElementById("update_file").files[0];

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
@@ -23,6 +23,7 @@ import static org.fcrepo.kernel.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.RdfLexicon.RDFS_LABEL;
 import static org.fcrepo.kernel.RdfLexicon.HAS_VERSION;
 import static org.fcrepo.kernel.RdfLexicon.HAS_CONTENT;
+import static org.fcrepo.kernel.RdfLexicon.RDF_NAMESPACE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.text.SimpleDateFormat;
@@ -412,6 +413,29 @@ public class ViewHelpers {
 
         sb.append("\n");
         return sb.toString();
+    }
+
+    /**
+     * Determines whether the subject is kind of RDF resource
+     */
+    public boolean isRdfResource(final DatasetGraph dataset, final Node subject,
+            final String namespace, final String resource) {
+        final Iterator<Quad> it = dataset.find(ANY, subject,
+                ResourceFactory.createResource(RDF_NAMESPACE + "type").asNode(),
+                ResourceFactory.createResource(namespace + resource).asNode());
+        return it.hasNext();
+    }
+
+    /**
+     * Retrieve the uri for the locks
+     */
+    public String getLockUrl(final DatasetGraph dataset, final Node subject) {
+        final Iterator<Quad> it = dataset.find(ANY, subject,
+                RdfLexicon.HAS_LOCK.asNode(), ANY);
+        if (it.hasNext()) {
+            return it.next().getObject().getURI();
+        }
+        return "";
     }
 
     /**

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/ViewHelpersTest.java
@@ -33,6 +33,7 @@ import static org.fcrepo.kernel.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.RdfLexicon.HAS_VERSION;
 import static org.fcrepo.kernel.RdfLexicon.HAS_CONTENT;
 import static org.fcrepo.kernel.RdfLexicon.WRITABLE;
+import static org.fcrepo.kernel.RdfLexicon.RDF_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import java.util.Map;
 
 import javax.ws.rs.core.UriInfo;
 
+import org.fcrepo.kernel.RdfLexicon;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -164,6 +166,31 @@ public class ViewHelpersTest {
         mem.add(createAnon(), createURI("a/b/c"), HAS_PRIMARY_TYPE.asNode(),
                 createLiteral("nt:file"));
         assertFalse("Node is not a frozen node.", testObj.isFrozenNode(mem, createURI("a/b/c")));
+    }
+
+    @Test
+    public void testRdfResource() {
+        final String ns = "http://any/namespace#";
+        final String type = "anyType";
+        final DatasetGraph mem = createMem();
+        mem.add(createAnon(), createURI("a/b"),
+                ResourceFactory.createResource(RDF_NAMESPACE + "type").asNode(),
+                ResourceFactory.createResource(ns + type).asNode());
+        assertTrue("Node is a " + type + " node.",
+                testObj.isRdfResource(mem, createURI("a/b"), ns, type));
+        assertFalse("Node is not a " + type + " node.",
+                testObj.isRdfResource(mem, createURI("a/b"), ns, "otherType"));
+    }
+
+    @Test
+    public void testGetLockUrl() {
+        final Node lockUrl = createURI("a/b/fcr:lock");
+        final DatasetGraph mem = createMem();
+        mem.add(createAnon(), createURI("a/b"),
+                RdfLexicon.HAS_LOCK.asNode(),
+                lockUrl);
+        assertEquals("Wrong lock url returned!", lockUrl.getURI(),
+                testObj.getLockUrl(mem, createURI("a/b")));
     }
 
     @Test

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -303,6 +303,30 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
         assertTrue("New uri was not found", page2.asText().contains(uri_value));
     }
 
+    /**
+     * This test create a lock from the object page and examine the lock created.
+     */
+    @Test
+    public void testLockCreationFromObjectPage() throws IOException {
+        final String pid = randomUUID().toString();
+        createAndVerifyObjectWithIdFromRootPage(pid);
+
+        final HtmlPage page = webClient.getPage(serverAddress + pid);
+        final HtmlButton createButton = (HtmlButton) page.getElementById("btn_create_lock");
+        assertTrue("Should have Create Lock button.", createButton != null);
+        createButton.click();
+
+        webClient.waitForBackgroundJavaScript(1000);
+        webClient.waitForBackgroundJavaScriptStartingBefore(10000);
+
+        final HtmlPage page1 = webClient.getPage(serverAddress + pid);
+        assertTrue("Should have the View Lock button.", page1.getElementById("btn_view_lock") != null);
+
+        final HtmlPage lockPage = webClient.getPage(serverAddress + pid + "/fcr:lock");
+        assertTrue("Should have fedora:locks property.", lockPage.asText().contains("lock"));
+        assertTrue("Should have fedora:isDeep property.", lockPage.asText().contains("isDeep"));
+    }
+
     private void checkForHeaderSearch(final HtmlPage page) {
         final HtmlForm form = page.getFirstByXPath("//form[@role='search']");
         assertNotNull(form);


### PR DESCRIPTION
https://www.pivotaltracker.com/s/projects/684825/stories/70438216

I've extended the support for all lockable resource but not limit to objects and contents. We'll have a "Locks" form on the right of the node page in the actions panel for a lockable with a button "Create Lock" and a checkbox "Is Deep" for creating a lock when there are no locks created yet, otherwise a button "View Lock" button will be showing up that links to the lock page, which allows us to view the information for the existing lock. 
