### PR TITLE
Use methods on FedoraResource instead of getting the JCR Node

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtils.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/utils/FedoraTypesUtils.java
@@ -74,29 +74,7 @@ public abstract class FedoraTypesUtils implements FedoraJcrTypes {
 
                 @Override
                 public boolean apply(final FedoraResource f) {
-                    try {
-
-                        if (f.hasType(FROZEN_NODE)) {
-                            return true;
-                        }
-
-                        final Node node = f.getNode();
-
-                        if (node != null) {
-                            final String path = node.getPath();
-
-                            if (path == null) {
-                                return false;
-                            }
-
-                            if (path.contains(JCR_FROZEN_NODE)) {
-                                return true;
-                            }
-                        }
-                        return false;
-                    } catch (final RepositoryException e) {
-                        throw new RepositoryRuntimeException(e);
-                    }
+                    return f.hasType(FROZEN_NODE) || f.getPath().contains(JCR_FROZEN_NODE);
                 }
      };
 

--- a/fcrepo-serialization/src/main/java/org/fcrepo/serialization/JcrXmlSerializer.java
+++ b/fcrepo-serialization/src/main/java/org/fcrepo/serialization/JcrXmlSerializer.java
@@ -63,7 +63,7 @@ public class JcrXmlSerializer extends BaseFedoraObjectSerializer {
         final Node node = obj.getNode();
         // jcr/xml export system view implemented for noRecurse:
         // exportSystemView(String absPath, OutputStream out, boolean skipBinary, boolean noRecurse)
-        node.getSession().exportSystemView(node.getPath(), out, skipBinary, !recurse);
+        node.getSession().exportSystemView(obj.getPath(), out, skipBinary, !recurse);
     }
 
     @Override

--- a/fcrepo-serialization/src/test/java/org/fcrepo/serialization/JcrXmlSerializerTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/serialization/JcrXmlSerializerTest.java
@@ -58,9 +58,9 @@ public class JcrXmlSerializerTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        when(mockObject.getPath()).thenReturn(testPath);
         when(mockObject.getNode()).thenReturn(mockNode);
         when(mockNode.getSession()).thenReturn(mockSession);
-        when(mockNode.getPath()).thenReturn(testPath);
     }
 
     @Test


### PR DESCRIPTION
These were the egregious uses outside of -kernel.

https://www.pivotaltracker.com/story/show/81689998
