### PR TITLE
Reject fedora resource property update that contains fcr namespace

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -922,6 +922,22 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testIngestWithSparqlQueryJcrNS() throws Exception {
+        final HttpPost method = postObjMethod("");
+        method.addHeader("Content-Type", "application/sparql-update");
+        final BasicHttpEntity entity = new BasicHttpEntity();
+        entity.setContent(new ByteArrayInputStream(
+                ("PREFIX fcr: <http://xmlns.com/my-fcr/> "
+                        + "INSERT { <> <http://purl.org/dc/elements/1.1/title> \"this is a title\" } WHERE {}")
+                        .getBytes()));
+        method.setEntity(entity);
+        final HttpResponse response = client.execute(method);
+        final int status = response.getStatusLine().getStatusCode();
+        assertFalse("Got a CREATED response with jcr namspace prefix!",
+                CREATED.getStatusCode() == status);
+    }
+
+    @Test
     public void testIngestWithNewAndGraph() throws Exception {
         final HttpPost method = postObjMethod("");
         method.addHeader("Content-Type", "application/n3");
@@ -1515,6 +1531,28 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 "<" + subjectURI + "> <info:rubydora#label> \"asdfg\" \\.",
                 DOTALL).matcher(content).find());
 
+    }
+
+    @Test
+    public void testUpdateWithSparqlQueryJcrNS() throws Exception {
+        final HttpResponse createResponse = createObject("");
+        final String subjectURI = createResponse.getFirstHeader("Location").getValue();
+        final HttpPatch updateObjectGraphMethod = new HttpPatch(subjectURI);
+
+        updateObjectGraphMethod.addHeader("Content-Type",
+                "application/sparql-update");
+
+        final BasicHttpEntity e = new BasicHttpEntity();
+        e.setContent(new ByteArrayInputStream(
+                ("PREFIX fcr: <http://xmlns.com/my-fcr/> "
+                        + "INSERT { <" + subjectURI + "> <info:rubydora#label> \"asdfg\" } WHERE {}")
+                        .getBytes()));
+
+        updateObjectGraphMethod.setEntity(e);
+        final HttpResponse response = client.execute(updateObjectGraphMethod);
+        final int status = response.getStatusLine().getStatusCode();
+        assertFalse("Got updated response with jcr namspace prefix!\n",
+                NO_CONTENT.getStatusCode() == status);
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/converters/PropertyConverter.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/converters/PropertyConverter.java
@@ -20,6 +20,8 @@ import com.google.common.base.Converter;
 import com.google.common.collect.ImmutableBiMap;
 import com.hp.hpl.jena.rdf.model.Property;
 import com.hp.hpl.jena.rdf.model.Resource;
+
+import org.fcrepo.kernel.exception.FedoraInvalidNamespaceException;
 import org.modeshape.jcr.api.NamespaceRegistry;
 import org.modeshape.jcr.api.Namespaced;
 import org.slf4j.Logger;
@@ -117,9 +119,14 @@ public class PropertyConverter extends Converter<javax.jcr.Property, Property> {
 
         final String prefix;
 
-        final String namespace = getJcrNamespaceForRDFNamespace(rdfNamespace);
-
         assert (namespaceRegistry != null);
+
+        // reject if update request contains any fcr namespacess
+        if (namespaceMapping != null && namespaceMapping.containsKey("fcr")) {
+            throw new FedoraInvalidNamespaceException("Invalid fcr namespace properties " + predicate + ".");
+        }
+
+        final String namespace = getJcrNamespaceForRDFNamespace(rdfNamespace);
 
         if (namespaceRegistry.isRegisteredUri(namespace)) {
             LOGGER.debug("Discovered namespace: {} in namespace registry.",namespace);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/converters/PropertyConverterTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/rdf/converters/PropertyConverterTest.java
@@ -18,6 +18,8 @@ package org.fcrepo.kernel.impl.rdf.converters;
 
 import com.hp.hpl.jena.rdf.model.Property;
 import com.hp.hpl.jena.shared.InvalidPropertyURIException;
+
+import org.fcrepo.kernel.exception.FedoraInvalidNamespaceException;
 import org.fcrepo.kernel.impl.utils.JcrPropertyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +31,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.Workspace;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createProperty;
@@ -107,6 +110,14 @@ public class PropertyConverterTest {
         final Property p = createProperty(REPOSITORY_NAMESPACE, "uuid");
         assertEquals("jcr:uuid", PropertyConverter.getPropertyNameFromPredicate(mockNode, p, EMPTY_NAMESPACE_MAP));
 
+    }
+
+    @Test(expected = FedoraInvalidNamespaceException.class)
+    public final void shouldRejectFcrPredicates() throws RepositoryException {
+        final Property p = createProperty(mockUri, "fcr");
+        final Map<String, String> nsMap = new HashMap<String, String>();
+        nsMap.put("fcr", mockUri);
+        PropertyConverter.getPropertyNameFromPredicate(mockNode, p, nsMap);
     }
 
     @Test


### PR DESCRIPTION
https://jira.duraspace.org/browse/FCREPO-1244
Okay, I've reimplemented the feature down as suggested in method getPropertyNameFromPredicate https://github.com/fcrepo4/fcrepo4/blob/master/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/rdf/converters/PropertyConverter.java#L110.
