### PR TITLE
Adds additional data source configuration parameters as well as changes the defaults of select properties

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/DatabaseConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/DatabaseConfig.java
@@ -56,6 +56,15 @@ public class DatabaseConfig {
     @Value("${fcrepo.db.max.pool.size:15}")
     private Integer maxPoolSize;
 
+    @Value("${fcrepo.db.connection.checkout.timeout:10000}")
+    private Integer checkoutTimeout;
+
+    @Value("${fcrepo.db.connection.idle.test.period:300}")
+    private Integer idleConnectionTestPeriod;
+
+    @Value("${fcrepo.db.connection.test.on.checkout:true}")
+    private boolean testConnectionOnCheckout;
+
     private static final Map<String, String> DB_DRIVER_MAP = Map.of(
             "h2", "org.h2.Driver",
             "postgresql", "org.postgresql.Driver",
@@ -75,8 +84,10 @@ public class DatabaseConfig {
         dataSource.setJdbcUrl(dbUrl);
         dataSource.setUser(dbUser);
         dataSource.setPassword(dbPassword);
-        dataSource.setCheckoutTimeout(10_000);
+        dataSource.setCheckoutTimeout(checkoutTimeout);
         dataSource.setMaxPoolSize(maxPoolSize);
+        dataSource.setIdleConnectionTestPeriod(idleConnectionTestPeriod);
+        dataSource.setTestConnectionOnCheckout(testConnectionOnCheckout);
         return dataSource;
     }
 


### PR DESCRIPTION
Below are the newly configurable properties and their defaults

fcrepo.db.connection.checkout.timeout: 10000  (ms) (unchanged)
fcrepo.db.connection.idle.test.period: 0 (sec) (unchanged)
fcrepo.db.connection.test.on.checkout: true  (new)

With this new configuration, connections are tested on checkout by default
using the JDBC Connection isValid() operation.
Idle uncheckout connections will not be tested (c3po default behavior), but
in case we want to change it via system properties we can.

Resolves: https://jira.lyrasis.org/browse/FCREPO-3401

*Adds additional data source configuration parameters.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3401

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

Adds additional data source configuration parameters as well as changes the defaults of select properties in order to address the timeout issues Calvin Xu was a having seeing on Mysql.

Below are the newly configurable properties and their defaults

fcrepo.db.connection.checkout.timeout: 10000  (ms) (unchanged)
fcrepo.db.connection.idle.test.period: 0 (sec) (unchanged)
fcrepo.db.connection.test.on.checkout: true  (new)

With this new configuration, connections are tested on checkout by default
using the JDBC Connection isValid() operation.
Idle unacquired connections will not be tested (c3po default behavior), but
in case we want to change it via system properties we can.

# How should this be tested?
I tested by starting up fedora against a mysql instance and ran the jmeter tests.  
I'm hoping Calvin Xu can rerun his tests with these changes.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
