### PR TITLE
get fedora working against s3

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/Storage.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/Storage.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.config;
+
+/**
+ * Indicates what storage backend to use.
+ *
+ * @author pwinckles
+ */
+public enum Storage {
+
+    OCFL_FILESYSTEM("ocfl-fs"),
+    OCFL_S3("ocfl-s3");
+
+    private final String value;
+
+    Storage(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static Storage fromString(final String value) {
+        for (var storage : values()) {
+            if (storage.value.equalsIgnoreCase(value)) {
+                return storage;
+            }
+        }
+        throw new IllegalArgumentException("Unknown storage: " + value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -70,7 +70,46 @@
       <artifactId>fcrepo-storage-ocfl</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>edu.wisc.library.ocfl</groupId>
+      <artifactId>ocfl-java-aws</artifactId>
+      <version>${ocfl-java.version}</version>
+      <!--
+      These are convergence issues stemming from within the AWS SDK. These deps must be manually kept up-to-date
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.reactivestreams</groupId>
+          <artifactId>reactive-streams</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Needed for the AWS SDK. See above exclusions -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>4.1.46.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>4.1.46.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -24,9 +24,14 @@ import edu.wisc.library.ocfl.api.DigestAlgorithmRegistry;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.OcflConfig;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
+import edu.wisc.library.ocfl.aws.OcflS3Client;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
+import edu.wisc.library.ocfl.core.db.ObjectDetailsDatabaseBuilder;
 import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.lock.ObjectLockBuilder;
+import edu.wisc.library.ocfl.core.path.constraint.ContentPathConstraints;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
+import edu.wisc.library.ocfl.core.storage.cloud.CloudOcflStorage;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.http.impl.auth.UnsupportedDigestAlgorithmException;
@@ -35,10 +40,13 @@ import org.fcrepo.kernel.api.utils.ContentDigest;
 import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.S3Client;
 
+import javax.sql.DataSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Consumer;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static org.apache.jena.riot.RDFFormat.NTRIPLES;
@@ -78,17 +86,61 @@ public class OcflPersistentStorageUtils {
     }
 
     /**
-     * Create a new ocfl repository
+     * Create a new ocfl repository backed by the filesystem
      * @param ocflStorageRootDir The ocfl storage root directory
      * @param ocflWorkDir The ocfl work directory
      * @return the repository
      */
-    public static MutableOcflRepository createRepository(final Path ocflStorageRootDir, final Path ocflWorkDir)
-            throws IOException {
+    public static MutableOcflRepository createFilesystemRepository(final Path ocflStorageRootDir,
+                                                                   final Path ocflWorkDir) throws IOException {
         Files.createDirectories(ocflStorageRootDir);
+
+        final var storage = FileSystemOcflStorage.builder().repositoryRoot(ocflStorageRootDir).build();
+
+        return createRepository(ocflWorkDir, builder -> {
+            builder.storage(storage);
+        });
+    }
+
+    /**
+     * Create a new ocfl repository backed by s3
+     *
+     * @param dataSource the datasource to keep inventories in and use as a lock
+     * @param s3Client aws s3 client
+     * @param bucket the bucket to store objects in
+     * @param prefix the prefix within the bucket to store objects under
+     * @param ocflWorkDir the local directory to stage objects in
+     * @return the repository
+     */
+    public static MutableOcflRepository createS3Repository(final DataSource dataSource,
+                                                           final S3Client s3Client,
+                                                           final String bucket,
+                                                           final String prefix,
+                                                           final Path ocflWorkDir) throws IOException {
         Files.createDirectories(ocflWorkDir);
 
-        log.debug("Fedora OCFL persistence directories:\n- {}\n- {}", ocflStorageRootDir, ocflWorkDir);
+        final var storage = CloudOcflStorage.builder()
+                .cloudClient(OcflS3Client.builder()
+                        .s3Client(s3Client)
+                        .bucket(bucket)
+                        .repoPrefix(prefix)
+                        .build())
+                .workDir(ocflWorkDir)
+                .build();
+
+        return createRepository(ocflWorkDir, builder -> {
+            builder.contentPathConstraints(ContentPathConstraints.cloud())
+                    .objectLock(new ObjectLockBuilder().buildDbLock(dataSource))
+                    .objectDetailsDb(new ObjectDetailsDatabaseBuilder().build(dataSource))
+                    .storage(storage);
+        });
+    }
+
+    private static MutableOcflRepository createRepository(final Path ocflWorkDir,
+                                                          final Consumer<OcflRepositoryBuilder> configurer)
+            throws IOException {
+        Files.createDirectories(ocflWorkDir);
+
         final var defaultFcrepoAlg = ContentDigest.DEFAULT_DIGEST_ALGORITHM;
         final DigestAlgorithm ocflDigestAlg = translateFedoraDigestToOcfl(defaultFcrepoAlg);
         if (ocflDigestAlg == null) {
@@ -99,13 +151,15 @@ public class OcflPersistentStorageUtils {
         final var logicalPathMapper = SystemUtils.IS_OS_WINDOWS ?
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
-        return new OcflRepositoryBuilder()
+        final var builder = new OcflRepositoryBuilder()
                 .layoutConfig(new HashedTruncatedNTupleConfig())
                 .ocflConfig(new OcflConfig().setDefaultDigestAlgorithm(ocflDigestAlg))
                 .logicalPathMapper(logicalPathMapper)
-                .storage((FileSystemOcflStorage.builder().repositoryRoot(ocflStorageRootDir).build()))
-                .workDir(ocflWorkDir)
-                .buildMutable();
+                .workDir(ocflWorkDir);
+
+        configurer.accept(builder);
+
+        return builder.buildMutable();
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -52,7 +52,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.DELETE;
-import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createRepository;
+import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createFilesystemRepository;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -101,7 +101,7 @@ public class IndexBuilderImplTest {
         final var workDir = dataDir.resolve("ocfl-work");
         final var staging = dataDir.resolve("ocfl-staging");
 
-        final var repository = createRepository(repoDir, workDir);
+        final var repository = createFilesystemRepository(repoDir, workDir);
 
         index = new TestOcflObjectIndex();
         index.reset();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -63,7 +63,7 @@ import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
-import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createRepository;
+import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createFilesystemRepository;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
@@ -146,7 +146,7 @@ public class OcflPersistentStorageSessionTest {
         final var workDir = tempFolder.newFolder("ocfl-work").toPath();
 
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
-        final var repository = createRepository(repoDir, workDir);
+        final var repository = createFilesystemRepository(repoDir, workDir);
         objectSessionFactory = new DefaultOcflObjectSessionFactory(repository, stagingDir,
                 objectMapper, CommitType.NEW_VERSION,
                 "Fedora 6 test", "fedoraAdmin", "info:fedora/fedoraAdmin");

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jgroups.version>4.0.13.Final</jgroups.version>
     <jsonld.version>0.12.1</jsonld.version>
     <logback.version>1.2.3</logback.version>
-    <ocfl-java.version>0.0.4-SNAPSHOT</ocfl-java.version>
+    <ocfl-java.version>0.0.5-SNAPSHOT</ocfl-java.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy-java.version>1.1.7.2</snappy-java.version>
     <spring.version>5.2.7.RELEASE</spring.version>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3436

# What does this Pull Request do?

Allows you to configure Fedora to write directly to S3 rather than the filesystem.

Note: This integration seems VERY SLOW. I have not done any investigation into the root cause, but I suspect it's a combination of inefficiencies in Fedora (eg repeatedly reading the resource headers) and inefficiencies in the ocfl-java S3 implementation, which works but is not as optimized as it could be.

Another note, ocfl-java only supports H2 and Postgres, and really the H2 support only exists for testing. The database is necessary to work around eventual consistency issues. After the troubles I've seen here when working with MySQL, I'm less inclined to add support for additional databases...

# How should this be tested?

1. Create a AWS user and bucket with the [necessary permissions](https://github.com/UW-Madison-Library/ocfl-java#amazon-s3).
2. [Setup your credentials](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/setup-credentials.html)
3. Start Fedora, something along these lines: `mvn -Dfcrepo.storage=ocfl-s3 -Dfcrepo.aws.region=us-east-2 -Dfcrepo.ocfl.s3.bucket=pwinckles-ocfl -Dfcrepo.ocfl.s3.prefix=fcrepo-1 clean jetty:run`
4. Use Fedora normally

[rocfl](https://github.com/pwinckles/rocfl/) supports S3. For example, `rocfl -b pwinckles-ocfl -R us-east-2 -r fcrepo-1 ls -l`

# Interested parties
@fcrepo/committers
