### PR TITLE
Make ghost nodes immutable - FCREPO-3256

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -92,6 +92,16 @@ abstract public class FedoraBaseResource extends AbstractResource {
         return resourceFactory.doesResourceExist(transaction, fedoraId);
     }
 
+    /**
+     *
+     * @param transaction the transaction in which to check
+     * @param fedoraId identifier of the object to check
+     * @return Returns true if object does not exist but whose ID starts other resources that do exist.
+     */
+    protected boolean isGhostNode(final Transaction transaction, final FedoraId fedoraId) {
+        return resourceFactory.isGhostNode(transaction, fedoraId);
+    }
+
     protected String getUserPrincipal() {
         final Principal p = securityContext.getUserPrincipal();
         return p == null ? null : p.getName();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -26,6 +26,7 @@ import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.ResourceHelper;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
@@ -49,6 +50,9 @@ abstract public class FedoraBaseResource extends AbstractResource {
 
     @Inject
     protected ResourceFactory resourceFactory;
+
+    @Inject
+    protected ResourceHelper resourceHelper;
 
     @Context protected HttpServletRequest servletRequest;
 
@@ -89,7 +93,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
      * @return Returns true if an object with the provided id exists
      */
     protected boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId) {
-        return resourceFactory.doesResourceExist(transaction, fedoraId);
+        return resourceHelper.doesResourceExist(transaction, fedoraId);
     }
 
     /**
@@ -99,7 +103,7 @@ abstract public class FedoraBaseResource extends AbstractResource {
      * @return Returns true if object does not exist but whose ID starts other resources that do exist.
      */
     protected boolean isGhostNode(final Transaction transaction, final FedoraId fedoraId) {
-        return resourceFactory.isGhostNode(transaction, fedoraId);
+        return resourceHelper.isGhostNode(transaction, fedoraId);
     }
 
     protected String getUserPrincipal() {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -408,7 +408,7 @@ public class FedoraLdp extends ContentExposingResource {
         }
 
         if (isGhostNode(transaction(), fedoraId)) {
-            throw new GhostNodeException("Resource path " + externalPath() + " is an immutable node.");
+            throw new GhostNodeException("Resource path " + externalPath() + " is an immutable resource.");
         }
 
         // TODO: Refactor to check preconditions
@@ -808,7 +808,7 @@ public class FedoraLdp extends ContentExposingResource {
         final FedoraId fullTestPath = fedoraId.resolve(pid);
 
         if (doesResourceExist(transaction(), fullTestPath) || isGhostNode(transaction(), fullTestPath)) {
-            LOGGER.debug("Resource with path {} already exists or is ghost node; minting new path instead",
+            LOGGER.debug("Resource with path {} already exists or is an immutable resource; minting new path instead",
                     fullTestPath);
             return mintNewPid(fedoraId, null);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -96,6 +96,7 @@ import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
+import org.fcrepo.kernel.api.exception.GhostNodeException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
@@ -404,6 +405,10 @@ public class FedoraLdp extends ContentExposingResource {
             //    throw new InteractionModelViolationException("Changing the interaction model " + resInteractionModel
             //            + " to " + interactionModel + " is not allowed!");
             //}
+        }
+
+        if (isGhostNode(transaction(), fedoraId)) {
+            throw new GhostNodeException("Resource path " + externalPath() + " is an immutable node.");
         }
 
         // TODO: Refactor to check preconditions
@@ -802,8 +807,9 @@ public class FedoraLdp extends ContentExposingResource {
 
         final FedoraId fullTestPath = fedoraId.resolve(pid);
 
-        if (doesResourceExist(transaction(), fullTestPath)) {
-            LOGGER.debug("Resource with path {} already exists; minting new path instead", fullTestPath);
+        if (doesResourceExist(transaction(), fullTestPath) || isGhostNode(transaction(), fullTestPath)) {
+            LOGGER.debug("Resource with path {} already exists or is ghost node; minting new path instead",
+                    fullTestPath);
             return mintNewPid(fedoraId, null);
         }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -128,6 +128,7 @@ import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.ResourceHelper;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 import org.fcrepo.kernel.api.services.ContainmentTriplesService;
@@ -195,6 +196,9 @@ public class FedoraLdpTest {
 
     @Mock
     private ResourceFactory resourceFactory;
+
+    @Mock
+    private ResourceHelper resourceHelper;
 
     @Mock
     private TimeMapService mockTimeMapService;
@@ -276,6 +280,7 @@ public class FedoraLdpTest {
         setField(testObj, "createResourceService", createResourceService);
         setField(testObj, "replacePropertiesService", replacePropertiesService);
         setField(testObj, "updatePropertiesService", updatePropertiesService);
+        setField(testObj, "resourceHelper", resourceHelper);
 
         when(rdfNamespaceRegistry.getNamespaces()).thenReturn(new HashMap<>());
 
@@ -290,7 +295,7 @@ public class FedoraLdpTest {
         when(mockContainer.getDescribedResource()).thenReturn(mockContainer);
         when(mockContainer.getFedoraId()).thenReturn(pathId);
 
-        when(resourceFactory.doesResourceExist(mockTransaction, pathId)).thenReturn(false);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(false);
 
         when(mockNonRdfSourceDescription.getEtagValue()).thenReturn("");
         when(mockNonRdfSourceDescription.getStateToken()).thenReturn("");
@@ -995,7 +1000,7 @@ public class FedoraLdpTest {
         final Container mockObject = (Container)setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("PUT");
         when(resourceFactory.getResource(mockTransaction, pathId)).thenReturn(mockObject);
-        when(resourceFactory.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
 
         final Response actual = testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
@@ -1010,7 +1015,7 @@ public class FedoraLdpTest {
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(true);
         when(resourceFactory.getResource(mockTransaction, pathId)).thenReturn(mockContainer);
-        when(resourceFactory.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
 
         testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/GhostNodeExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/GhostNodeExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.status;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.fcrepo.kernel.api.exception.GhostNodeException;
+
+/**
+ * Map an GhostNodeException to a response.
+ * @author whikloj
+ */
+@Provider
+public class GhostNodeExceptionMapper implements ExceptionMapper<GhostNodeException> {
+
+    @Override
+    public Response toResponse(final GhostNodeException e) {
+        final String msg = e.getMessage();
+        return status(CONFLICT).entity(msg).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -50,45 +50,45 @@ public interface ContainmentIndex {
 
     /**
      * Return the ID of the containing resource for resourceID.
-     * @param txID The transaction id, or null if no transaction
+     * @param txId The transaction id, or null if no transaction
      * @param resource The FedoraId of the resource to find the containing resource for.
      * @return The id of the containing resource or null if none found.
      */
-    String getContainedBy(String txID, final FedoraId resource);
+    String getContainedBy(String txId, final FedoraId resource);
 
     /**
      * Mark a contained by relation between the child resource and its parent as deleted.
      *
-     * @param txID The transaction ID.
+     * @param txId The transaction ID.
      * @param parent The containing resource fedoraID.
      * @param child The contained resource fedoraID.
      */
-    void removeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
+    void removeContainedBy(@Nonnull final String txId, final FedoraId parent, final FedoraId child);
 
     /**
      * Mark all relationships to the specified resource as deleted.
      *
-     * @param txID The transaction ID.
+     * @param txId The transaction ID.
      * @param resource The FedoraId of resource to remove.
      */
-    void removeResource(@Nonnull final String txID, final FedoraId resource);
+    void removeResource(@Nonnull final String txId, final FedoraId resource);
 
     /**
      * Remove all relationships to the specified resource.
      *
-     * @param txID The transaction ID.
+     * @param txId The transaction ID.
      * @param resource The FedoraId of resource to remove.
      */
-    void purgeResource(@Nonnull final String txID, final FedoraId resource);
+    void purgeResource(@Nonnull final String txId, final FedoraId resource);
 
     /**
      * Add a contained by relation between the child resource and its parent.
      *
-     * @param txID The transaction ID.
+     * @param txId The transaction ID.
      * @param parent The containing resource fedoraID.
      * @param child The contained resource fedoraID.
      */
-    void addContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child);
+    void addContainedBy(@Nonnull final String txId, final FedoraId parent, final FedoraId child);
 
     /**
      * Commit the changes made in the transaction.
@@ -105,19 +105,19 @@ public interface ContainmentIndex {
     /**
      * Check if the resourceID exists in the containment index. Which should mean it exists.
      *
-     * @param txID The transaction id, or null if no transaction
+     * @param txId The transaction id, or null if no transaction
      * @param fedoraID The resource's FedoraId.
      * @return True if it is in the index.
      */
-    boolean resourceExists(final String txID, final FedoraId fedoraID);
+    boolean resourceExists(final String txId, final FedoraId fedoraID);
 
     /**
      * Find the ID for the container of the provided resource by iterating up the path until you find a real resource.
-     * @param txID The transaction id, or null if no transaction
+     * @param txId The transaction id, or null if no transaction
      * @param fedoraId The resource's ID.
      * @return The container ID.
      */
-    FedoraId getContainerIdByPath(final String txID, final FedoraId fedoraId);
+    FedoraId getContainerIdByPath(final String txId, final FedoraId fedoraId);
 
     /**
      * Truncates the containment index. This should only be called when rebuilding the index.
@@ -126,9 +126,9 @@ public interface ContainmentIndex {
 
     /**
      * Find whether there are any resources that starts with the ID provided.
-     * @param txID The transaction id, or null if no transaction.
+     * @param txId The transaction id, or null if no transaction.
      * @param fedoraId The ID to use to look for other IDs.
      * @return Are there any matching IDs.
      */
-    boolean hasResourcesStartingWith(final String txID, final FedoraId fedoraId);
+    boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -106,10 +106,10 @@ public interface ContainmentIndex {
      * Check if the resourceID exists in the containment index. Which should mean it exists.
      *
      * @param txId The transaction id, or null if no transaction
-     * @param fedoraID The resource's FedoraId.
+     * @param fedoraId The resource's FedoraId.
      * @return True if it is in the index.
      */
-    boolean resourceExists(final String txId, final FedoraId fedoraID);
+    boolean resourceExists(final String txId, final FedoraId fedoraId);
 
     /**
      * Find the ID for the container of the provided resource by iterating up the path until you find a real resource.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -124,4 +124,11 @@ public interface ContainmentIndex {
      */
     void reset();
 
+    /**
+     * Find whether there are any resources that starts with the ID provided.
+     * @param txID The transaction id, or null if no transaction.
+     * @param fedoraId The ID to use to look for other IDs.
+     * @return Are there any matching IDs.
+     */
+    boolean hasResourcesStartingWith(final String txID, final FedoraId fedoraId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/GhostNodeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/GhostNodeException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Exception when trying to alter an immutable node.
+ * @author whikloj
+ */
+public class GhostNodeException extends RepositoryRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public GhostNodeException(final String msg) {
+        super(msg);
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/GhostNodeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/GhostNodeException.java
@@ -18,7 +18,7 @@
 package org.fcrepo.kernel.api.exception;
 
 /**
- * Exception when trying to alter an immutable node.
+ * Exception when trying to alter an immutable resource.
  * @author whikloj
  */
 public class GhostNodeException extends RepositoryRuntimeException {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
@@ -89,15 +89,6 @@ public interface ResourceFactory {
                                                     final Class<T> clazz) throws PathNotFoundException;
 
     /**
-     * Check if a resource exists.
-     * @param transaction The current transaction
-     * @param fedoraId The internal identifier
-     * @return True if the identifier resolves to a resource.
-     */
-    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId);
-
-
-    /**
      * Get the containing resource (if exists).
      * @param transactionId The current transaction id
      * @param resourceId The internal identifier
@@ -113,16 +104,4 @@ public interface ResourceFactory {
      */
     public Stream<FedoraResource> getChildren(final String transactionId, final FedoraId resourceId);
 
-    /**
-     * Is the resource a "ghost node". Ghost nodes are defined as a resource that does not exist, but whose URI is part
-     * of the URI of another resource? For example:
-     *
-     * http://localhost/rest/a/b - does exist
-     * http://localhost/rest/a - does not exist and is therefore a ghost node.
-     *
-     * @param transaction The transaction
-     * @param resourceId Identifier of the resource
-     * @return Whether the resource does not exist, but has
-     */
-    public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceFactory.java
@@ -112,4 +112,17 @@ public interface ResourceFactory {
      * @return Stream of child resources
      */
     public Stream<FedoraResource> getChildren(final String transactionId, final FedoraId resourceId);
+
+    /**
+     * Is the resource a "ghost node". Ghost nodes are defined as a resource that does not exist, but whose URI is part
+     * of the URI of another resource? For example:
+     *
+     * http://localhost/rest/a/b - does exist
+     * http://localhost/rest/a - does not exist and is therefore a ghost node.
+     *
+     * @param transaction The transaction
+     * @param resourceId Identifier of the resource
+     * @return Whether the resource does not exist, but has
+     */
+    public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.models;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
+/**
+ * Utility class interface for helper methods.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public interface ResourceHelper {
+
+    /**
+     * Check if a resource exists.
+     * @param transaction The current transaction
+     * @param fedoraId The internal identifier
+     * @return True if the identifier resolves to a resource.
+     */
+    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId);
+
+    /**
+     * Is the resource a "ghost node". Ghost nodes are defined as a resource that does not exist, but whose URI is part
+     * of the URI of another resource? For example:
+     *
+     * http://localhost/rest/a/b - does exist
+     * http://localhost/rest/a - does not exist and is therefore a ghost node.
+     *
+     * @param transaction The transaction
+     * @param resourceId Identifier of the resource
+     * @return Whether the resource does not exist, but has
+     */
+    public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId);
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -364,13 +364,13 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public String getContainedBy(final String txID, final FedoraId resource) {
+    public String getContainedBy(final String txId, final FedoraId resource) {
         final String resourceID = resource.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
         final List<String> parentID;
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
+        if (txId != null) {
+            parameterSource.addValue("transactionId", txId);
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS_IN_TRANSACTION, parameterSource, String.class);
         } else {
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS, parameterSource, String.class);
@@ -379,16 +379,16 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public void addContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child) {
+    public void addContainedBy(@Nonnull final String txId, final FedoraId parent, final FedoraId child) {
         final String parentID = parent.getFullId();
         final String childID = child.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
 
-        LOGGER.debug("Adding: parent: {}, child: {}, in txn: {}", parentID, childID, txID);
+        LOGGER.debug("Adding: parent: {}, child: {}, in txn: {}", parentID, childID, txId);
 
         parameterSource.addValue("parent", parentID);
         parameterSource.addValue("child", childID);
-        parameterSource.addValue("transactionId", txID);
+        parameterSource.addValue("transactionId", txId);
         final boolean purgedInTxn = !jdbcTemplate.queryForList(IS_CHILD_PURGED_IN_TRANSACTION, parameterSource)
                 .isEmpty();
         if (purgedInTxn) {
@@ -399,13 +399,13 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public void removeContainedBy(@Nonnull final String txID, final FedoraId parent, final FedoraId child) {
+    public void removeContainedBy(@Nonnull final String txId, final FedoraId parent, final FedoraId child) {
         final String parentID = parent.getFullId();
         final String childID = child.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("parent", parentID);
         parameterSource.addValue("child", childID);
-        parameterSource.addValue("transactionId", txID);
+        parameterSource.addValue("transactionId", txId);
         final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION, parameterSource)
                 .isEmpty();
         if (addedInTxn) {
@@ -416,17 +416,17 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public void removeResource(@Nonnull final String txID, final FedoraId resource) {
+    public void removeResource(@Nonnull final String txId, final FedoraId resource) {
         final String resourceID = resource.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
-        parameterSource.addValue("transactionId", txID);
+        parameterSource.addValue("transactionId", txId);
         final boolean addedInTxn = !jdbcTemplate.queryForList(IS_CHILD_ADDED_IN_TRANSACTION_NO_PARENT,
                 parameterSource).isEmpty();
         if (addedInTxn) {
             jdbcTemplate.update(UNDO_INSERT_CHILD_IN_TRANSACTION_NO_PARENT, parameterSource);
         } else {
-            final String parent = getContainedBy(txID, resource);
+            final String parent = getContainedBy(txId, resource);
             if (parent != null) {
                 LOGGER.debug("Marking containment relationship between parent ({}) and child ({}) deleted", parent,
                         resourceID);
@@ -437,12 +437,12 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public void purgeResource(@Nonnull final String txID, final FedoraId resource) {
+    public void purgeResource(@Nonnull final String txId, final FedoraId resource) {
         final String resourceID = resource.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
-        parameterSource.addValue("transactionId", txID);
-        final String parent = getContainedByDeleted(txID, resource);
+        parameterSource.addValue("transactionId", txId);
+        final String parent = getContainedByDeleted(txId, resource);
         final boolean deletedInTxn = !jdbcTemplate.queryForList(IS_CHILD_DELETED_IN_TRANSACTION_NO_PARENT,
                 parameterSource).isEmpty();
         if (deletedInTxn) {
@@ -457,17 +457,17 @@ public class ContainmentIndexImpl implements ContainmentIndex {
 
     /**
      * Find parent for a resource using a deleted containment relationship.
-     * @param txID the transaction id.
+     * @param txId the transaction id.
      * @param resource the child resource id.
      * @return the parent id.
      */
-    private String getContainedByDeleted(final String txID, final FedoraId resource) {
+    private String getContainedByDeleted(final String txId, final FedoraId resource) {
         final String resourceID = resource.getFullId();
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
         final List<String> parentID;
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
+        if (txId != null) {
+            parameterSource.addValue("transactionId", txId);
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS_DELETED_IN_TRANSACTION, parameterSource, String.class);
         } else {
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS_DELETED, parameterSource, String.class);
@@ -504,10 +504,10 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public boolean resourceExists(final String txID, final FedoraId fedoraID) {
+    public boolean resourceExists(final String txId, final FedoraId fedoraID) {
         // Get the containing ID because fcr:metadata will not exist here but MUST exist if the containing resource does
         final String resourceID = fedoraID.getBaseId();
-        LOGGER.debug("Checking if {} exists in transaction {}", resourceID, txID);
+        LOGGER.debug("Checking if {} exists in transaction {}", resourceID, txId);
         if (fedoraID.isRepositoryRoot()) {
             // Root always exists.
             return true;
@@ -515,8 +515,8 @@ public class ContainmentIndexImpl implements ContainmentIndex {
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("child", resourceID);
         final boolean exists;
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
+        if (txId != null) {
+            parameterSource.addValue("transactionId", txId);
             exists = !jdbcTemplate.queryForList(RESOURCE_EXISTS_IN_TRANSACTION, parameterSource, String.class)
                     .isEmpty();
         } else {
@@ -526,12 +526,12 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public FedoraId getContainerIdByPath(final String txID, final FedoraId fedoraId) {
+    public FedoraId getContainerIdByPath(final String txId, final FedoraId fedoraId) {
         if (fedoraId.isRepositoryRoot()) {
             // If we are root then we are the top.
             return fedoraId;
         }
-        final String parent = getContainedBy(txID, fedoraId);
+        final String parent = getContainedBy(txId, fedoraId);
         if (parent != null) {
             return FedoraId.create(parent);
         }
@@ -542,7 +542,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
                 return FedoraId.getRepositoryRootId();
             }
             final FedoraId testID = FedoraId.create(fullId);
-            if (resourceExists(txID, testID)) {
+            if (resourceExists(txId, testID)) {
                 return testID;
             }
         }
@@ -561,12 +561,12 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public boolean hasResourcesStartingWith(final String txID, final FedoraId fedoraId) {
+    public boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId) {
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
         parameterSource.addValue("resourceId", fedoraId.getFullId() + "/%");
         final boolean matchingIds;
-        if (txID != null) {
-            parameterSource.addValue("transactionId", txID);
+        if (txId != null) {
+            parameterSource.addValue("transactionId", txId);
             matchingIds = !jdbcTemplate.queryForList(SELECT_ID_LIKE_IN_TRANSACTION, parameterSource, String.class)
                 .isEmpty();
         } else {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -504,16 +504,16 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
-    public boolean resourceExists(final String txId, final FedoraId fedoraID) {
+    public boolean resourceExists(final String txId, final FedoraId fedoraId) {
         // Get the containing ID because fcr:metadata will not exist here but MUST exist if the containing resource does
-        final String resourceID = fedoraID.getBaseId();
-        LOGGER.debug("Checking if {} exists in transaction {}", resourceID, txId);
-        if (fedoraID.isRepositoryRoot()) {
+        final String resourceId = fedoraId.getBaseId();
+        LOGGER.debug("Checking if {} exists in transaction {}", resourceId, txId);
+        if (fedoraId.isRepositoryRoot()) {
             // Root always exists.
             return true;
         }
         final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-        parameterSource.addValue("child", resourceID);
+        parameterSource.addValue("child", resourceId);
         final boolean exists;
         if (txId != null) {
             parameterSource.addValue("transactionId", txId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -66,6 +66,8 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
             DB, CONTAINMENT, OPERATION, "getContainerIdByPath");
     private static final Timer resetTimer = Metrics.timer(METRIC_NAME,
             DB, CONTAINMENT, OPERATION, "reset");
+    private static final Timer hasResourcesStartingWithTimer = Metrics.timer(METRIC_NAME,
+            DB, CONTAINMENT, OPERATION, "hasResourcesStartingWith");
 
     @Autowired
     @Qualifier("containmentIndexImpl")
@@ -153,5 +155,11 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
         resetTimer.record(() -> {
             containmentIndexImpl.reset();
         });
+    }
+
+    @Override
+    public boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId) {
+        return MetricsHelper.time(hasResourcesStartingWithTimer, () ->
+                containmentIndexImpl.hasResourcesStartingWith(txId, fedoraId));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -137,9 +137,9 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
     }
 
     @Override
-    public boolean resourceExists(final String txID, final FedoraId fedoraID) {
+    public boolean resourceExists(final String txID, final FedoraId fedoraId) {
         return MetricsHelper.time(resourceExistsTimer, () -> {
-            return containmentIndexImpl.resourceExists(txID, fedoraID);
+            return containmentIndexImpl.resourceExists(txID, fedoraId);
         });
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -153,6 +153,14 @@ public class ResourceFactoryImpl implements ResourceFactory {
         }
     }
 
+    @Override
+    public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId) {
+        if (!doesResourceExist(transaction, resourceId)) {
+            return containmentIndex.hasResourcesStartingWith(TransactionUtils.openTxId(transaction), resourceId);
+        }
+        return false;
+    }
+
     /**
      * Returns the appropriate FedoraResource class for an object based on the provided headers
      *

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.inject.Inject;
+
+import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.TransactionUtils;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.kernel.api.models.ResourceHelper;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.common.ResourceHeadersImpl;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility class for helper methods.
+ * @author whikloj
+ * @since 6.0.0
+ */
+@Component
+public class ResourceHelperImpl implements ResourceHelper {
+
+    private static final Logger LOGGER = getLogger(ResourceHeadersImpl.class);
+
+    @Inject
+    private PersistentStorageSessionManager persistentStorageSessionManager;
+
+    @Autowired
+    @Qualifier("containmentIndex")
+    private ContainmentIndex containmentIndex;
+
+    @Override
+    public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId) {
+        if (!doesResourceExist(transaction, resourceId)) {
+            return containmentIndex.hasResourcesStartingWith(TransactionUtils.openTxId(transaction), resourceId);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId) {
+        final String transactionId = TransactionUtils.openTxId(transaction);
+        if (fedoraId.isRepositoryRoot()) {
+            // Root always exists.
+            return true;
+        }
+        if (!(fedoraId.isMemento() || fedoraId.isAcl())) {
+            // containment index doesn't handle versions and only tells us if the resource (not acl) is there,
+            // so don't bother checking for them.
+            return containmentIndex.resourceExists(transactionId, fedoraId);
+        } else {
+
+            final PersistentStorageSession psSession = getSession(transactionId);
+
+            try {
+                // Resource ID for metadata or ACL contains their individual endopoints (ie. fcr:metadata, fcr:acl)
+                final ResourceHeaders headers = psSession.getHeaders(fedoraId, fedoraId.getMementoInstant());
+                return !headers.isDeleted();
+            } catch (final PersistentItemNotFoundException e) {
+                // Object doesn't exist.
+                return false;
+            } catch (final PersistentStorageException e) {
+                // Other error, pass along.
+                throw new RepositoryRuntimeException(e.getMessage(), e);
+            } finally {
+                if (transactionId == null) {
+                    // Commit session (if read-only) so it doesn't hang around.
+                    try {
+                        psSession.commit();
+                    } catch (final PersistentStorageException e) {
+                        LOGGER.error("Error committing session, message: {}", e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Get a session for this interaction.
+     *
+     * @param transactionId The supplied transaction id.
+     * @return a storage session.
+     */
+    private PersistentStorageSession getSession(final String transactionId) {
+        final PersistentStorageSession session;
+        if (transactionId == null) {
+            session = persistentStorageSessionManager.getReadOnlySession();
+        } else {
+            session = persistentStorageSessionManager.getSession(transactionId);
+        }
+        return session;
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -565,6 +565,37 @@ public class ContainmentIndexImplTest {
         assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
     }
 
+    @Test
+    public void testHasResourcesStartingFailure() {
+        stubObject("parent1");
+        stubObject("child1");
+        stubObject("transaction1");
+        // Nothing exists.
+        assertFalse(containmentIndex.hasResourcesStartingWith(null, parent1.getFedoraId()));
+        // Add the single resource.
+        containmentIndex.addContainedBy(transaction1.getId(), FedoraId.getRepositoryRootId(), parent1.getFedoraId());
+        containmentIndex.commitTransaction(transaction1.getId());
+        // Still no similar paths.
+        assertFalse(containmentIndex.hasResourcesStartingWith(null, parent1.getFedoraId()));
+        // Add a contained resource that does NOT share the URI path.
+        assertFalse(child1.getFedoraId().getFullId().startsWith(parent1.getFedoraId().getFullId()));
+        containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
+        containmentIndex.commitTransaction(transaction1.getId());
+        // Still no similar paths.
+        assertFalse(containmentIndex.hasResourcesStartingWith(null, parent1.getFedoraId()));
+    }
+
+    @Test
+    public void testHasResourcesStartingSuccess() {
+        stubObject("parent1");
+        final var subPathId = parent1.getFedoraId().resolve("a/layer/down");
+        stubObject("transaction1");
+        // Add a resource.
+        containmentIndex.addContainedBy(transaction1.getId(), FedoraId.getRepositoryRootId(), subPathId);
+        // That resource's ID starts with the ID we are checking.
+        assertTrue(subPathId.getFullId().startsWith(parent1.getFedoraId().getFullId()));
+        assertTrue(containmentIndex.hasResourcesStartingWith(transaction1.getId(), parent1.getFedoraId()));
+    }
 }
 
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceHelperImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceHelperImplTest.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.models;
+
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import javax.inject.Inject;
+
+import java.util.UUID;
+
+import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.persistence.api.exceptions.PersistentSessionClosedException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test for ResourceHelper
+ * @author whikloj
+ * @since 6.0.0
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/containmentIndexTest.xml")
+public class ResourceHelperImplTest {
+
+    @Mock
+    private PersistentStorageSessionManager sessionManager;
+
+    @Mock
+    private PersistentStorageSession psSession;
+
+    @Mock
+    private Transaction mockTx;
+
+    @Inject
+    private ContainmentIndex containmentIndex;
+
+    @InjectMocks
+    private ResourceHelperImpl resourceHelper;
+
+    private String fedoraIdStr;
+
+    private String sessionId;
+
+    private final FedoraId rootId = FedoraId.getRepositoryRootId();
+
+    private FedoraId fedoraId;
+
+    private String fedoraMementoIdStr;
+
+    private FedoraId fedoraMementoId;
+
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        fedoraIdStr = FEDORA_ID_PREFIX + "/" + UUID.randomUUID().toString();
+        fedoraId = FedoraId.create(fedoraIdStr);
+        fedoraMementoIdStr = fedoraIdStr + "/fcr:versions/20000102120000";
+        fedoraMementoId = FedoraId.create(fedoraMementoIdStr);
+
+        sessionId = UUID.randomUUID().toString();
+        when(mockTx.getId()).thenReturn(sessionId);
+
+        resourceHelper = new ResourceHelperImpl();
+
+        setField(resourceHelper, "persistentStorageSessionManager", sessionManager);
+        setField(resourceHelper, "containmentIndex", containmentIndex);
+
+        when(sessionManager.getSession(sessionId)).thenReturn(psSession);
+        when(sessionManager.getReadOnlySession()).thenReturn(psSession);
+    }
+
+    @Test
+    public void doesResourceExist_Exists_WithSession() throws Exception {
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, fedoraId);
+        assertTrue(answerIn);
+        final boolean answerOut = resourceHelper.doesResourceExist(null, fedoraId);
+        assertFalse(answerOut);
+    }
+
+    @Test
+    public void doesResourceExist_Exists_Description_WithSession() {
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        final FedoraId descId = fedoraId.asDescription();
+        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, descId);
+        assertTrue(answerIn);
+        final boolean answerOut = resourceHelper.doesResourceExist(null, descId);
+        assertFalse(answerOut);
+    }
+
+    @Test
+    public void doesResourceExist_Exists_WithoutSession() throws Exception {
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        containmentIndex.commitTransaction(mockTx.getId());
+        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId);
+        assertTrue(answer);
+    }
+
+    @Test
+    public void doesResourceExist_Exists_Description_WithoutSession() {
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        containmentIndex.commitTransaction(mockTx.getId());
+        final FedoraId descId = fedoraId.asDescription();
+        final boolean answer = resourceHelper.doesResourceExist(null, descId);
+        assertTrue(answer);
+    }
+
+    @Test
+    public void doesResourceExist_DoesntExist_WithSession() throws Exception {
+        final boolean answer = resourceHelper.doesResourceExist(mockTx, fedoraId);
+        assertFalse(answer);
+    }
+
+    @Test
+    public void doesResourceExist_DoesntExists_Description_WithSession() {
+        final FedoraId descId = fedoraId.asDescription();
+        final boolean answer = resourceHelper.doesResourceExist(mockTx, descId);
+        assertFalse(answer);
+    }
+
+    @Test
+    public void doesResourceExist_DoesntExist_WithoutSession() throws Exception {
+        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId);
+        assertFalse(answer);
+    }
+
+    @Test
+    public void doesResourceExist_DoesntExists_Description_WithoutSession() {
+        final FedoraId descId = fedoraId.asDescription();
+        final boolean answer = resourceHelper.doesResourceExist(null, descId);
+        assertFalse(answer);
+    }
+
+    /**
+     * Only Mementos go to the persistence layer.
+     */
+    @Test(expected = RepositoryRuntimeException.class)
+    public void doesResourceExist_Exception_WithSession() throws Exception {
+        when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
+                .thenThrow(PersistentSessionClosedException.class);
+        resourceHelper.doesResourceExist(mockTx, fedoraMementoId);
+    }
+
+    /**
+     * Only Mementos go to the persistence layer.
+     */
+    @Test(expected = RepositoryRuntimeException.class)
+    public void doesResourceExist_Exception_WithoutSession() throws Exception {
+        when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
+                .thenThrow(PersistentSessionClosedException.class);
+        resourceHelper.doesResourceExist(null, fedoraMementoId);
+    }
+
+    /**
+     * Test an item is not a ghost node because it exists.
+     */
+    @Test
+    public void testGhostNodeFailure() {
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
+        // Inside the transaction the resource exists, so its not a ghost node.
+        assertTrue(resourceHelper.doesResourceExist(mockTx, fedoraId));
+        assertFalse(resourceHelper.isGhostNode(mockTx, fedoraId));
+        // Outside the transaction the resource does not exist.
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        // Because there are no other items it is not a ghost node.
+        assertFalse(resourceHelper.isGhostNode(null, fedoraId));
+
+        containmentIndex.commitTransaction(mockTx.getId());
+
+        // Now it exists outside the transaction.
+        assertTrue(resourceHelper.doesResourceExist(null, fedoraId));
+        // So it can't be a ghost node.
+        assertFalse(resourceHelper.isGhostNode(null, fedoraId));
+    }
+
+    /**
+     * Test that when the resource that does exist shares the ID of a resource that does not, then we have a ghost node.
+     */
+    @Test
+    public void testGhostNodeSuccess() {
+        final var resourceId = fedoraId.resolve("the/child/path");
+        containmentIndex.addContainedBy(mockTx.getId(), rootId, resourceId);
+        assertTrue(resourceHelper.doesResourceExist(mockTx, resourceId));
+        assertFalse(resourceHelper.doesResourceExist(mockTx, fedoraId));
+        assertTrue(resourceHelper.isGhostNode(mockTx, fedoraId));
+        assertFalse(resourceHelper.doesResourceExist(null, resourceId));
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        assertFalse(resourceHelper.isGhostNode(null, fedoraId));
+
+        containmentIndex.commitTransaction(mockTx.getId());
+
+        assertTrue(resourceHelper.doesResourceExist(null, resourceId));
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        assertTrue(resourceHelper.isGhostNode(null, fedoraId));
+    }
+}

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Sets;
 import com.google.common.eventbus.AllowConcurrentEvents;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.ResourceHelper;
 import org.fcrepo.kernel.api.observer.Event;
 import org.fcrepo.kernel.api.observer.EventType;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
@@ -61,7 +61,7 @@ public class SearchIndexUpdater {
     private SearchIndex searchIndex;
 
     @Inject
-    private ResourceFactory resourceFactory;
+    private ResourceHelper resourceHelper;
 
     @Inject
     private PersistentStorageSessionManager persistentStorageSessionManager;
@@ -77,7 +77,7 @@ public class SearchIndexUpdater {
         try {
             final var fedoraId = event.getFedoraId();
             final var types = event.getTypes();
-            if (types.contains(RESOURCE_DELETION) && !resourceFactory.doesResourceExist(null, fedoraId)) {
+            if (types.contains(RESOURCE_DELETION) && !resourceHelper.doesResourceExist(null, fedoraId)) {
                 this.searchIndex.removeFromIndex(fedoraId);
             } else if (types.contains(RESOURCE_CREATION) || types.contains(RESOURCE_MODIFICATION)) {
                 final var session = persistentStorageSessionManager.getReadOnlySession();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3256

# What does this Pull Request do?
Makes it so you can't create a real resource at the address of a ghost node.

# How should this be tested?

Testing steps in the ticket or
1. Create a resource `a/b/c` - `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/a/b/c`
1. Try to create resource `a/b` - `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/a/b`
    Without this PR get a `201 Created`, with this PR get a `409 Conflict`.
1. Delete resource `a/b/c` - `curl -i -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/a/b/c`
1. With the PR, you still can't create at `a/b` due to the tombstone. Running step 2 still returns a 409 Conflict.
1. Delete the `a/b/c/fcr:tombstone` - `curl -i -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/a/b/c/fcr:tombstone`
1. Now you can create a resource at `a/b` - `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/a/b`

# Interested parties
@fcrepo/committers
