### PR TITLE
Removed query portion of repository.json.

### DIFF
--- a/fcrepo-configs/src/main/resources/config/clustered/repository.json
+++ b/fcrepo-configs/src/main/resources/config/clustered/repository.json
@@ -9,20 +9,6 @@
     "clustering" : {
         "clusterName" : "modeshape-cluster"
     },
-    "query" : {
-        "enabled" : "${fcrepo.modeshape.query.enabled:true}",
-        "indexStorage" : {
-            "type" : "filesystem",
-            "location" : "${fcrepo.modeshape.index.location:target/indexes}",
-            "lockingStrategy" : "native",
-            "fileSystemAccessType" : "auto"
-        },
-        "rebuildUponStartup" : "if_missing",
-
-        "indexing" : {
-            "mode" : "${fcrepo.modeshape.query.mode:sync}"
-        }
-    },
     "storage" : {
         "cacheName" : "FedoraRepository",
         "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb/infinispan.xml}",

--- a/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
+++ b/fcrepo-configs/src/main/resources/config/servlet-auth/repository.json
@@ -6,20 +6,6 @@
         "default" : "default",
         "allowCreation" : true
     },
-    "query" : {
-        "enabled" : "${fcrepo.modeshape.query.enabled:true}",
-        "indexStorage" : {
-            "type" : "filesystem",
-            "location" : "${fcrepo.modeshape.index.location:target/indexes}",
-            "lockingStrategy" : "native",
-            "fileSystemAccessType" : "auto"
-        },
-        "rebuildUponStartup" : "if_missing",
-
-        "indexing" : {
-            "mode" : "${fcrepo.modeshape.query.mode:sync}"
-        }
-    },
     "storage" : {
         "cacheName" : "FedoraRepository",
         "cacheConfiguration" : "${fcrepo.infinispan.cache_configuration:config/infinispan/leveldb-default/infinispan.xml}",


### PR DESCRIPTION
I couldn't really find documentation about this change, but the prior commit (https://github.com/fcrepo4/fcrepo4/commit/3c127128ec71919200e6e687444b9709700ee529) appeared to unceremoniously remove the query section of this config, so I suspect the default behavior in modeshape 4 is acceptable.

The one change fixes fcrepo-webapp-auth.war in fcrepo-webapp/, the other fixes anywhere (nowhere?) where the clustered config is used.
