### PR TITLE
Exclude tombstone resources when getting a resource's children

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
@@ -172,7 +172,9 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
                 public boolean apply(final Node n) {
                     LOGGER.trace("Testing child node {}", n);
                     try {
-                        return (isInternalNode.apply(n) || n.getName().equals(JCR_CONTENT));
+                        return isInternalNode.apply(n)
+                                || n.getName().equals(JCR_CONTENT)
+                                || TombstoneImpl.hasMixin(n);
                     } catch (final RepositoryException e) {
                         throw new RepositoryRuntimeException(e);
                     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
@@ -638,4 +638,15 @@ public class FedoraResourceImplIT extends AbstractIT {
 
         assertEquals(resource, container.getChildren().next());
     }
+
+    @Test
+    public void testGetChildrenTombstonesAreHidden() throws RepositoryException {
+        final String pid = getRandomPid();
+        final FedoraObject container = objectService.findOrCreateObject(session, "/" + pid);
+        final FedoraResource resource = objectService.findOrCreateObject(session, "/" + pid + "/a");
+
+        resource.delete();
+
+        assertFalse(container.getChildren().hasNext());
+    }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/FedoraResourceImplTest.java
@@ -392,6 +392,15 @@ public class FedoraResourceImplTest {
     }
 
     @Test
+    public void testGetChildrenExcludesTombstones() throws RepositoryException {
+        when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
+        when(mockChild.isNodeType("fedora:tombstone")).thenReturn(true);
+        when(mockChild.getName()).thenReturn("x");
+        final Iterator<FedoraResource> children = testObj.getChildren();
+        assertFalse("Expected an empty iterator", children.hasNext());
+    }
+
+    @Test
     public void testGetChildrenExcludesJcrContent() throws RepositoryException {
         when(mockNode.getNodes()).thenReturn(nodeIterator(mockChild));
         when(mockChild.getName()).thenReturn(JCR_CONTENT);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/80962550
