### PR TITLE
Improved error message for cases of invalid or missing namespaces.

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpResourceConverter.java
@@ -27,6 +27,7 @@ import static org.fcrepo.kernel.impl.identifiers.NodeResourceConverter.nodeConve
 import static org.fcrepo.kernel.impl.services.TransactionServiceImpl.getCurrentTransactionId;
 import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.getClosestExistingAncestor;
 import static org.fcrepo.kernel.impl.utils.FedoraTypesUtils.isFrozenNode;
+import static org.fcrepo.kernel.utils.NamespaceTools.validatePath;
 import static org.modeshape.jcr.api.JcrConstants.JCR_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.web.context.ContextLoader.getCurrentWebApplicationContext;
@@ -125,6 +126,7 @@ public class HttpResourceConverter extends IdentifierConverter<Resource,FedoraRe
             throw new IdentifierConversionException("Asked to translate a resource " + resource
                     + " that doesn't match the URI template");
         } catch (final RepositoryException e) {
+            validatePath(session, path);
             try {
                 if ( e instanceof PathNotFoundException ) {
                     final Node preexistingNode = getClosestExistingAncestor(session, path);

--- a/fcrepo-kernel/src/main/java/org/fcrepo/kernel/utils/NamespaceTools.java
+++ b/fcrepo-kernel/src/main/java/org/fcrepo/kernel/utils/NamespaceTools.java
@@ -17,8 +17,13 @@ package org.fcrepo.kernel.utils;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.jcr.NamespaceException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.fcrepo.kernel.exception.FedoraInvalidNamespaceException;
+import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.modeshape.jcr.api.NamespaceRegistry;
 
 import com.google.common.base.Function;
@@ -47,4 +52,46 @@ public abstract class NamespaceTools {
         }
 
     };
+
+    /**
+     * Validate resource path for unregistered namespace prefixes
+     *
+     * @param session the JCR session to use
+     * @param path the absolute path to the object
+     * @throws org.fcrepo.kernel.exception.FedoraInvalidNamespaceException on unregistered namespaces
+     * @throws org.fcrepo.kernel.exception.RepositoryRuntimeException
+     */
+    public static void validatePath(final Session session, final String path) {
+
+        final javax.jcr.NamespaceRegistry namespaceRegistry;
+        try {
+            namespaceRegistry =
+                    session.getWorkspace().getNamespaceRegistry();
+            checkNotNull(namespaceRegistry,
+                    "Couldn't find namespace registry in repository!");
+        } catch (final RepositoryException e) {
+            throw new RepositoryRuntimeException(e);
+        }
+
+        final String relPath = path.replaceAll("^/+", "").replaceAll("/+$", "");
+        final String[] pathSegments = relPath.split("/");
+        for (final String segment : pathSegments) {
+            if (segment.length() > 0 && segment.contains(":") &&
+                    segment.substring(0, segment.indexOf(":")) != "fedora") {
+                final String prefix = segment.substring(0, segment.indexOf(":"));
+                if (prefix.length() == 0) {
+                    throw new FedoraInvalidNamespaceException(
+                            String.format("Unable to identify namespace for (%s)", segment));
+                }
+                try {
+                    namespaceRegistry.getURI(prefix);
+                } catch (final NamespaceException e) {
+                    throw new FedoraInvalidNamespaceException(
+                            String.format("The namespace prefix (%s) has not been registered", prefix), e);
+                } catch (final RepositoryException e) {
+                    throw new RepositoryRuntimeException(e);
+                }
+            }
+        }
+    }
 }

--- a/fcrepo-kernel/src/test/java/org/fcrepo/kernel/utils/NamespaceToolsTest.java
+++ b/fcrepo-kernel/src/test/java/org/fcrepo/kernel/utils/NamespaceToolsTest.java
@@ -16,17 +16,22 @@
 package org.fcrepo.kernel.utils;
 
 import static org.fcrepo.kernel.utils.NamespaceTools.getNamespaceRegistry;
+import static org.fcrepo.kernel.utils.NamespaceTools.validatePath;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import javax.jcr.NamespaceException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
 
+import org.fcrepo.kernel.exception.FedoraInvalidNamespaceException;
+import org.fcrepo.kernel.exception.RepositoryRuntimeException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.modeshape.jcr.api.NamespaceRegistry;
 
 /**
  * <p>NamespaceToolsTest class.</p>
@@ -44,15 +49,56 @@ public class NamespaceToolsTest {
     @Mock
     private Workspace mockWork;
 
+    @Mock
+    private NamespaceRegistry mockNamespaceRegistry;
+
     @Before
-    public void setUp() {
+    public void setUp() throws RepositoryException {
         initMocks(this);
+        when(mockNode.getSession()).thenReturn(mockSession);
+        when(mockSession.getWorkspace()).thenReturn(mockWork);
     }
 
     @Test
     public void testFunction() throws RepositoryException {
-        when(mockNode.getSession()).thenReturn(mockSession);
-        when(mockSession.getWorkspace()).thenReturn(mockWork);
         getNamespaceRegistry.apply(mockNode);
     }
+
+    @Test (expected = NullPointerException.class)
+    public void testNullNamespaceRegistry() {
+        validatePath(mockSession, "irrelevant");
+    }
+
+    @Test (expected = RepositoryRuntimeException.class)
+    public void testWrapsRepositoryException() {
+        when(mockSession.getWorkspace()).thenThrow(new RepositoryRuntimeException(""));
+        validatePath(mockSession, "irrelevant");
+    }
+
+    @Test
+    public void testValidatePathWithValidNamespace() throws RepositoryException {
+        when(mockWork.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
+        validatePath(mockSession, "easy/valid:test");
+    }
+
+    @Test (expected = FedoraInvalidNamespaceException.class)
+    public void testValidatePathWithUnregisteredNamespace() throws RepositoryException {
+        when(mockWork.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
+        when(mockNamespaceRegistry.getURI("invalid")).thenThrow(new NamespaceException());
+        validatePath(mockSession, "easy/invalid:test");
+    }
+
+    @Test (expected = FedoraInvalidNamespaceException.class)
+    public void testValidatePathWithNoNamespace() throws RepositoryException {
+        when(mockWork.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
+        validatePath(mockSession, "easy/:test");
+    }
+
+    @Test (expected = RepositoryRuntimeException.class)
+    public void testWrapsRepositoryExceptionFromNamespaceRegistry() throws RepositoryException {
+        when(mockWork.getNamespaceRegistry()).thenReturn(mockNamespaceRegistry);
+        when(mockNamespaceRegistry.getURI("broken")).thenThrow(new RepositoryException());
+        validatePath(mockSession, "test/a/broken:namespace-registry");
+    }
+
 }


### PR DESCRIPTION
Since grizzly eats the entity from the jersey 2 responses, I couldn't easily write an integration test.

You can test this using curl:
curl -v -H "Content-Type: text/turtle" -X PUT --data-binary "@u.txt" "http://localhost:8080/rest/test/te/st/12/3/test123"

where u.txt is:
`
<http://localhost:8080/rest/test/te/st/12/3/test123> <http://fedora.info/definitions/v4/rels-ext#isPartOf> <http://localhost:8080/rest/test/sa/mp/le/:b/sample_batch_id>
`

You can test a similar case by changing u.txt to:
`
<http://localhost:8080/rest/test/te/st/12/3/test123> <http://fedora.info/definitions/v4/rels-ext#isPartOf> <http://localhost:8080/rest/test/sa/mp/le/unregistered:b/sample_batch_id>
`
