### PR TITLE
Refactor referenceService to emit events.

### DIFF
--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
@@ -86,9 +86,9 @@ public class JsonLDSerializerTest extends EventSerializerTestBase {
         assertEquals(EventType.RESOURCE_MODIFICATION.getName(), node.get("name").textValue());
         assertEquals(EventType.RESOURCE_MODIFICATION.getTypeAbbreviated(), node.get("type").get(0).asText());
         assertEquals(user, node.get("actor").get(0).get("id").asText());
-        assertEquals("Person", node.get("actor").get(0).get("type").get(0).asText());
+        assertEquals("Person", node.get("actor").get(0).get("type").asText());
         assertEquals(softwareAgent, node.get("actor").get(1).get("name").asText());
-        assertEquals("Application", node.get("actor").get(1).get("type").get(0).asText());
+        assertEquals("Application", node.get("actor").get(1).get("type").asText());
         assertEquals(node.get("published").textValue(), timestamp.toString());
         final List<String> types = new ArrayList<>();
         final JsonNode objectNode = node.get("object");

--- a/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
+++ b/fcrepo-jms/src/main/java/org/fcrepo/jms/AbstractJMSPublisher.java
@@ -67,7 +67,7 @@ abstract class AbstractJMSPublisher {
     protected abstract Destination createDestination() throws JMSException;
 
     /**
-     * When an EventBus mesage is received, map it to our JMS
+     * When an EventBus message is received, map it to our JMS
      * message payload and push it onto the queue.
      *
      * @param event the fedora event
@@ -86,7 +86,7 @@ abstract class AbstractJMSPublisher {
     }
 
     /**
-     * Connect to JCR Repostory and JMS queue
+     * Connect to JCR Repository and JMS queue
      *
      * @throws JMSException if JMS Exception occurred
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -49,9 +49,11 @@ public interface ReferenceService {
      * Parse the stream of triples for references, add any new ones and remove any missing ones.
      * @param txId the transaction ID
      * @param resourceId the subject ID of the triples.
+     * @param userPrincipal the user who's action is updating references.
      * @param rdfStream the RDF stream.
      */
-    void updateReferences(final String txId, final FedoraId resourceId, final RdfStream rdfStream);
+    void updateReferences(final String txId, final FedoraId resourceId, final String userPrincipal,
+                          final RdfStream rdfStream);
 
     /**
      * Commit any pending references.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
@@ -74,6 +74,8 @@ public class ResourceOperationEventBuilder implements EventBuilder {
                 return EventType.RESOURCE_DELETION;
             case PURGE:
                 return EventType.RESOURCE_PURGE;
+            case FOLLOW:
+                return EventType.INBOUND_REFERENCE;
             default:
                 throw new IllegalStateException(
                         String.format("There is no EventType mapping for ResourceOperation type %s on operation %s",

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/ReferenceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/ReferenceOperation.java
@@ -15,14 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
- *
- * @author bbpennel
+ * Operation to track a reference operation.
+ * @author whikloj
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE, FOLLOW
+public class ReferenceOperation extends AbstractResourceOperation {
+
+    protected ReferenceOperation(final FedoraId rescId) {
+        super(rescId);
+    }
+
+    @Override
+    public ResourceOperationType getType() {
+        return ResourceOperationType.FOLLOW;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/ReferenceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/ReferenceOperationBuilder.java
@@ -15,14 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.operations;
+package org.fcrepo.kernel.impl.operations;
 
+import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 /**
- * Specifies the type of modification action represented by a resource operation.
- *
- * @author bbpennel
+ * Build a reference operation.
+ * @author whikloj
  */
-public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE, FOLLOW
+public class ReferenceOperationBuilder extends AbstractResourceOperationBuilder {
+
+    /**
+     * Constructor.
+     *
+     * @param rescId the resource identifier.
+     */
+    public ReferenceOperationBuilder(final FedoraId rescId) {
+        super(rescId);
+    }
+
+    @Override
+    public ReferenceOperation build() {
+        final var operation = new ReferenceOperation(rescId);
+        operation.setUserPrincipal(userPrincipal);
+        return operation;
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -235,8 +235,9 @@ public abstract class AbstractService {
      * @param resourceId the resource's ID.
      * @param model the model of the request body.
      */
-    protected void updateReferences(final String transactionId, final FedoraId resourceId, final Model model) {
-        referenceService.updateReferences(transactionId, resourceId,
+    protected void updateReferences(final String transactionId, final FedoraId resourceId, final String user,
+                                    final Model model) {
+        referenceService.updateReferences(transactionId, resourceId, user,
                 fromModel(model.getResource(resourceId.getFullId()).asNode(), model));
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -180,7 +180,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         try {
             pSession.persist(createOp);
-            updateReferences(txId, fedoraId, model);
+            updateReferences(txId, fedoraId, userPrincipal, model);
             addToContainmentIndex(txId, parentId, fedoraId);
             recordEvent(txId, fedoraId, createOp);
         } catch (final PersistentStorageException exc) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -70,7 +70,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                 .build();
 
             pSession.persist(updateOp);
-            updateReferences(txId, fedoraId, inputModel);
+            updateReferences(txId, fedoraId, userPrincipal, inputModel);
             recordEvent(txId, fedoraId, updateOp);
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(String.format("failed to replace resource %s",

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReferenceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReferenceServiceImplTest.java
@@ -84,6 +84,8 @@ public class ReferenceServiceImplTest {
 
     private String transactionId;
 
+    private static final String TEST_USER = "someUser";
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -105,7 +107,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
 
         final List<Triple> refs = referenceService.getInboundReferences(null, targetResource)
@@ -122,7 +124,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, "http://some/text/uri");
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
         assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
     }
@@ -133,7 +135,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
         final List<Triple> refs = referenceService.getInboundReferences(null, targetResource).collect(
                 Collectors.toList());
@@ -144,7 +146,7 @@ public class ReferenceServiceImplTest {
         model.add(subject2, referenceProp, target);
         final RdfStream stream2 = fromModel(subject2.asNode(),
                 model);
-        referenceService.updateReferences(transactionId, subject2Id, stream2);
+        referenceService.updateReferences(transactionId, subject2Id, TEST_USER, stream2);
         referenceService.commitTransaction(transactionId);
         final List<Triple> refs2 = referenceService.getInboundReferences(null, targetResource).collect(
                 Collectors.toList());
@@ -161,14 +163,14 @@ public class ReferenceServiceImplTest {
         model.add(external, referenceProp, target);
         final RdfStream stream = fromModel(external.asNode(), model);
 
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
         assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
 
         model.remove(external, referenceProp, target);
         model.add(subject1, referenceProp, target);
         final RdfStream stream2 = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream2);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream2);
         referenceService.commitTransaction(transactionId);
         assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
 
@@ -181,7 +183,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         // Still nothing outside the transaction.
         assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
         // One inside the transaction
@@ -199,7 +201,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         // Still nothing outside the transaction.
         assertEquals(0, referenceService.getInboundReferences(null, targetResource).count());
         // One inside the transaction
@@ -223,7 +225,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
 
         final String transaction2 = UUID.randomUUID().toString();
         // Still not public.
@@ -247,7 +249,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
         assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
 
@@ -256,7 +258,7 @@ public class ReferenceServiceImplTest {
         model.add(subject1, ResourceFactory.createProperty("http://someother/description"), "Some text");
         model.remove(subject1, referenceProp, target);
         final RdfStream stream2 = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transaction2, subject1Id, stream2);
+        referenceService.updateReferences(transaction2, subject1Id, TEST_USER, stream2);
         // Reference still available outside transaction.
         assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
         // But gone inside the transaction
@@ -280,7 +282,7 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, binaryUri);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         // Check before committing
         assertEquals(0, referenceService.getInboundReferences(null, binaryDescriptionResource).count());
         assertEquals(1, referenceService.getInboundReferences(transactionId, binaryDescriptionResource)
@@ -293,7 +295,7 @@ public class ReferenceServiceImplTest {
         final Model model2 = createDefaultModel();
         model2.add(subject2, referenceProp, binaryDescUri);
         final RdfStream stream2 = fromModel(subject2.asNode(), model2);
-        referenceService.updateReferences(transactionId, subject2Id, stream2);
+        referenceService.updateReferences(transactionId, subject2Id, TEST_USER, stream2);
         // One reference outside the transaction
         assertEquals(1, referenceService.getInboundReferences(null, binaryDescriptionResource).count());
         // Two inside
@@ -317,13 +319,13 @@ public class ReferenceServiceImplTest {
         final Model model = createDefaultModel();
         model.add(subject1, referenceProp, target);
         final RdfStream stream = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject1Id, stream);
+        referenceService.updateReferences(transactionId, subject1Id, TEST_USER, stream);
         referenceService.commitTransaction(transactionId);
         assertEquals(1, referenceService.getInboundReferences(null, targetResource).count());
 
         // Add the same reference from another resource.
         final RdfStream stream2 = fromModel(subject1.asNode(), model);
-        referenceService.updateReferences(transactionId, subject2Id, stream2);
+        referenceService.updateReferences(transactionId, subject2Id, TEST_USER, stream2);
         referenceService.commitTransaction(transactionId);
         assertEquals(2, referenceService.getInboundReferences(null, targetResource).count());
         final Triple expectedTriple = Triple.create(subject1.asNode(), referenceProp.asNode(), target.asNode());

--- a/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
+++ b/fcrepo-kernel-impl/src/test/resources/containmentIndexTest.xml
@@ -26,4 +26,8 @@
     <bean id="referenceIndex" class="org.fcrepo.kernel.impl.services.ReferenceServiceImpl">
         <property name="dataSource" ref="dataSource" />
     </bean>
+
+    <bean id="eventAccumulator" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="org.fcrepo.kernel.api.observer.EventAccumulator"/>
+    </bean>
 </beans>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -170,7 +170,7 @@ public class IndexBuilderImpl implements IndexBuilder {
                     final Optional<InputStream> content = session.readContent(fedoraId.getFullId()).getContentStream();
                     if (content.isPresent()) {
                         final RdfStream rdf = parseRdf(fedoraId, content.get());
-                        this.referenceService.updateReferences(txId, fedoraId, rdf);
+                        this.referenceService.updateReferences(txId, fedoraId, null, rdf);
                     }
                 }
 


### PR DESCRIPTION
Fix AbstractJmsIT to stop checking message headers.

Fix JsonLdEventMessage to have only one type for Object and Actor.


**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3434

# What does this Pull Request do?
Implements the INBOUND_REFERENCE event type when you reference an item.

Fixes the fcrepo-jms tests to stop relying on the message headers and actually decode the body of the message.

# How should this be tested?

1. Setup a JMSClient to listen to Fedora.
1. Create two resources.
1. Make one reference the other ie. `<http://localhost:8080/rest/first> <http://example.org/pointsTo> <http://localhost:8080/rest/second>`
1. Check your JMSClient for a Follow event, like
    ```
    {"id":"urn:uuid:8cea1bab-c1c1-4b9b-ac5d-a666aa6abad1","type":["Follow"],"name":"refer to resource","published":"2020-09-25T20:57:08.641850Z","actor":[{"type":"Person","id":"info:fedora/local-user#fedoraAdmin"},{"type":"Application","name":"curl/7.64.1"}],"object":{"type":["http://mementoweb.org/ns#TimeGate","http://fedora.info/definitions/v4/repository#Container","http://www.w3.org/ns/ldp#RDFSource","http://www.w3.org/ns/ldp#Resource","http://www.w3.org/ns/ldp#Container","http://mementoweb.org/ns#OriginalResource","http://fedora.info/definitions/v4/repository#Resource","http://www.w3.org/ns/ldp#BasicContainer","http://www.w3.org/ns/prov#Entity"],"id":"http://localhost:8080/rest/second","isPartOf":"http://localhost:8080/rest"},"@context":["https://www.w3.org/ns/activitystreams#",{"prov":"http://www.w3.org/ns/prov#","dcterms":"http://purl.org/dc/terms/","type":"@type","id":"@id","isPartOf":{"@id":"dcterms:isPartOf","@type":"@id"}}]}
    ```
1. Do the same but make the target of the reference a resource that does NOT exist.
1. See NO Follow event.


# Interested parties
@fcrepo4/committers
