### PR TITLE
Use the resource passed into getContent

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -241,7 +241,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @throws IOException in case of error extracting content
      */
     protected Response getContent(final int limit, final FedoraResource resource) throws IOException {
-        final RdfStream rdfStream = httpRdfService.bodyToExternalStream(getUri(resource()).toString(),
+        final RdfStream rdfStream = httpRdfService.bodyToExternalStream(getUri(resource).toString(),
                 getResourceTriples(limit, resource), identifierConverter());
         final var outputStream = new RdfNamespacedStream(
                     rdfStream, namespaceRegistry.getNamespaces());


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3445

# What does this Pull Request do?
For one call in `getContent` we call the `resource()` method which in a version listing you actually get the Original Resource, which then breaks the StreamingBaseHtmlProvider.

# How should this be tested?

Assuming auto versioning.
Create a resource in the HTML UI (or curl), then check the versions page for that resource with a web browser. You should see the initial version.
Make a change to the resource (again either the HTML UI or curl) and check the versions page again. You should see 2 versions, etc.

# Interested parties
@fcrepo/committers
