### PR TITLE
cleanup exceptions

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -627,9 +627,10 @@ public class WebACFilter extends RequestContextFilter {
             throw new BadRequestException("RDF was not parsable: " + e.getMessage(), e);
         } catch (final RuntimeIOException e) {
             if (e.getCause() instanceof JsonParseException) {
-                throw new MalformedRdfException(e.getCause());
+                final var cause = e.getCause();
+                throw new MalformedRdfException(cause.getMessage(), cause);
             }
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -237,7 +237,7 @@ public class WebACRolesProvider {
                     final FedoraResource resource = resourceFactory.getResource(transaction, fedoraId);
                     return getAgentMembers(translator, resource, hashedSuffix);
                 } catch (final PathNotFoundException e) {
-                    throw new PathNotFoundRuntimeException(e);
+                    throw new PathNotFoundRuntimeException(e.getMessage(), e);
                 }
             } else if (agentGroup.equals(FOAF_AGENT_VALUE)) {
                 return of(agentGroup);

--- a/fcrepo-event-serialization/src/main/java/org/fcrepo/event/serialization/TurtleSerializer.java
+++ b/fcrepo-event-serialization/src/main/java/org/fcrepo/event/serialization/TurtleSerializer.java
@@ -44,7 +44,7 @@ public class TurtleSerializer implements EventSerializer {
             model.write(out, "TTL");
             return out.toString("UTF-8");
         } catch (final UnsupportedEncodingException ex) {
-            throw new RepositoryRuntimeException(ex);
+            throw new RepositoryRuntimeException(ex.getMessage(), ex);
         }
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -996,7 +996,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         } else if (rootThrowable instanceof RuntimeException) {
             throw (RuntimeException) rootThrowable;
         } else {
-            throw new RepositoryRuntimeException(rootThrowable);
+            throw new RepositoryRuntimeException(rootThrowable.getMessage(), rootThrowable);
         }
     }
 
@@ -1048,7 +1048,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
             return fedoraResource;
         } catch (final PathNotFoundException exc) {
-            throw new PathNotFoundRuntimeException(exc);
+            throw new PathNotFoundRuntimeException(exc.getMessage(), exc);
         }
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -158,7 +158,7 @@ public class FedoraAcl extends ContentExposingResource {
                 return noContent().location(location).build();
             }
         } catch (PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+            throw new PathNotFoundRuntimeException(e.getMessage(), e);
         }
 
     }
@@ -294,7 +294,7 @@ public class FedoraAcl extends ContentExposingResource {
                         "To override the default root ACL you must PUT a user-defined ACL to this endpoint.",
                         CONFLICT);
             }
