### PR TITLE
https://www.pivotaltracker.com/story/show/79728226

### DIFF
--- a/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/AbstractFedoraFileSystemConnectorIT.java
+++ b/fcrepo-connector-file/src/test/java/org/fcrepo/integration/connector/file/AbstractFedoraFileSystemConnectorIT.java
@@ -33,11 +33,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.modeshape.common.util.SecureHash.getHash;
 import static org.modeshape.common.util.SecureHash.Algorithm.SHA_1;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.Iterator;
@@ -64,6 +67,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -130,6 +134,9 @@ public abstract class AbstractFedoraFileSystemConnectorIT {
         return getProperty(PROP_TEST_DIR2);
     }
 
+    private static final Logger logger =
+            getLogger(AbstractFedoraFileSystemConnectorIT.class);
+
     /**
      * Sets a system property and ensures artifacts from previous tests are
      * cleaned up.
@@ -141,7 +148,6 @@ public abstract class AbstractFedoraFileSystemConnectorIT {
         // we configure the FedoraFileSystemFederation instances to
         // point to paths within the "target" directory.
         final File testDir1 = new File("target/test-classes/config/testing");
-        cleanUpJsonFilesFiles(testDir1);
         setProperty(PROP_TEST_DIR1, testDir1.getAbsolutePath());
 
         final File testDir2 = new File("target/test-classes/spring-test");
@@ -171,8 +177,13 @@ public abstract class AbstractFedoraFileSystemConnectorIT {
 
         // Clean up files persisted in previous runs
         while (iterator.hasNext()) {
-            if (!iterator.next().delete()) {
-                fail("Unable to delete work files from a previous test run");
+            final File f = iterator.next();
+            final String path = f.getAbsolutePath();
+            try {
+                Files.deleteIfExists(Paths.get(path));
+            } catch (IOException e) {
+                logger.error("Error in clean up", e);
+                fail("Unable to delete work files from a previous test run. File=" + path);
             }
         }
     }


### PR DESCRIPTION
The specific functionality that's causing the symptom noted in PT # 79728226 was introduced via commit https://github.com/fcrepo4/fcrepo4/commit/068c3460e7c302caba4e36a8abc216d02704fee2

Rationale for the PR:

ReadOnlyExternalPropertiesFedoraFileSystemConnectorIT fails when trying to delete a file generated when running
BasicReadWriteFedoraFileSystemConnectorIT. The former makes no use of this file, and hence shouldn't try to delete it (indirectly via AbstractFedoraFileSystemConnectorIT).

This fixes the specific build error that result from attempting to delete a file that's still held on by another Java process. The file lock was observed on Windows Java 7u67 (and 7u25). I used the Windows handle command to see that the file was indeed being held open by a java process. I was unable to get further details about which thread was holding the file open. As this seems to be a common problem on Windows, it's not clear to me whether this is worth investigating.
