### PR TITLE
Handle ldp:isMemberOfRelation on IndirectContainers

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -168,6 +168,8 @@ public final class RdfLexicon {
             createProperty(LDP_NAMESPACE + "membershipResource");
     public static final Property HAS_MEMBER_RELATION =
             createProperty(LDP_NAMESPACE + "hasMemberRelation");
+    public static final Property IS_MEMBER_OF_RELATION =
+            createProperty(LDP_NAMESPACE + "isMemberOfRelation");
     public static final Property CONTAINS =
         createProperty(LDP_NAMESPACE + "contains");
     public static final Property LDP_MEMBER =

--- a/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpIsMemberOfRdfContext.java
+++ b/fcrepo-kernel-modeshape/src/main/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpIsMemberOfRdfContext.java
@@ -44,6 +44,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.modeshape.rdf.converters.PropertyConverter.getPropertyNameFromPredicate;
 import static org.fcrepo.kernel.modeshape.rdf.impl.ReferencesRdfContext.REFERENCE_TYPES;
 import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getJcrNode;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.getReferencePropertyName;
 import static org.fcrepo.kernel.modeshape.utils.StreamUtils.iteratorToStream;
 
 /**
@@ -102,8 +103,13 @@ public class LdpIsMemberOfRdfContext extends NodeRdfContext {
         if (insertedContainerProperty.equals(MEMBER_SUBJECT.getURI())) {
             return of(create(subject(), memberRelation.asNode(), membershipResource));
         } else if (container.hasType(LDP_INDIRECT_CONTAINER)) {
-            final String insertedContentProperty = getPropertyNameFromPredicate(getJcrNode(resource()), createResource
+            String insertedContentProperty = getPropertyNameFromPredicate(getJcrNode(resource()), createResource
                     (insertedContainerProperty), null);
+
+            // The insertedContentProperty may be a pseudo reference property
+            if (resource().hasProperty(getReferencePropertyName(insertedContentProperty))) {
+                insertedContentProperty = getReferencePropertyName(insertedContentProperty);
+            }
 
             if (resource().hasProperty(insertedContentProperty)) {
                 return iteratorToStream(new PropertyValueIterator(

--- a/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpIsMemberOfRdfContextTest.java
+++ b/fcrepo-kernel-modeshape/src/test/java/org/fcrepo/kernel/modeshape/rdf/impl/LdpIsMemberOfRdfContextTest.java
@@ -48,6 +48,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.LDP_IS_MEMBER_OF_RELATION;
 import static org.fcrepo.kernel.api.FedoraTypes.LDP_MEMBER_RESOURCE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.modeshape.identifiers.NodeResourceConverter.nodeToResource;
+import static org.fcrepo.kernel.modeshape.utils.FedoraTypesUtils.REFERENCE_PROPERTY_SUFFIX;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -221,8 +222,9 @@ public class LdpIsMemberOfRdfContextTest {
         when(mockNamespaceRegistry.isRegisteredUri("some:")).thenReturn(true);
         when(mockNamespaceRegistry.getPrefix("some:")).thenReturn("some");
 
-        when(mockResource.hasProperty("some:relation")).thenReturn(true);
-        when(mockResourceNode.getProperty("some:relation")).thenReturn(mockRelationProperty);
+        when(mockResource.hasProperty("some:relation" + REFERENCE_PROPERTY_SUFFIX)).thenReturn(true);
+        when(mockResourceNode.getProperty("some:relation" + REFERENCE_PROPERTY_SUFFIX))
+                .thenReturn(mockRelationProperty);
         when(mockRelationProperty.isMultiple()).thenReturn(false);
         when(mockRelationProperty.getValue()).thenReturn(mockRelationValue);
         when(mockRelationValue.getType()).thenReturn(URI);


### PR DESCRIPTION
This is a partial resolution related to: https://jira.duraspace.org/browse/FCREPO-2092

This commit:
- correctly handles _ref properties on proxy resources
- adds an integration test ensuring dynamically added property on indirect resource
  *\* the above integration test failing in this commit
