### PR TITLE
Added an ExceptionMapper to propagate BadRequestException messages to th...

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/BadRequestExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/BadRequestExceptionMapper.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2014 DuraSpace, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import org.slf4j.Logger;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.status;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * For generic BadRequestExceptions.
+ *
+ * @author md5wz
+ * @since November 18, 2014
+ */
+@Provider
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+
+    private static final Logger LOGGER = getLogger(BadRequestExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final BadRequestException e) {
+        LOGGER.trace("BadRequestExceptionMapper caught and exception: {}", e.getMessage());
+        return status(BAD_REQUEST).entity(e.getMessage()).build();
+    }
+
+}


### PR DESCRIPTION
...e UI.

Should we be concerned with the quality of other messages that may be the result of this change?  While I doubt they could be a worse user experience than no message, they may include things like references to JCR.  
