### PR TITLE
Non-rdf resources emit /fcr:metadata events instead of /jcr:content

### DIFF
--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
@@ -16,6 +16,7 @@
 package org.fcrepo.jms.headers;
 
 import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Set;
@@ -95,8 +96,8 @@ public class DefaultMessageFactory implements JMSEventMessageFactory {
         final Message message = jmsSession.createMessage();
         message.setLongProperty(TIMESTAMP_HEADER_NAME, jcrEvent.getDate());
         String path = jcrEvent.getPath();
-        if ( path.endsWith("jcr:content") ) {
-            path = path.replaceAll("jcr:content","fcr:metadata");
+        if ( path.endsWith("/" + JCR_CONTENT) ) {
+            path = path.replaceAll("/" + JCR_CONTENT,"");
         }
         message.setStringProperty(IDENTIFIER_HEADER_NAME, path);
         message.setStringProperty(EVENT_TYPE_HEADER_NAME, getEventURIs( jcrEvent

--- a/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
@@ -26,6 +26,7 @@ import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 
 import java.util.Set;
 
@@ -81,9 +82,8 @@ public class DefaultMessageFactoryTest {
     @Test
     public void testBuildMessageContent() throws RepositoryException, JMSException {
         final String testPath = "/path/to/resource";
-        final Message msg = doTestBuildMessage("base-url", testPath + "/jcr:content");
-        assertEquals("Got wrong identifier in message!", testPath + "/fcr:metadata",
-                msg.getStringProperty(IDENTIFIER_HEADER_NAME));
+        final Message msg = doTestBuildMessage("base-url", testPath + "/" + JCR_CONTENT);
+        assertEquals("Got wrong identifier in message!", testPath, msg.getStringProperty(IDENTIFIER_HEADER_NAME));
     }
 
     private Message doTestBuildMessage(final String baseUrl, final String id) throws RepositoryException, JMSException {


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/81279166
