### PR TITLE
Mark the hash-uri container as a pairtree node, exclude it from Resource...

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/FedoraResourceImpl.java
@@ -174,7 +174,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
                     try {
                         return isInternalNode.apply(n)
                                 || n.getName().equals(JCR_CONTENT)
-                                || TombstoneImpl.hasMixin(n);
+                                || TombstoneImpl.hasMixin(n)
+                                || n.getName().equals("#");
                     } catch (final RepositoryException e) {
                         throw new RepositoryRuntimeException(e);
                     }
@@ -217,7 +218,8 @@ public class FedoraResourceImpl extends JcrTools implements FedoraJcrTypes, Fedo
 
             Node container = getNode().getParent();
             while (container.getDepth() > 0) {
-                if (container.isNodeType(FEDORA_PAIRTREE) || container.isNodeType(FEDORA_DATASTREAM)) {
+                if (container.isNodeType(FEDORA_PAIRTREE)
+                        || container.isNodeType(FEDORA_DATASTREAM)) {
                     container = container.getParent();
                 } else {
                     return nodeConverter.convert(container);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -25,6 +25,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 import static org.fcrepo.jcr.FedoraJcrTypes.FEDORA_PAIRTREE;
+import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.getClosestExistingAncestor;
 import static org.modeshape.jcr.api.JcrConstants.NT_FOLDER;
 
 
@@ -39,7 +40,7 @@ public abstract class AbstractService implements Service {
                                     final String path,
                                     final String finalNodeType) throws RepositoryException {
 
-        final Node preexistingNode = getClosestPreexistingNode(session, path);
+        final Node preexistingNode = getClosestExistingAncestor(session, path);
 
         if (TombstoneImpl.hasMixin(preexistingNode)) {
             throw new TombstoneException(new TombstoneImpl(preexistingNode));
@@ -64,25 +65,4 @@ public abstract class AbstractService implements Service {
         }
     }
 
-    private Node getClosestPreexistingNode(final Session session,
-                                           final String path) throws RepositoryException {
-        final String[] pathSegments = path.replaceAll("^/+", "").replaceAll("/+$", "").split("/");
-
-        Node node = session.getRootNode();
-
-        final int len = pathSegments.length;
-        for (int i = 0; i != len; ++i) {
-            final String pathSegment = pathSegments[i];
-
-            if (node.hasNode(pathSegment)) {
-                // Find the existing node ...
-                node = node.getNode(pathSegment);
-            } else {
-                return node;
-            }
-
-        }
-
-        return node;
-    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtils.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static javax.jcr.PropertyType.REFERENCE;
@@ -144,5 +145,35 @@ public abstract class FedoraTypesUtils implements FedoraJcrTypes {
             }
         }
     };
+
+    /**
+     * Get the closest ancestor that current exists
+     *
+     * @param session
+     * @param path
+     * @return
+     * @throws RepositoryException
+     */
+    public static Node getClosestExistingAncestor(final Session session,
+                                                  final String path) throws RepositoryException {
+        final String[] pathSegments = path.replaceAll("^/+", "").replaceAll("/+$", "").split("/");
+
+        Node node = session.getRootNode();
+
+        final int len = pathSegments.length;
+        for (int i = 0; i != len; ++i) {
+            final String pathSegment = pathSegments[i];
+
+            if (node.hasNode(pathSegment)) {
+                // Find the existing node ...
+                node = node.getNode(pathSegment);
+            } else {
+                return node;
+            }
+
+        }
+
+        return node;
+    }
 
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraResourceImplIT.java
@@ -646,6 +646,14 @@ public class FedoraResourceImplIT extends AbstractIT {
         final FedoraResource resource = objectService.findOrCreateObject(session, "/" + pid + "/a");
 
         resource.delete();
+        assertFalse(container.getChildren().hasNext());
+    }
+
+    @Test
+    public void testGetChildrenHidesHashUris() throws RepositoryException {
+        final String pid = getRandomPid();
+        final FedoraObject container = objectService.findOrCreateObject(session, "/" + pid);
+        final FedoraResource resource = objectService.findOrCreateObject(session, "/" + pid + "/#/a");
 
         assertFalse(container.getChildren().hasNext());
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtilsTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.fcrepo.kernel.impl.utils;
 
+import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.getClosestExistingAncestor;
 import static org.fcrepo.kernel.services.functions.JcrPropertyFunctions.isBinaryContentProperty;
 import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.isReferenceProperty;
 import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.isInternalProperty;
@@ -136,6 +137,12 @@ public class FedoraTypesUtilsTest {
 
     @Mock
     private Property mockProperty;
+
+    @Mock
+    private Node mockRootNode;
+
+    @Mock
+    private Node mockContainer;
 
     @Before
     public void setUp() {
@@ -291,6 +298,37 @@ public class FedoraTypesUtilsTest {
         assertEquals("Found wrong Value!", testIterator.next(), mockValue);
         assertEquals("Found wrong Value!", testIterator.next(), mockValue2);
 
+    }
+
+    @Test
+    public void testGetClosestExistingAncestorRoot() throws RepositoryException {
+        when(mockSession.getRootNode()).thenReturn(mockRootNode);
+        when(mockRootNode.hasNode(anyString())).thenReturn(false);
+
+        final Node closestExistingAncestor = getClosestExistingAncestor(mockSession, "/some/path");
+        assertEquals(mockRootNode, closestExistingAncestor);
+    }
+
+    @Test
+    public void testGetClosestExistingAncestorContainer() throws RepositoryException {
+        when(mockSession.getRootNode()).thenReturn(mockRootNode);
+        when(mockRootNode.hasNode("some")).thenReturn(true);
+        when(mockRootNode.getNode("some")).thenReturn(mockContainer);
+
+        final Node closestExistingAncestor = getClosestExistingAncestor(mockSession, "/some/path");
+        assertEquals(mockContainer, closestExistingAncestor);
+    }
+
+    @Test
+    public void testGetClosestExistingAncestorNode() throws RepositoryException {
+        when(mockSession.getRootNode()).thenReturn(mockRootNode);
+        when(mockRootNode.hasNode("some")).thenReturn(true);
+        when(mockRootNode.getNode("some")).thenReturn(mockContainer);
+        when(mockContainer.hasNode("path")).thenReturn(true);
+        when(mockContainer.getNode("path")).thenReturn(mockNode);
+
+        final Node closestExistingAncestor = getClosestExistingAncestor(mockSession, "/some/path");
+        assertEquals(mockNode, closestExistingAncestor);
     }
 
 }


### PR DESCRIPTION
...#getChildren() requests, and ensure clients can't create 'deep' hash uri resources from a request body

https://www.pivotaltracker.com/story/show/81034970
