### PR TITLE
Moved attaching Javadocs to release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -923,19 +923,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <reporting>
@@ -1126,6 +1113,19 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>1.4</version>


### PR DESCRIPTION
Moved the attaching of Javadocs to the release profile so they don't get built every time a `mvn install` is run. They can still be generated locally with `mvn site` or `mvn javadoc:javadoc`.

https://www.pivotaltracker.com/story/show/79040178
