### PR TITLE
Patch for MODE-2343: Dispose of the observation manager's own listener when logging out a session

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionProvider.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/SessionProvider.java
@@ -16,6 +16,7 @@
 package org.fcrepo.http.commons.session;
 
 import static org.fcrepo.kernel.impl.services.TransactionServiceImpl.isInTransaction;
+import static org.modeshape.jcr.SessionUtils.unregisterObservationManager;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.inject.Inject;
@@ -64,6 +65,7 @@ public class SessionProvider implements Factory<Session> {
         LOGGER.trace("Disposing session {}", session);
 
         if (session.isLive() && !isInTransaction(session)) {
+            unregisterObservationManager(session);
             session.logout();
         }
     }

--- a/fcrepo-kernel-impl/src/main/java/org/modeshape/jcr/SessionUtils.java
+++ b/fcrepo-kernel-impl/src/main/java/org/modeshape/jcr/SessionUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.modeshape.jcr;
+
+import org.modeshape.jcr.bus.ChangeBus;
+import org.slf4j.Logger;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author cabeer
+ * @since 10/15/14
+ */
+public class SessionUtils {
+
+    /**
+     * No public constructor for utility classes
+     */
+    private SessionUtils() {
+
+    }
+
+    private static final Logger LOGGER = getLogger(SessionUtils.class);
+
+    /**
+     * Until MODE-2343 is fixed, we need to manually dispose of the ObservationManager listener.
+     *
+     * @param session
+     */
+    public static void unregisterObservationManager(final Session session) {
+        try {
+            getChangeBus(session).unregister(getObservationManager(session));
+        } catch (final RepositoryException e) {
+            LOGGER.info("Unable to dispose observation manager: {}", e);
+        }
+    }
+
+    private static JcrObservationManager getObservationManager(final Session session) throws RepositoryException {
+        return (JcrObservationManager) session.getWorkspace().getObservationManager();
+    }
+
+    private static ChangeBus getChangeBus(final Session session) {
+        return ((JcrRepository)session.getRepository()).changeBus();
+    }
+}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/80735796
