### PR TITLE
remove trailing slash from jms baseUrl header

### DIFF
--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/headers/DefaultMessageFactory.java
@@ -74,7 +74,11 @@ public class DefaultMessageFactory implements JMSEventMessageFactory {
             final String userdata = event.getUserData();
             if (!StringUtils.isBlank(userdata)) {
                 final JsonObject json = new JsonParser().parse(userdata).getAsJsonObject();
-                this.baseURL = json.get("baseURL").getAsString();
+                String url = json.get("baseURL").getAsString();
+                while (url.endsWith("/")) {
+                    url = url.substring(0, url.length() - 1);
+                }
+                this.baseURL = url;
                 log.debug("MessageFactory baseURL: {}", baseURL);
 
             } else {

--- a/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/jms/headers/DefaultMessageFactoryTest.java
@@ -89,7 +89,7 @@ public class DefaultMessageFactoryTest {
     @Test
     public void testBuildMessageContent() throws RepositoryException, JMSException {
         final String testPath = "/path/to/resource";
-        final Message msg = doTestBuildMessage("base-url", testPath + "/" + JCR_CONTENT);
+        final Message msg = doTestBuildMessage("base-url/", testPath + "/" + JCR_CONTENT);
         assertEquals("Got wrong identifier in message!", testPath, msg.getStringProperty(IDENTIFIER_HEADER_NAME));
     }
 
@@ -110,9 +110,15 @@ public class DefaultMessageFactoryTest {
         when(mockEvent.getProperties()).thenReturn(singleton(prop));
 
         final Message msg = testDefaultMessageFactory.getMessage(mockEvent, mockSession);
+
+        String trimmedBaseUrl = baseUrl;
+        while (!StringUtils.isBlank(trimmedBaseUrl) && trimmedBaseUrl.endsWith("/")) {
+            trimmedBaseUrl = trimmedBaseUrl.substring(0, trimmedBaseUrl.length() - 1);
+        }
+
         assertEquals("Got wrong date in message!", testDate, (Long) msg.getLongProperty(TIMESTAMP_HEADER_NAME));
         assertEquals("Got wrong type in message!", testReturnType, msg.getStringProperty(EVENT_TYPE_HEADER_NAME));
-        assertEquals("Got wrong base-url in message", baseUrl, msg.getStringProperty(BASE_URL_HEADER_NAME));
+        assertEquals("Got wrong base-url in message", trimmedBaseUrl, msg.getStringProperty(BASE_URL_HEADER_NAME));
         assertEquals("Got wrong property in message", prop, msg.getStringProperty(PROPERTIES_HEADER_NAME));
         return msg;
     }


### PR DESCRIPTION
This addresses https://jira.duraspace.org/browse/FCREPO-1271

The JMS headers are currently sent such that the baseUrl value has a trailing slash and the identifier header has an initial slash. This makes it cumbersome for clients to compose the two values.

This PR strips off any trailing slash from the baseUrl value before sending a message to a broker.
