### PR TITLE
removed duplicate dep

### DIFF
--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -85,11 +85,6 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <!-- This dependency is for compile-time: it keeps this module independent 
       of any given choice of JAX-RS implementation. It must be _after_ the test 


### PR DESCRIPTION
# What does this Pull Request do?

Removes a duplicate hamcrest dependency.

# How should this be tested?

Build the project before the change and see:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.fcrepo:fcrepo-kernel-impl:bundle:6.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.hamcrest:hamcrest-all:jar -> duplicate declaration of version (?) @ line 88, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
Build after this change and the error is gone.

# Interested parties
@fcrepo4/committers
