### PR TITLE
Check if metadata is available in commons.js

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -113,7 +113,12 @@
           // WARNING: Fragile code relying on magic suffix '/fcr:metadata' and absence of 'Link' header 
           // on external resource.
           if(!url.match(/.*fcr:(metadata|tx)/)){
-            newLocation = url + "/fcr:metadata";
+             http('HEAD', url + "/fcr/metadata", function(res) {
+		            if(res.status == 200) {
+			              newLocation = url + "/fcr:metadata";
+		            } else {
+		              newLocation = url;
+	            }
           }
           location.href = newLocation ;
           return;


### PR DESCRIPTION
# What does this Pull Request do?
Added code which only adds the suffix fcr:metadata to a resource URL if metadata is available.
Background: For a possibly strange use case we have references to external resources which are not known to fedora, so fedora does not have any metadata about these resources. This led to a problem because checkIfNonRdfResource has code which tries to provide metadata instead of the binary content by adding the fcr:metadata suffix if a HEAD request does not have a Link-Header (see fcrepo4#1168)
For our non-fedora resources this leads to 404 errors. I worked around this by testing if adding the suffix brings up status code 200 in a second HEAD request.

# What's new?
Added 5 lines of JavaScript code which sends a HEAD request to the resource and only adds the fcr:metadata suffix if the status code is 200.

# Additional Notes:
This change does not change the original behaviour for resources known to Fedora, except that an additional HEAD request is made when the user clicks on a link.