### PR TITLE
add metrics framework

### DIFF
--- a/fcrepo-configs/pom.xml
+++ b/fcrepo-configs/pom.xml
@@ -51,6 +51,14 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.config;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * @author pwinckles
+ */
+@Configuration
+public class MetricsConfig {
+
+    @Value("${fcrepo.metrics.enable:true}")
+    private boolean enableMetrics;
+
+    @Bean
+    public MeterRegistry meterRegistry() {
+        final MeterRegistry registry;
+
+        if (enableMetrics) {
+            registry = new PrometheusMeterRegistry(new PrometheusConfig() {
+                @Override
+                public Duration step() {
+                    return Duration.ofSeconds(30);
+                }
+                @Override
+                public String get(final String key) {
+                    return null;
+                }
+            });
+            // Enables distribution stats for all timer metrics
+            registry.config().meterFilter(new MeterFilter() {
+                @Override
+                public DistributionStatisticConfig configure(final Meter.Id id,
+                                                             final DistributionStatisticConfig config) {
+                    if (id.getType() == Meter.Type.TIMER) {
+                        return DistributionStatisticConfig.builder()
+                                .percentilesHistogram(true)
+                                .percentiles(0.5, 0.90, 0.99)
+                                .build().merge(config);
+                    }
+                    return config;
+                }
+            });
+            new JvmThreadMetrics().bindTo(registry);
+            new JvmGcMetrics().bindTo(registry);
+            new JvmMemoryMetrics().bindTo(registry);
+            new ProcessorMetrics().bindTo(registry);
+            new UptimeMetrics().bindTo(registry);
+        } else {
+            registry = new SimpleMeterRegistry();
+        }
+
+        Metrics.addRegistry(registry);
+
+        return registry;
+    }
+
+    @Bean
+    public CollectorRegistry collectorRegistry(final MeterRegistry meterRegistry) {
+        if (meterRegistry instanceof PrometheusMeterRegistry) {
+            return ((PrometheusMeterRegistry) meterRegistry).getPrometheusRegistry();
+        }
+        return CollectorRegistry.defaultRegistry;
+    }
+
+}

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
@@ -44,7 +44,7 @@ import java.time.Duration;
 @Configuration
 public class MetricsConfig {
 
-    @Value("${fcrepo.metrics.enable:true}")
+    @Value("${fcrepo.metrics.enable:false}")
     private boolean enableMetrics;
 
     @Bean

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -114,7 +114,10 @@
       <version>${jersey.version}</version>
     </dependency>
 
-
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
 
     <!-- test gear -->
     <dependency>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
@@ -87,6 +88,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author peichman
  * @since 4/20/18
  */
+@Timed
 @Scope("request")
 @Path("/{path: (.+/)?}fcr:acl")
 public class FedoraAcl extends ContentExposingResource {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -38,6 +38,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Link;
 import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.annotation.Timed;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.models.Binary;
@@ -52,6 +53,7 @@ import org.springframework.context.annotation.Scope;
  * @author ajs6f
  * @since Jun 12, 2013
  */
+@Timed
 @Scope("request")
 @Path("/{path: .*}/fcr:fixity")
 public class FedoraFixity extends ContentExposingResource {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.search.api.Condition;
@@ -51,7 +52,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author dbernstein
  * @since 05/06/20
  */
-
+@Timed
 @Scope("request")
 @Path("/fcr:search")
 public class FedoraSearch extends FedoraBaseResource {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -18,6 +18,7 @@
 package org.fcrepo.http.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.annotation.Timed;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -46,6 +47,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  *
  * @author cbeer
  */
+@Timed
 @Scope("request")
 @Path("/{path: .*}/fcr:tombstone")
 public class FedoraTombstones extends ContentExposingResource {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -18,6 +18,7 @@
 package org.fcrepo.http.api;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.micrometer.core.annotation.Timed;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.LinkFormatStream;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
@@ -71,6 +72,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  * @author cabeer
  * @since 9/25/14
  */
+@Timed
 @Scope("request")
 @Path("/{path: .*}/fcr:versions")
 public class FedoraVersioning extends ContentExposingResource {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/Transactions.java
@@ -41,6 +41,7 @@ import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.micrometer.core.annotation.Timed;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
@@ -56,6 +57,7 @@ import org.springframework.context.annotation.Scope;
  * @author gregjan
  * @author mohideen
  */
+@Timed
 @Scope("prototype")
 @Path("/fcr:tx")
 public class Transactions extends FedoraBaseResource {

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -100,7 +100,6 @@
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-configs</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -234,6 +233,10 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-jersey2</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_servlet</artifactId>

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -233,7 +233,12 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+    </dependency>
+
     <!-- commons-digester-1.8 is explicitly added here because of a dependency 
     convergence issue in velocity-tools. If/when velocity-tools gets its 
     version of commons-digester in sync across its dependencies, the exclusion 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraApplication.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/FedoraApplication.java
@@ -17,10 +17,12 @@
  */
 package org.fcrepo.http.commons;
 
+import org.fcrepo.http.commons.metrics.MicrometerFeature;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+
 import java.util.logging.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -41,6 +43,7 @@ public class FedoraApplication extends ResourceConfig {
         packages("org.fcrepo");
         register(MultiPartFeature.class);
         register(JacksonFeature.class);
+        register(MicrometerFeature.class);
 
         if (LOGGER.isDebugEnabled()) {
             register(new LoggingFeature(Logger.getLogger(LoggingFeature.class.getName())));

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/PrometheusMetricsServlet.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/PrometheusMetricsServlet.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.MetricsServlet;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+
+/**
+ * This class is an extension of Prometheus's MetricsServlet. It only exists because there isn't an easy way to
+ * set the CollectorRegistry on with a Spring bean.
+ *
+ * @author pwinckles
+ */
+public class PrometheusMetricsServlet extends MetricsServlet {
+
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+        final var context = WebApplicationContextUtils
+                .getRequiredWebApplicationContext(config.getServletContext());
+        final var collector = context.getBean(CollectorRegistry.class);
+
+        try {
+            final var field = MetricsServlet.class.getDeclaredField("registry");
+            field.setAccessible(true);
+            field.set(this, collector);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new ServletException(e);
+        }
+
+        super.init(config);
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/MicrometerFeature.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/MicrometerFeature.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.jersey2.server.DefaultJerseyTagsProvider;
+import io.micrometer.jersey2.server.MetricsApplicationEventListener;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Enables Micrometer metrics on Jersey APIs (still must be annotated with @Timed)
+ *
+ * @author pwinckles
+ */
+public class MicrometerFeature implements Feature {
+
+    @Context
+    private ServletContext servletContext;
+
+    @Override
+    public boolean configure(final FeatureContext context) {
+        if (this.servletContext == null) {
+            return false;
+        }
+        final var appCtx = WebApplicationContextUtils.getWebApplicationContext(servletContext);
+        if (appCtx == null) {
+            return false;
+        }
+
+        final var registry = appCtx.getBean(MeterRegistry.class);
+
+        final var micrometerListener = new MetricsApplicationEventListener(
+                registry,
+                new DefaultJerseyTagsProvider(),
+                "http.server.requests",
+                false);
+
+        context.register(micrometerListener);
+
+        return true;
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/PrometheusMetricsServlet.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/PrometheusMetricsServlet.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.http.commons;
+package org.fcrepo.http.commons.metrics;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.MetricsServlet;

--- a/fcrepo-webapp/src/main/jetty-console/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/jetty-console/WEB-INF/web.xml
@@ -34,6 +34,15 @@
 
 	</servlet-mapping>
 
+    <servlet>
+        <servlet-name>prometheus</servlet-name>
+        <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>prometheus</servlet-name>
+        <url-pattern>/prometheus</url-pattern>
+    </servlet-mapping>
+
   <filter>
     <filter-name>ETagFilter</filter-name>
     <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -55,6 +55,15 @@
     <load-on-startup>1</load-on-startup>
   </servlet>
 
+  <servlet>
+    <servlet-name>prometheus</servlet-name>
+    <servlet-class>org.fcrepo.http.commons.PrometheusMetricsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>prometheus</servlet-name>
+    <url-pattern>/prometheus</url-pattern>
+  </servlet-mapping>
+
   <servlet-mapping>
 		<servlet-name>jersey-servlet</servlet-name>
 		<url-pattern>/rest/*</url-pattern>

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -55,20 +55,20 @@
     <load-on-startup>1</load-on-startup>
   </servlet>
 
-  <servlet>
-    <servlet-name>prometheus</servlet-name>
-    <servlet-class>org.fcrepo.http.commons.PrometheusMetricsServlet</servlet-class>
-  </servlet>
-  <servlet-mapping>
-    <servlet-name>prometheus</servlet-name>
-    <url-pattern>/prometheus</url-pattern>
-  </servlet-mapping>
-
   <servlet-mapping>
 		<servlet-name>jersey-servlet</servlet-name>
 		<url-pattern>/rest/*</url-pattern>
 
 	</servlet-mapping>
+
+  <servlet>
+    <servlet-name>prometheus</servlet-name>
+    <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>prometheus</servlet-name>
+    <url-pattern>/prometheus</url-pattern>
+  </servlet-mapping>
 
   <filter>
     <filter-name>ETagFilter</filter-name>

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,21 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-registry-prometheus</artifactId>
+        <version>1.5.5</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_servlet</artifactId>
+        <version>0.8.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,17 @@
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-jersey2</artifactId>
+        <version>1.5.5</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
         <version>1.5.5</version>
       </dependency>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3443

# What does this Pull Request do?

This PR is intended to demonstration a possible metrics integration. It uses [Micrometer](https://micrometer.io/) for collecting metrics within the app and reports them to [Prometheus](https://prometheus.io/). Micrometer could also be configured to report to any number of alternative metrics backends. Prometheus is very powerful, though it is not the most intuitive to use.

Regardless, if we do want to support capturing metrics, I think it would likely make sense to offer a number of different backends so that the metrics could more easily integrate with whatever service an institution is already using. For example, [Graphite](https://graphiteapp.org/) is also popular. However, the bigger question is in regards to if we want to use Micrometer or an alternative like [Dropwizard](https://metrics.dropwizard.io/4.1.2/). Micrometer is more popular currently and perhaps better designed, but Dropwizard does have some out-of-the-box [Jersey integrations](https://metrics.dropwizard.io/4.1.2/manual/jersey.html) that Micrometer does not have.

A word about annotations, out of the box, Micrometer only supports AspectJ for annotation based annotation based metrics collection. I do not think this is a bad thing. Spring proxy based AOP is not a good fit for annotation based metrics collection because it has serious limitations which would likely result in people adding annotations that they think would emit metrics when they are actually doing nothing.

Prometheus works by periodically "scraping" metrics. I added a new endpoint, `/prometheus` to the webapp that exposes the metrics for Prometheus. I exposed some default JVM metrics and added two timing metrics on get and put resource requests. No other custom metrics have been added at this point.

# How should this be tested?

Write the following to a file named `prometheus.yml`:

```yml
scrape_configs:
  - job_name: 'fcrepo'
    scrape_interval: 30s 
    metrics_path: '/prometheus'
    static_configs:
    - targets: ['host.docker.internal:8080']
    basic_auth:
      username: fedoraAdmin
      password: fedoraAdmin
```

Write the following to a file named `docker-compose.yml` that is in the same directory as `prometheus.yml`:

```yml
version: '3.8'
services:
 prometheus:
   image: prom/prometheus
   ports:
     - "9090:9090"
   volumes:
     - ./prometheus.yml:/etc/prometheus/prometheus.yml
    
 grafana:
   image: grafana/grafana
   ports:
   - "3000:3000"
```

Execute: `docker-compose up`

Finally, startup Fedora with metrics enabled (`-Dfcrepo.metrics.enable=true`) and execute a few requests like:

```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -X PUT --data-binary "testing"
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary
```

Navigate to http://localhost:9090, to query the metrics directly in Prometheus or go to http://localhost:3000, if you'd like to use Grafana.

If you're using Grafana, here are the steps to connect it to Prometheus:

1. Login: admin/admin
1. Configuration -> Datasources
1. Add datasource -> Prometheus
1. URL: http://prometheus:9090
1. Save & Test
1. Create a new dashboard

**[EDIT]** The following queries don't work anymore because I removed the metrics. Load [this dashboard](https://github.com/fcrepo4/fcrepo4/files/5285946/grafana.txt) into Grafana for some example queries.

Here are some example queries:

* JVM memory usage: `jvm_memory_used_bytes`
* All API requests throughput: `rate(fcrepo_http_request_seconds_count[1m])`
* GetResource API request throughput: `rate(fcrepo_http_request_seconds_count{api="getResource"}[1m])`
* GetResource API mean request time: `rate(fcrepo_http_request_seconds_sum{api="getResource"}[1m])/rate(fcrepo_http_request_seconds_count{api="getResource"}[1m])`
* GetResource API p99 request time: `histogram_quantile(0.99, sum(rate(fcrepo_http_request_seconds_bucket{api="getResource"}[1m])) by (le))`

# Interested parties
@fcrepo4/committers @awoods 
