### PR TITLE
Update SessionFactory to handle path parsing the correct way, with a hack for Grizzly's path handler behavior

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionFactory.java
@@ -199,7 +199,12 @@ public class SessionFactory {
      */
     protected String getEmbeddedId(
             final HttpServletRequest servletRequest, final Prefix prefix) {
-        final String requestPath = servletRequest.getRequestURI();
+        String requestPath = servletRequest.getPathInfo();
+
+        // http://stackoverflow.com/questions/18963562/grizzlys-request-getpathinfo-returns-always-null
+        if (requestPath == null && servletRequest.getContextPath().isEmpty()) {
+            requestPath = servletRequest.getRequestURI();
+        }
 
         String id = null;
         if (requestPath != null) {

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/session/SessionFactoryTest.java
@@ -83,7 +83,8 @@ public class SessionFactoryTest {
 
     @Test
     public void testGetSessionWithNullPath() throws RepositoryException {
-        when(mockRequest.getRequestURI()).thenReturn(null);
+        when(mockRequest.getPathInfo()).thenReturn(null);
+        when(mockRequest.getContextPath()).thenReturn("");
         when(mockRepo.login(any(Credentials.class))).thenReturn(mockSession);
         testObj.getSession(mockRequest);
         verify(mockRepo).login(any(ServletCredentials.class));
@@ -97,14 +98,14 @@ public class SessionFactoryTest {
 
     @Test
     public void testCreateSession() throws RepositoryException {
-        when(mockRequest.getRequestURI()).thenReturn("/some/path");
+        when(mockRequest.getPathInfo()).thenReturn("/some/path");
         testObj.createSession(mockRequest);
         verify(mockRepo).login(any(Credentials.class));
     }
 
     @Test
     public void testGetSessionFromTransaction() throws RepositoryException {
-        when(mockRequest.getRequestURI()).thenReturn("/tx:123/some/path");
+        when(mockRequest.getPathInfo()).thenReturn("/tx:123/some/path");
         when(mockTx.getSession()).thenReturn(mock(Session.class));
         when(mockTxService.getTransaction("123", null)).thenReturn(mockTx);
         final Session session = testObj.getSessionFromTransaction(mockRequest, "123");
@@ -113,7 +114,7 @@ public class SessionFactoryTest {
 
     @Test
     public void testGetSessionThrowException() throws RepositoryException {
-        when(mockRequest.getRequestURI()).thenReturn("/tx:123/some/path");
+        when(mockRequest.getPathInfo()).thenReturn("/tx:123/some/path");
         when(mockTx.getSession()).thenReturn(mock(Session.class));
         when(mockTxService.getTransaction("123", null)).thenThrow(
                 new TransactionMissingException(""));
@@ -132,7 +133,7 @@ public class SessionFactoryTest {
         final String fedoraUser = "fedoraUser";
         when(mockRequest.getUserPrincipal()).thenReturn(mockUser);
         when(mockUser.getName()).thenReturn(fedoraUser);
-        when(mockRequest.getRequestURI()).thenReturn("/tx:123/some/path");
+        when(mockRequest.getPathInfo()).thenReturn("/tx:123/some/path");
         when(mockTx.getSession()).thenReturn(txSession);
         when(mockTx.isAssociatedWithUser(eq(fedoraUser))).thenReturn(true);
         when(mockTxService.getTransaction("123", fedoraUser))
@@ -144,7 +145,7 @@ public class SessionFactoryTest {
 
     @Test
     public void testGetEmbeddedIdTx() {
-        when(mockRequest.getRequestURI()).thenReturn("/tx:123/some/path");
+        when(mockRequest.getPathInfo()).thenReturn("/tx:123/some/path");
         final String txId = testObj.getEmbeddedId(mockRequest, SessionFactory.Prefix.TX);
         assertEquals("txId should be 123", "123", txId);
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/80654132
