### PR TITLE
(For Andrew) Add docker-compose to launch fcrepo in Tomcat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.1'
+
+services:
+
+    fcrepo:
+        image: tomcat:8.5.51-jdk11-adoptopenjdk-openj9
+        container_name: fcrepo
+        ports: 
+            - 8080:8080
+        volumes: 
+            - ./fcrepo-webapp/target/fcrepo-webapp-6.0.0-SNAPSHOT.war:/usr/local/tomcat/webapps/fcrepo.war
+            - ./tomcat-users.xml:/usr/local/tomcat/conf/tomcat-users.xml

--- a/tomcat-users.xml
+++ b/tomcat-users.xml
@@ -1,0 +1,7 @@
+<tomcat-users>
+  <role rolename="fedoraUser" />
+  <role rolename="fedoraAdmin" />
+  <user name="testuser" password="password1" roles="fedoraUser" />
+  <user name="adminuser" password="password2" roles="fedoraUser" />
+  <user name="fedoraAdmin" password="secret3" roles="fedoraAdmin" />
+</tomcat-users>


### PR DESCRIPTION
Uses an off-the-shelf tomcat image to run fcrepo6,   Bind mounts the war file, and a `tomcat-users.xml` file.

# To try it out
* Build fedora (the war needs to exist in `fcrepo-webapp`/target1)
* do `docker-compose up -d`
* Wait for it to start and try it out.  use `docker logs -f fcrepo` to tail the logs.  

It seems to start just fine for me @awoods !