### PR TITLE
Updated Modeshape to Beta2, which required mock object updates

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspacesTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/repository/FedoraRepositoryWorkspacesTest.java
@@ -22,6 +22,7 @@ import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
 import static org.fcrepo.kernel.RdfLexicon.HAS_WORKSPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -36,6 +37,7 @@ import javax.ws.rs.core.UriInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.modeshape.jcr.api.NamespaceRegistry;
 import org.modeshape.jcr.api.Repository;
 
@@ -75,6 +77,8 @@ public class FedoraRepositoryWorkspacesTest {
     @Before
     public void setUp() {
         initMocks(this);
+        mockWorkspaceSession = mock(Session.class,
+                Mockito.withSettings().extraInterfaces(org.modeshape.jcr.api.Session.class));
         mockUriInfo = getUriInfoImpl();
         workspaces = new FedoraRepositoryWorkspaces();
         setField(workspaces, "session", mockSession);
@@ -104,7 +108,7 @@ public class FedoraRepositoryWorkspacesTest {
         final Repository mockRepository = mockRepository();
         when(mockSession.getRepository()).thenReturn(mockRepository);
         when(mockWorkspaceSession.getRepository()).thenReturn(mockRepository);
-        when(mockRepository.login("xxx")).thenReturn(mockWorkspaceSession);
+        when(mockRepository.login("xxx")).thenReturn((org.modeshape.jcr.api.Session) mockWorkspaceSession);
         when(mockWorkspaceSession.getWorkspace()).thenReturn(mockOtherWorkspace);
         when(mockOtherWorkspace.getName()).thenReturn("xxx");
         final Response response = workspaces.createWorkspace("xxx", mockUriInfo);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraNodesIT.java
@@ -1804,9 +1804,10 @@ public class FedoraNodesIT extends AbstractResourceIT {
     **/
     @Test
     public void testBreakFederation() throws Exception {
+        final String pid = getRandomUniquePid();
         testGetRepositoryGraph();
-        createObject("files/a0/b0");
-        createObject("files/a0/b1");
+        createObject("files/a0/" + pid + "b0");
+        createObject("files/a0/" + pid + "b1");
         testGetRepositoryGraph();
     }
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
@@ -60,6 +60,7 @@ import org.fcrepo.http.commons.AbstractResource;
 import org.fcrepo.kernel.Datastream;
 import org.fcrepo.kernel.FedoraBinary;
 import org.fcrepo.kernel.impl.identifiers.UUIDPidMinter;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.modeshape.jcr.api.NamespaceRegistry;
@@ -111,7 +112,7 @@ public abstract class TestHelpers {
         try {
             final Query mockQ = getQueryMock();
             when(mockQM.createQuery(anyString(), anyString()))
-                    .thenReturn(mockQ);
+                    .thenReturn((org.modeshape.jcr.api.query.Query) mockQ);
             when(mockWS.getQueryManager()).thenReturn(mockQM);
         } catch (final RepositoryException e) {
             e.printStackTrace();
@@ -204,8 +205,8 @@ public abstract class TestHelpers {
     public static Repository mockRepository() throws LoginException,
                                              RepositoryException {
         final Repository mockRepo = mock(Repository.class);
-        final Session mockSession = mock(Session.class);
-        when(mockRepo.login()).thenReturn(mockSession);
+        when(mockRepo.login()).thenReturn(
+                mock(org.modeshape.jcr.api.Session.class, Mockito.withSettings().extraInterfaces(Session.class)));
         return mockRepo;
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/DefaultFilterTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/DefaultFilterTest.java
@@ -25,6 +25,7 @@ import static javax.jcr.observation.Event.PROPERTY_ADDED;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -38,6 +39,7 @@ import javax.jcr.observation.Event;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.modeshape.jcr.api.Repository;
 
 import com.google.common.base.Predicate;
@@ -72,12 +74,13 @@ public class DefaultFilterTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        mockSession = mock(Session.class, Mockito.withSettings().extraInterfaces(org.modeshape.jcr.api.Session.class));
         when(mockEvent.getPath()).thenReturn(testPath);
         when(mockEvent.getIdentifier()).thenReturn(testId);
         when(mockEvent.getType()).thenReturn(NODE_ADDED);
         when(mockNode.isNode()).thenReturn(true);
         testObj = new DefaultFilter();
-        when(mockRepo.login()).thenReturn(mockSession);
+        when(mockRepo.login()).thenReturn((org.modeshape.jcr.api.Session) mockSession);
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/SimpleObserverTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/SimpleObserverTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.mock;
 
 import javax.jcr.Session;
 import javax.jcr.Workspace;
@@ -35,6 +36,7 @@ import org.fcrepo.kernel.observer.FedoraEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.modeshape.jcr.api.Repository;
 
 import com.google.common.base.Predicate;
@@ -73,7 +75,8 @@ public class SimpleObserverTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        when(mockRepository.login()).thenReturn(mockSession);
+        mockSession = mock(Session.class, Mockito.withSettings().extraInterfaces(org.modeshape.jcr.api.Session.class));
+        when(mockRepository.login()).thenReturn((org.modeshape.jcr.api.Session) mockSession);
         when(mockEvents.hasNext()).thenReturn(true, false);
         when(mockEvents.next()).thenReturn(mockEvent);
         testObserver = new SimpleObserver();

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <jgroups.version>3.5.0.Final</jgroups.version>
     <joda-time.version>2.4</joda-time.version>
     <logback.version>1.1.2</logback.version>
-    <modeshape.version>4.0.0.Beta1</modeshape.version>
+    <modeshape.version>4.0.0.Beta2</modeshape.version>
     <metrics.version>3.1.0</metrics.version>
     <sesame.version>2.7.13</sesame.version>
     <slf4j.version>1.7.7</slf4j.version>


### PR DESCRIPTION
PR for https://www.pivotaltracker.com/story/show/79523284

Updating to Beta2, which required some updates to the Session mock object.  I also updated FedoraNodesIT to add a pid to a test that was periodically failing without `mvn clean`.
