### PR TITLE
Possible fix for jacoco surefire problem

### DIFF
--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -144,9 +144,6 @@
         <!-- Using Surefire instead of Failsafe as workaround: https://code.google.com/p/powermock/issues/detail?id=504  -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>-XX:-UseSplitVerifier</argLine>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -734,7 +734,9 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
           <configuration>
-            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=512m</argLine>
+            <!-- split verifier and jacoco agent args here as workaround for
+              https://code.google.com/p/powermock/issues/detail?id=504 -->
+            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=512m -XX:-UseSplitVerifier ${jacoco.agent.it.arg}</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Workaround for PowerMock / JDK incompatibility seems to have broken the Jacoco reporting of kernel-impl unit tests.  This PR adds some additional Surefire configuration information so that it (in theory) will work with Jacoco.

I think this will fix the problem, but am not running Sonar locally so am hoping Jenkins is run as a result of this PR (so I can see whether it actually fixes the problem or not).