-            throw new PathNotFoundRuntimeException(exc);
+            throw new PathNotFoundRuntimeException(exc.getMessage(), exc);
         } finally {
             transaction().commitIfShortLived();
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -119,7 +119,7 @@ public class FedoraTombstones extends ContentExposingResource {
         try {
             return getFedoraResource(transaction(), resourceId);
         } catch (final PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+            throw new PathNotFoundRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -233,7 +233,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
                 return resourceFactory.getResource(tx.getId(), fedoraID);
             }
         } catch (final PathNotFoundException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -224,9 +224,10 @@ public class HttpRdfService {
 
         } catch (final RuntimeIOException e) {
             if (e.getCause() instanceof JsonParseException) {
-                throw new MalformedRdfException(e.getCause());
+                final var cause = e.getCause();
+                throw new MalformedRdfException(cause.getMessage(), cause);
             }
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExternalContentAccessExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExternalContentAccessExceptionMapper.java
@@ -45,7 +45,7 @@ public class ExternalContentAccessExceptionMapper
 
     @Override
     public Response toResponse(final ExternalContentAccessException exception) {
-        debugException(this, exception, LOGGER);
+        LOGGER.warn("Failed to read external content", exception);
         return status(BAD_GATEWAY).entity(exception.getMessage()).type(TEXT_PLAIN_WITH_CHARSET)
             .build();
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InsufficientStorageExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InsufficientStorageExceptionMapper.java
@@ -18,17 +18,16 @@
 
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.InsufficientStorageException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.InsufficientStorageException;
-
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Translate InsufficientStorageException errors into HTTP error codes
@@ -47,10 +46,7 @@ public class InsufficientStorageExceptionMapper implements
 
     @Override
     public Response toResponse(final InsufficientStorageException e) {
-        LOGGER.error("InsufficientStorageException intercepted by {}: {}\n",
-                getClass().getSimpleName(),
-                e.getMessage());
-        debugException(this, e, LOGGER);
+        LOGGER.error("Insufficient storage", e);
         return status(INSUFFICIENT_STORAGE_HTTP_CODE).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InterruptedExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InterruptedExceptionMapper.java
@@ -42,7 +42,7 @@ public class InterruptedExceptionMapper implements
 
     @Override
     public Response toResponse(final InterruptedRuntimeException e) {
-        debugException(this, e, LOGGER);
+        LOGGER.warn("Service interrupted", e);
         return status(SERVICE_UNAVAILABLE).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidChecksumExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidChecksumExceptionMapper.java
@@ -17,18 +17,17 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.CONFLICT;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.slf4j.LoggerFactory.getLogger;
-
+import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.InvalidChecksumException;
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  *  Translate InvalidChecksumException errors into reasonable
@@ -47,10 +46,7 @@ public class InvalidChecksumExceptionMapper implements
 
     @Override
     public Response toResponse(final InvalidChecksumException e) {
-
-        LOGGER.error("InvalidChecksumException intercepted by InvalidChecksumExceptionMapper: {}\n",
-                e.getMessage());
-        debugException(this, e, LOGGER);
+        LOGGER.error("Invalid checksum", e);
 
         return status(CONFLICT).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidPrefixExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidPrefixExceptionMapper.java
@@ -17,18 +17,17 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.InvalidPrefixException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.InvalidPrefixException;
-
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * For invalid namespace exceptions on CRUD actions for nodes/datastreams
@@ -44,7 +43,6 @@ public class InvalidPrefixExceptionMapper implements
 
     @Override
     public Response toResponse(final InvalidPrefixException e) {
-        LOGGER.error("FedoraInvalidPrefixExceptionMapper caught an exception: {}", e.getMessage());
         debugException(this, e, LOGGER);
         return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
@@ -44,8 +44,7 @@ public class InvalidResourceIdentifierExceptionMapper implements
 
     @Override
     public Response toResponse(final InvalidResourceIdentifierException e) {
-        LOGGER.error("InvalidResourceIdentifierExceptionMapper caught an exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
+        LOGGER.warn("Invalid resource identifier", e);
         return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ItemNotFoundExceptionMapper.java
@@ -17,13 +17,14 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.fcrepo.kernel.api.exception.ItemNotFoundException;
-import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 
 /**
@@ -40,8 +41,6 @@ public class ItemNotFoundExceptionMapper implements
 
     @Override
     public Response toResponse(final ItemNotFoundException e) {
-
-        LOGGER.debug("Exception intercepted by ItemNotFoundExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
         return Response.status(Response.Status.NOT_FOUND).
                 entity("Error: " + e.getMessage()).build();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ParamExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ParamExceptionMapper.java
@@ -42,8 +42,6 @@ public class ParamExceptionMapper implements
 
     @Override
     public Response toResponse(final ParamException e) {
-
-        LOGGER.error("ParamException intercepted by ParamExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
 
         final String msg = "Error parsing parameter: " + e.getParameterName() + ", of type: " +

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundExceptionMapper.java
@@ -41,8 +41,6 @@ public class PathNotFoundExceptionMapper implements
 
     @Override
     public Response toResponse(final PathNotFoundException e) {
-
-        LOGGER.debug("Exception intercepted by PathNotFoundExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
         return Response.status(Response.Status.NOT_FOUND).
                 entity("Error: " + e.getMessage()).build();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/PathNotFoundRuntimeExceptionMapper.java
@@ -41,8 +41,6 @@ public class PathNotFoundRuntimeExceptionMapper implements
 
     @Override
     public Response toResponse(final PathNotFoundRuntimeException e) {
-
-        LOGGER.debug("Exception intercepted by PathNotFoundRuntimeExceptionMapper: {}\n", e.getMessage());
         debugException(this, e, LOGGER);
         return Response.status(Response.Status.NOT_FOUND).
                 entity("Error: " + e.getMessage()).build();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryExceptionMapper.java
@@ -17,20 +17,18 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static com.google.common.base.Throwables.getStackTraceAsString;
-import static javax.ws.rs.core.Response.serverError;
-import static javax.ws.rs.core.Response.status;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.fcrepo.kernel.api.exception.RepositoryException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
-
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.RepositoryException;
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.serverError;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Provide a quasi-useful stacktrace when a generic RepositoryException is caught
@@ -45,13 +43,12 @@ public class RepositoryExceptionMapper implements
 
     @Override
     public Response toResponse(final RepositoryException e) {
+        LOGGER.error("Caught a repository exception", e);
 
-        LOGGER.error("Caught a repository exception: {}", e.getMessage());
-        debugException(this, e, LOGGER);
         if (e.getMessage().matches("Error converting \".+\" from String to a Name")) {
             return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
         }
 
-        return serverError().entity(getStackTraceAsString(e)).type(TEXT_PLAIN_WITH_CHARSET).build();
+        return serverError().entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapper.java
@@ -18,7 +18,6 @@
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-
 import org.slf4j.Logger;
 
 import javax.ws.rs.core.Context;
@@ -27,7 +26,6 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.ext.Providers;
 
-import static com.google.common.base.Throwables.getStackTraceAsString;
 import static javax.ws.rs.core.Response.serverError;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -65,8 +63,7 @@ public class RepositoryRuntimeExceptionMapper implements
         if (exceptionMapper != null) {
             return exceptionMapper.toResponse(cause);
         }
-        LOGGER.error("Caught a repository exception: {}", e.getMessage());
-        debugException(this, cause, LOGGER);
-        return serverError().entity(getStackTraceAsString(e)).type(TEXT_PLAIN_WITH_CHARSET).build();
+        LOGGER.error("Caught a repository exception", e);
+        return serverError().entity(null).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerErrorExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ServerErrorExceptionMapper.java
@@ -17,12 +17,12 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
+import org.slf4j.Logger;
+
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-
-import org.slf4j.Logger;
 
 import static javax.ws.rs.core.Response.fromResponse;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
@@ -41,7 +41,7 @@ public class ServerErrorExceptionMapper implements
 
     @Override
     public Response toResponse(final ServerErrorException e) {
-        debugException(this, e, LOGGER);
+        LOGGER.warn("Server error", e);
         return fromResponse(e.getResponse()).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WebApplicationExceptionMapper.java
@@ -17,16 +17,16 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static javax.ws.rs.core.Response.fromResponse;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
-import static org.slf4j.LoggerFactory.getLogger;
+import org.slf4j.Logger;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.slf4j.Logger;
+import static javax.ws.rs.core.Response.fromResponse;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Handle Jersey WebApplicationException
@@ -42,9 +42,7 @@ public class WebApplicationExceptionMapper implements
 
     @Override
     public Response toResponse(final WebApplicationException e) {
-        LOGGER.warn(
-                "WebApplicationException intercepted by WebApplicationExceptionMapper: {}\n", e.getMessage());
-        debugException(this, e, LOGGER);
+        LOGGER.warn("Web application error", e);
         final String msg = null == e.getCause() ? e.getMessage() : e.getCause().getMessage();
         // 204, 205, 304 MUST NOT contain an entity body - RFC2616
         switch (e.getResponse().getStatus()) {

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapper.java
@@ -17,17 +17,17 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
-import static com.google.common.base.Throwables.getStackTraceAsString;
-import static javax.ws.rs.core.Response.serverError;
-import static org.slf4j.LoggerFactory.getLogger;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import org.fcrepo.kernel.api.exception.SessionMissingException;
+import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
-import org.fcrepo.kernel.api.exception.SessionMissingException;
-import org.slf4j.Logger;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static javax.ws.rs.core.Response.serverError;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Catch all the exceptions!
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 public class WildcardExceptionMapper implements
         ExceptionMapper<Exception>, ExceptionDebugLogging {
 
-    Boolean showStackTrace = true;
+    Boolean showStackTrace = false;
 
     private static final Logger LOGGER =
         getLogger(WildcardExceptionMapper.class);
@@ -53,9 +53,7 @@ public class WildcardExceptionMapper implements
                     .toResponse((SessionMissingException) e.getCause());
         }
 
-
-        LOGGER.error("Exception intercepted by WildcardExceptionMapper: {}\n", e.getMessage());
-        debugException(this, e, LOGGER);
+        LOGGER.warn("Unmapped exception", e);
         return serverError().entity(
                 showStackTrace ? getStackTraceAsString(e) : null).type(TEXT_PLAIN_WITH_CHARSET).build();
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/RepositoryRuntimeExceptionMapperTest.java
@@ -56,7 +56,7 @@ public class RepositoryRuntimeExceptionMapperTest {
     public void testToResponseWithHandledRepositoryException() {
         when(mockProviders.getExceptionMapper(RepositoryException.class)).thenReturn(mockProvider);
         final RepositoryException cause = new RepositoryException("xyz");
-        final RepositoryRuntimeException ex = new RepositoryRuntimeException(cause);
+        final RepositoryRuntimeException ex = new RepositoryRuntimeException(cause.getMessage(), cause);
         testObj.toResponse(ex);
         verify(mockProvider).toResponse(cause);
     }
@@ -65,7 +65,7 @@ public class RepositoryRuntimeExceptionMapperTest {
     public void testToResponseWithUnhandledRepositoryException() {
         when(mockProviders.getExceptionMapper(Exception.class)).thenReturn(null);
         final Exception cause = new Exception("xyz");
-        final RepositoryRuntimeException ex = new RepositoryRuntimeException(cause);
+        final RepositoryRuntimeException ex = new RepositoryRuntimeException(cause.getMessage(), cause);
         final Response response = testObj.toResponse(ex);
         assertEquals(500, response.getStatus());
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapperTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/exceptionhandlers/WildcardExceptionMapperTest.java
@@ -17,15 +17,15 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import javax.ws.rs.core.Response;
-
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * <p>WildcardExceptionMapperTest class.</p>
@@ -43,6 +43,7 @@ public class WildcardExceptionMapperTest {
 
     @Test
     public void testToResponse() {
+        testObj.setShowStackTrace(true);
         final Exception input = new Exception();
         Response actual = testObj.toResponse(input);
         assertEquals(INTERNAL_SERVER_ERROR.getStatusCode(), actual.getStatus());

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/AccessDeniedException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/AccessDeniedException.java
@@ -28,12 +28,13 @@ public class AccessDeniedException extends RepositoryRuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Ordinary constructor.
+     * Constructor
      *
-     * @param rootCause the root cause
+     * @param msg message
+     * @param e cause
      */
-    public AccessDeniedException(final Throwable rootCause) {
-        super(rootCause);
+    public AccessDeniedException(final String msg, final Throwable e) {
+        super(msg, e);
     }
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConstraintViolationException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConstraintViolationException.java
@@ -39,15 +39,6 @@ public class ConstraintViolationException extends RepositoryRuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public ConstraintViolationException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InterruptedRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InterruptedRuntimeException.java
@@ -29,12 +29,13 @@ public class InterruptedRuntimeException extends RepositoryRuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Ordinary constructor
+     * Constructor
      *
-     * @param throwable that is being wrapped
+     * @param msg message
+     * @param e cause
      */
-    public InterruptedRuntimeException(final Throwable throwable) {
-        super(throwable);
+    public InterruptedRuntimeException(final String msg, final Throwable e) {
+        super(msg, e);
     }
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidACLException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidACLException.java
@@ -35,13 +35,4 @@ public class InvalidACLException extends ConstraintViolationException {
         super(msg);
     }
 
-    /**
-     * Ordinary constructor.
-     *
-     * @param rootCause the root cause
-     */
-    public InvalidACLException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ItemNotFoundException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ItemNotFoundException.java
@@ -39,15 +39,6 @@ public class ItemNotFoundException extends RepositoryRuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public ItemNotFoundException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MalformedRdfException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MalformedRdfException.java
@@ -42,15 +42,6 @@ public class MalformedRdfException extends ConstraintViolationException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public MalformedRdfException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundException.java
@@ -40,10 +40,10 @@ public class PathNotFoundException extends Exception {
     /**
      * Constructor for wrapping exception.
      *
-     * @param exception the original exception.
+     * @param message the original message.
+     * @param cause the root cause.
      */
-    public PathNotFoundException(final Throwable exception) {
-        super(exception);
+    public PathNotFoundException(final String message, final Throwable cause) {
+        super(message, cause);
     }
-
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
@@ -27,14 +27,6 @@ public class PathNotFoundRuntimeException extends RepositoryRuntimeException {
 
     /**
      * Wrap a PathNotFoundException in a runtime exception
-     * @param rootCause the root cause
-     */
-    public PathNotFoundRuntimeException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-    /**
-     * Wrap a PathNotFoundException in a runtime exception
      * @param message the original message.
      * @param rootCause the root cause.
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RepositoryRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RepositoryRuntimeException.java
@@ -37,16 +37,6 @@ public class RepositoryRuntimeException extends RuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public RepositoryRuntimeException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RepositoryVersionRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RepositoryVersionRuntimeException.java
@@ -27,14 +27,6 @@ public class RepositoryVersionRuntimeException extends RepositoryRuntimeExceptio
 
     /**
      * Wrap a RepositoryVersionException in a runtime exception
-     * @param rootCause the root cause
-     */
-    public RepositoryVersionRuntimeException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-    /**
-     * Wrap a RepositoryVersionException in a runtime exception
      * @param msg the message
      */
     public RepositoryVersionRuntimeException(final String msg) {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionClosedException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionClosedException.java
@@ -36,16 +36,6 @@ public class TransactionClosedException extends TransactionRuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public TransactionClosedException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionNotFoundException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionNotFoundException.java
@@ -36,16 +36,6 @@ public class TransactionNotFoundException extends TransactionRuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public TransactionNotFoundException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TransactionRuntimeException.java
@@ -37,16 +37,6 @@ public class TransactionRuntimeException extends RuntimeException {
     /**
      * Ordinary constructor.
      *
-     * @param rootCause the root cause
-     */
-    public TransactionRuntimeException(final Throwable rootCause) {
-        super(rootCause);
-    }
-
-
-    /**
-     * Ordinary constructor.
-     *
      * @param msg the message
      * @param rootCause the root cause
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
@@ -148,9 +148,9 @@ public final class ContentDigest {
 
             return new URI(scheme, value, null);
         } catch (final URISyntaxException unlikelyException) {
-            LOGGER.warn("Exception creating checksum URI: {}",
-                               unlikelyException);
-            throw new RepositoryRuntimeException(unlikelyException);
+            LOGGER.warn("Exception creating checksum URI: alg={}; value={}",
+                               algorithm, value);
+            throw new RepositoryRuntimeException(unlikelyException.getMessage(), unlikelyException);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -84,7 +84,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
             throw new ItemNotFoundException("Unable to find content for " + getId()
                     + " version " + getMementoDatetime(), e);
         } catch (final PersistentStorageException | IOException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 
@@ -138,7 +138,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
             }
             return resourceFactory.getResource(txId, descId);
         } catch (final PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+            throw new PathNotFoundRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -125,7 +125,7 @@ public class FedoraResourceImpl implements FedoraResource {
                 final var fedoraId = FedoraId.create(getFedoraId().getResourceId());
                 return getFedoraResource(fedoraId);
             } catch (final PathNotFoundException e) {
-                throw new PathNotFoundRuntimeException(e);
+                throw new PathNotFoundRuntimeException(e.getMessage(), e);
             }
         }
         return this;
@@ -245,7 +245,7 @@ public class FedoraResourceImpl implements FedoraResource {
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to retrieve headers for " + getId(), e);
         } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 
@@ -260,7 +260,7 @@ public class FedoraResourceImpl implements FedoraResource {
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
         } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 
@@ -274,7 +274,7 @@ public class FedoraResourceImpl implements FedoraResource {
         } catch (final PersistentItemNotFoundException e) {
             throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
         } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -70,7 +70,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
         try {
             return this.resourceFactory.getResource(txId, describedId);
         } catch (final PathNotFoundException e) {
-            throw new PathNotFoundRuntimeException(e);
+            throw new PathNotFoundRuntimeException(e.getMessage(), e);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -123,7 +123,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
                 return false;
             } catch (final PersistentStorageException e) {
                 // Other error, pass along.
-                throw new RepositoryRuntimeException(e);
+                throw new RepositoryRuntimeException(e.getMessage(), e);
             } finally {
                 if (transactionId == null) {
                     // Commit session (if read-only) so it doesn't hang around.
@@ -224,9 +224,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
         } catch (final SecurityException | ReflectiveOperationException e) {
             throw new RepositoryRuntimeException("Unable to construct object", e);
         } catch (final PersistentItemNotFoundException e) {
-            throw new PathNotFoundException(e);
+            throw new PathNotFoundException(e.getMessage(), e);
         } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e);
+            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
     }
 
@@ -280,7 +280,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
                 try {
                     return getResource(transactionId, FedoraId.create(childId));
                 } catch (final PathNotFoundException e) {
-                    throw new PathNotFoundRuntimeException(e);
+                    throw new PathNotFoundRuntimeException(e.getMessage(), e);
                 }
             });
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -126,7 +126,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
                 final var fedoraId = getInstantFedoraId(version);
                 return resourceFactory.getResource(txId, fedoraId);
             } catch (final PathNotFoundException e) {
-                throw new PathNotFoundRuntimeException(e);
+                throw new PathNotFoundRuntimeException(e.getMessage(), e);
             }
         });
     }
@@ -153,7 +153,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
             } catch (final PersistentItemNotFoundException e) {
                 throw new ItemNotFoundException("Unable to retrieve versions for " + getId(), e);
             } catch (final PersistentStorageException e) {
-                throw new RepositoryRuntimeException(e);
+                throw new RepositoryRuntimeException(e.getMessage(), e);
             }
         }
         return versions;

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -51,7 +51,7 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
 
             return resourceFactory.getResource(txId, originalId);
         } catch (final PathNotFoundException exc) {
-            throw new PathNotFoundRuntimeException(exc);
+            throw new PathNotFoundRuntimeException(exc.getMessage(), exc);
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -105,7 +105,7 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
                     }
                 } catch (final PathNotFoundException ex) {
                     log.error("Path not found for {}: {}", fedoraId.getFullId(), ex.getMessage());
-                    throw new PathNotFoundRuntimeException(ex);
+                    throw new PathNotFoundRuntimeException(ex.getMessage(), ex);
                 } catch (final PersistentStorageException ex) {
                     throw new RepositoryRuntimeException(format("failed to delete resource %s", fedoraId.getFullId()),
                             ex);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
@@ -64,9 +64,9 @@ public class UpdatePropertiesServiceImpl extends AbstractService implements Upda
             UpdateAction.execute(request, model);
             replacePropertiesService.perform(txId, userPrincipal, fedoraId, model);
         } catch (final PersistentItemNotFoundException ex) {
-            throw new ItemNotFoundException(ex);
+            throw new ItemNotFoundException(ex.getMessage(), ex);
         } catch (final PersistentStorageException ex) {
-            throw new RepositoryRuntimeException(ex);
+            throw new RepositoryRuntimeException(ex.getMessage(), ex);
         }
 
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
@@ -17,11 +17,6 @@
  */
 package org.fcrepo.kernel.impl.services;
 
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_WEBAC_ACL_URI;
-import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
-
-import javax.inject.Inject;
-
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
@@ -39,6 +34,11 @@ import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_WEBAC_ACL_URI;
+import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 
 /**
  * Implementation of {@link WebacAclService}
@@ -62,7 +62,7 @@ public class WebacAclServiceImpl extends AbstractService implements WebacAclServ
         try {
             return resourceFactory.getResource(transaction, fedoraId, WebacAclImpl.class);
         } catch (final PathNotFoundException exc) {
-            throw new PathNotFoundRuntimeException(exc);
+            throw new PathNotFoundRuntimeException(exc.getMessage(), exc);
         }
     }
 

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/PersistentStorageException.java
@@ -51,11 +51,4 @@ public class PersistentStorageException extends RepositoryRuntimeException {
         super(msg, e);
     }
 
-    /**
-     * Constructor
-     * @param e cause
-     */
-    public PersistentStorageException(final Throwable e) {
-        super(e);
-    }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -97,7 +97,7 @@ public class RepositoryInitializer {
             }
 
         } catch (PersistentStorageException ex) {
-            throw new RepositoryRuntimeException(ex);
+            throw new RepositoryRuntimeException(ex.getMessage(), ex);
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -116,7 +116,7 @@ abstract class AbstractPersister implements Persister {
                 //do nothing since there are cases where the resourceId will be the resource
                 //that is about to be created and thus will not yet exist in peristent storage.
             } catch (final PersistentStorageException ex) {
-                throw new RepositoryRuntimeException(ex);
+                throw new RepositoryRuntimeException(ex.getMessage(), ex);
             }
 
             //get the previous path segment not including the trailing slash

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -155,7 +155,7 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
         } catch (NotFoundException e) {
             throw new PersistentItemNotFoundException(e.getMessage(), e);
         } catch (Exception e) {
-            throw new PersistentStorageException(e);
+            throw new PersistentStorageException(e.getMessage(), e);
         }
     }
 
@@ -165,7 +165,7 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
         } catch (NotFoundException e) {
             throw new PersistentItemNotFoundException(e.getMessage(), e);
         } catch (Exception e) {
-            throw new PersistentStorageException(e);
+            throw new PersistentStorageException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?

1. Stacktraces are never returned by default
2. Server exceptions are always logged by default (client exceptions remain on debug only)
3. Removed custom exception constructors that do not accept an exception message. The problem with these constructors is that Java appends the exception class name to the wrapped exception message if a message is not provided. This creates a problem for Fedora's HTTP exception mapping, which tends to rely on calling `getMessage()`.

# How should this be tested?

Do some bad stuff and make sure you like how the exceptions are handled.

# Interested parties
@fcrepo/committers
