### PR TITLE
Use message/external-body MIME type for registering 'redirect' binaries

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -265,7 +265,7 @@ public class FedoraLdp extends ContentExposingResource {
 
         if (resource instanceof FedoraBinary) {
             replaceResourceBinaryWithStream((FedoraBinary) resource,
-                    requestBodyStream, contentDisposition, contentType.toString(), checksum);
+                    requestBodyStream, contentDisposition, requestContentType, checksum);
         } else if (isRdfContentType(contentType.toString())) {
             try {
                 replaceResourceWithStream(resource, requestBodyStream, contentType, resourceTriples);
@@ -417,7 +417,7 @@ public class FedoraLdp extends ContentExposingResource {
                 LOGGER.trace("Created a datastream and have a binary payload.");
 
                 replaceResourceBinaryWithStream((FedoraBinary) result,
-                        requestBodyStream, contentDisposition, contentTypeString, checksum);
+                        requestBodyStream, contentDisposition, requestContentType, checksum);
 
             } else if (contentTypeString.equals(contentTypeSPARQLUpdate)) {
                 LOGGER.trace("Found SPARQL-Update content, applying..");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -18,6 +18,7 @@ package org.fcrepo.integration.http.api;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Integer.parseInt;
 import static java.util.UUID.randomUUID;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -132,6 +133,7 @@ public abstract class AbstractResourceIT {
                 new HttpPut(serverAddress + pid + "/" + ds);
 
         put.setEntity(new StringEntity(content));
+        put.setHeader("Content-Type", TEXT_PLAIN);
         return put;
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraBinaryImplIT.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/integration/kernel/impl/FedoraBinaryImplIT.java
@@ -125,6 +125,30 @@ public class FedoraBinaryImplIT extends AbstractIT {
     }
 
     @Test
+    public void testDatastreamContentType() throws IOException,
+            RepositoryException,
+            InvalidChecksumException {
+        final Session session = repo.login();
+        containerService.findOrCreate(session, "/testDatastreamObject");
+
+        binaryService.findOrCreate(session, "/testDatastreamObject/testDatastreamNode1").setContent(
+                new ByteArrayInputStream("asdf".getBytes()),
+                "some/mime-type; with=params",
+                null,
+                null,
+                null
+        );
+
+        session.save();
+
+        final FedoraBinary ds = binaryService.findOrCreate(session,
+                "/testDatastreamObject/testDatastreamNode1");
+
+        assertEquals("some/mime-type; with=params", ds.getMimeType());
+
+    }
+
+    @Test
     public void testDatastreamContentDigestAndLength() throws IOException,
             RepositoryException,
             InvalidChecksumException {


### PR DESCRIPTION
Here's an idea for handling "redirect" binaries. I think it's a nice compromise between the empty-binary-with-a-special-property and creating a whole new type of thing.

Plus, I don't think we abuse the MIME type too much: https://tools.ietf.org/html/rfc2017

https://www.pivotaltracker.com/story/show/81770804
