### PR TITLE
LDP Transform should return an array rather than a single JSON object

### DIFF
--- a/fcrepo-transform/src/main/java/org/fcrepo/transform/transformations/LDPathTransform.java
+++ b/fcrepo-transform/src/main/java/org/fcrepo/transform/transformations/LDPathTransform.java
@@ -55,7 +55,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @author cbeer
  */
-public class LDPathTransform implements Transformation<Map<String, Collection<Object>>>  {
+public class LDPathTransform implements Transformation<List<Map<String, Collection<Object>>>>  {
 
     public static final String CONFIGURATION_FOLDER = "/fedora:system/fedora:transform/fedora:ldpath/";
 
@@ -135,7 +135,7 @@ public class LDPathTransform implements Transformation<Map<String, Collection<Ob
     }
 
     @Override
-    public Map<String, Collection<Object>> apply(final RdfStream stream) {
+    public List<Map<String, Collection<Object>>> apply(final RdfStream stream) {
         try {
             final LDPath<RDFNode> ldpathForResource =
                 getLdpathResource(stream);
@@ -146,7 +146,7 @@ public class LDPathTransform implements Transformation<Map<String, Collection<Ob
                 ldpathForResource.programQuery(context, new InputStreamReader(
                         query));
 
-            return transformLdpathOutputToSomethingSerializable(wildcardCollection);
+            return ImmutableList.of(transformLdpathOutputToSomethingSerializable(wildcardCollection));
         } catch (final LDPathParseException e) {
             throw new RuntimeException(e);
         }

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/FedoraTransformIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/FedoraTransformIT.java
@@ -72,7 +72,7 @@ public class FedoraTransformIT extends AbstractResourceIT {
         final JsonNode rootNode = new ObjectMapper().readTree(new JsonFactory().createParser(content));
 
         assertEquals("Failed to retrieve correct identifier in JSON!", serverAddress + "/" + pid,
-                rootNode.get("id").elements().next().asText());
+                rootNode.get(0).get("id").elements().next().asText());
 
     }
 
@@ -99,7 +99,7 @@ public class FedoraTransformIT extends AbstractResourceIT {
         final JsonNode rootNode = new ObjectMapper().readTree(new JsonFactory().createParser(content));
 
         assertEquals("Failed to retrieve correct identifier in JSON!", serverAddress + "/" + pid, rootNode
-                .get("id").elements().next().asText());
+                .get(0).get("id").elements().next().asText());
 
     }
 }

--- a/fcrepo-transform/src/test/java/org/fcrepo/integration/LDPathServiceIT.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/integration/LDPathServiceIT.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.List;
 
 import static org.fcrepo.kernel.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
@@ -87,9 +88,13 @@ public class LDPathServiceIT {
         final Resource topic = subjects.reverse().convert(object);
         final RdfStream triples = object.getTriples(subjects, PropertiesRdfContext.class)
                                         .topic(topic.asNode());
-        final Map<String, Collection<Object>> stuff = testObj.apply(triples);
+        final List<Map<String, Collection<Object>>> list = testObj.apply(triples);
 
-        assertNotNull("Failed to retrieve results!", stuff);
+        assertNotNull("Failed to retrieve results!", list);
+
+        assertTrue("List didn't contain a result", list.size() == 1);
+
+        final Map<String, Collection<Object>> stuff = list.get(0);
 
         assertTrue("Results didn't contain an identifier!", stuff.containsKey("id"));
         assertTrue("Results didn't contain a title!", stuff.containsKey("title"));

--- a/fcrepo-transform/src/test/java/org/fcrepo/transform/transformations/LDPathTransformTest.java
+++ b/fcrepo-transform/src/test/java/org/fcrepo/transform/transformations/LDPathTransformTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.List;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
@@ -141,7 +142,8 @@ public class LDPathTransformTest {
         final InputStream testReader = new ByteArrayInputStream("title = dc:title :: xsd:string ;".getBytes());
 
         testObj = new LDPathTransform(testReader);
-        final Map<String,Collection<Object>> stringCollectionMap = testObj.apply(rdfStream);
+        final List<Map<String,Collection<Object>>> stringCollectionMapList = testObj.apply(rdfStream);
+        final Map<String,Collection<Object>> stringCollectionMap = stringCollectionMapList.get(0);
 
         assert(stringCollectionMap != null);
         assertEquals(1, stringCollectionMap.size());


### PR DESCRIPTION
this makes it possible to send responses directly to Solr
