### PR TITLE
Leniently handle non-well-formed data and faithfully reproduce it on output

### DIFF
--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/MiscExamplesIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/MiscExamplesIT.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.rdf;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * @author cabeer
+ */
+public class MiscExamplesIT extends AbstractIntegrationRdfIT {
+
+
+    @Test
+    public void testSyntacticallyInvalidDate() throws IOException {
+        createLDPRSAndCheckResponse(getRandomUniquePid(), "<> <info:some/property> \"dunno\"^^<http://www.w3" +
+                ".org/2001/XMLSchema#dateTime>");
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/converters/ValueConverter.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/converters/ValueConverter.java
@@ -122,7 +122,13 @@ public class ValueConverter extends Converter<Value, RDFNode> {
 
             final Literal literal = resource.asLiteral();
             final RDFDatatype dataType = literal.getDatatype();
-            final Object rdfValue = literal.getValue();
+            final Object rdfValue;
+
+            if (literal.asNode().getLiteral().isWellFormed()) {
+                rdfValue = literal.getValue();
+            } else {
+                rdfValue = literal.getLexicalForm();
+            }
 
             if (dataType == null && rdfValue instanceof String
                     || (dataType != null && dataType.equals(XSDDatatype.XSDstring))) {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/converters/ValueConverterTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/converters/ValueConverterTest.java
@@ -90,6 +90,7 @@ public class ValueConverterTest {
                 {ResourceFactory.createTypedLiteral(true)},
                 {ResourceFactory.createResource("info:x")},
                 {ResourceFactory.createTypedLiteral("2014-10-24T01:23:45Z", XSDDatatype.XSDdateTime)},
+                {ResourceFactory.createTypedLiteral("some-invalid-data", XSDDatatype.XSDdateTime)},
                 // Types outside the JCR type system boundaries:
                 {ResourceFactory.createTypedLiteral("2014-10-24", XSDDatatype.XSDdate)},
                 {ResourceFactory.createTypedLiteral("01:02:03", XSDDatatype.XSDtime)},


### PR DESCRIPTION
Here's one option for addressing https://www.pivotaltracker.com/story/show/81380614

The current behavior (in `cbeer-rdf-types`, not sure about `master`) is to error on non-well-formed data. This is the other options. The user wants to store it, and we let them.

Or, we do tons more work and make it opt-in the repository configuration, or get really clever and make it opt-in at the request

@ajs6f ?
