### PR TITLE
do not reload resource headers when computing types

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -188,9 +188,14 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
 
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
-        final var types = super.getSystemTypes(forRdf);
-        // Add fedora:Binary type.
-        types.add(FEDORA_BINARY_URI);
+        var types = resolveSystemTypes(forRdf);
+
+        if (types == null) {
+            types = super.getSystemTypes(forRdf);
+            // Add fedora:Binary type.
+            types.add(FEDORA_BINARY_URI);
+        }
+
         return types;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -47,6 +47,8 @@ import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
  */
 public class BinaryImpl extends FedoraResourceImpl implements Binary {
 
+    private static final URI FEDORA_BINARY_URI = URI.create(FEDORA_BINARY.getURI());
+
     private String externalHandling;
 
     private String externalUrl;
@@ -100,7 +102,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
             return null;
         }
         final var digest = digests.stream().findFirst();
-        return digest.isPresent() ? digest.get() : null;
+        return digest.orElse(null);
     }
 
     @Override
@@ -188,7 +190,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     public List<URI> getSystemTypes(final boolean forRdf) {
         final var types = super.getSystemTypes(forRdf);
         // Add fedora:Binary type.
-        types.add(URI.create(FEDORA_BINARY.getURI()));
+        types.add(FEDORA_BINARY_URI);
         return types;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -63,10 +63,15 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
 
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
-        final var types = super.getSystemTypes(forRdf);
-        types.add(RDF_SOURCE_URI);
-        types.add(CONTAINER_URI);
-        types.add(FEDORA_CONTAINER_URI);
+        var types = resolveSystemTypes(forRdf);
+
+        if (types == null) {
+            types = super.getSystemTypes(forRdf);
+            types.add(RDF_SOURCE_URI);
+            types.add(CONTAINER_URI);
+            types.add(FEDORA_CONTAINER_URI);
+        }
+
         return types;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -39,6 +39,10 @@ import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
  */
 public class ContainerImpl extends FedoraResourceImpl implements Container {
 
+    private static final URI RDF_SOURCE_URI = URI.create(RDF_SOURCE.toString());
+    private static final URI CONTAINER_URI = URI.create(CONTAINER.toString());
+    private static final URI FEDORA_CONTAINER_URI = URI.create(FEDORA_CONTAINER.toString());
+
     /**
      * Construct the container
      *
@@ -60,8 +64,9 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
         final var types = super.getSystemTypes(forRdf);
-        types.addAll(List.of(URI.create(RDF_SOURCE.toString()), URI.create(CONTAINER.toString()),
-                URI.create(FEDORA_CONTAINER.toString())));
+        types.add(RDF_SOURCE_URI);
+        types.add(CONTAINER_URI);
+        types.add(FEDORA_CONTAINER_URI);
         return types;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -76,6 +76,12 @@ public class FedoraResourceImpl implements FedoraResource {
 
     private List<URI> types;
 
+    private List<URI> systemTypes;
+
+    private List<URI> systemTypesForRdf;
+
+    private List<URI> userTypes;
+
     private Instant lastModifiedDate;
 
     private String lastModifiedBy;
@@ -236,43 +242,60 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
-        final List<URI> types = new ArrayList<>();
-        types.add(create(interactionModel));
-        // ldp:Resource is on all resources
-        types.add(RESOURCE_URI);
-        types.add(FEDORA_RESOURCE_URI);
-        if (!forRdf) {
-            // These types are not exposed as RDF triples.
-            if (isArchivalGroup) {
-                types.add(ARCHIVAL_GROUP_URI);
+        var types = resolveSystemTypes(forRdf);
+
+        if (types == null) {
+            types = new ArrayList<>();
+            types.add(create(interactionModel));
+            // ldp:Resource is on all resources
+            types.add(RESOURCE_URI);
+            types.add(FEDORA_RESOURCE_URI);
+            if (!forRdf) {
+                // These types are not exposed as RDF triples.
+                if (isArchivalGroup) {
+                    types.add(ARCHIVAL_GROUP_URI);
+                }
+                if (isMemento) {
+                    types.add(MEMENTO_URI);
+                } else {
+                    types.add(VERSIONED_RESOURCE_URI);
+                    types.add(VERSIONING_TIMEGATE_URI);
+                }
             }
-            if (isMemento) {
-                types.add(MEMENTO_URI);
+
+            if (forRdf) {
+                systemTypesForRdf = types;
             } else {
-                types.add(VERSIONED_RESOURCE_URI);
-                types.add(VERSIONING_TIMEGATE_URI);
+                systemTypes = types;
             }
         }
+
         return types;
     }
 
     @Override
     public List<URI> getUserTypes() {
-        try {
-            final var description = getDescription();
-            final var triples = getSession().getTriples(description.getFedoraId().asResourceId(),
-                    description.getMementoDatetime());
-            return triples.filter(t -> t.predicateMatches(type.asNode())).map(Triple::getObject)
-                    .map(t -> URI.create(t.toString())).collect(toList());
-        } catch (final PersistentItemNotFoundException e) {
-            final var headers = getSession().getHeaders(getFedoraId().asResourceId(), getMementoDatetime());
-            if (headers.isDeleted()) {
-                return Collections.emptyList();
+        if (userTypes == null) {
+            userTypes = new ArrayList<>();
+            try {
+                final var description = getDescription();
+                final var triples = getSession().getTriples(description.getFedoraId().asResourceId(),
+                        description.getMementoDatetime());
+                userTypes = triples.filter(t -> t.predicateMatches(type.asNode())).map(Triple::getObject)
+                        .map(t -> URI.create(t.toString())).collect(toList());
+            } catch (final PersistentItemNotFoundException e) {
+                final var headers = getSession().getHeaders(getFedoraId().asResourceId(), getMementoDatetime());
+                if (headers.isDeleted()) {
+                    userTypes = Collections.emptyList();
+                } else {
+                    throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
+                }
+            } catch (final PersistentStorageException e) {
+                throw new RepositoryRuntimeException(e.getMessage(), e);
             }
-            throw new ItemNotFoundException("Unable to retrieve triples for " + getId(), e);
-        } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e.getMessage(), e);
         }
+
+        return userTypes;
     }
 
     @Override
@@ -431,5 +454,9 @@ public class FedoraResourceImpl implements FedoraResource {
      */
     public void setInteractionModel(final String interactionModel) {
         this.interactionModel = interactionModel;
+    }
+
+    protected List<URI> resolveSystemTypes(final boolean forRdf) {
+        return forRdf ? systemTypesForRdf : systemTypes;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -59,6 +59,13 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
  */
 public class FedoraResourceImpl implements FedoraResource {
 
+    private static final URI RESOURCE_URI = create(RESOURCE.toString());
+    private static final URI FEDORA_RESOURCE_URI = create(FEDORA_RESOURCE.getURI());
+    private static final URI ARCHIVAL_GROUP_URI = create(ARCHIVAL_GROUP.getURI());
+    private static final URI MEMENTO_URI = create(MEMENTO_TYPE);
+    private static final URI VERSIONED_RESOURCE_URI = create(VERSIONED_RESOURCE.getURI());
+    private static final URI VERSIONING_TIMEGATE_URI = create(VERSIONING_TIMEGATE_TYPE);
+
     private final PersistentStorageSessionManager pSessionManager;
 
     protected final ResourceFactory resourceFactory;
@@ -87,6 +94,10 @@ public class FedoraResourceImpl implements FedoraResource {
 
     // The transaction this representation of the resource belongs to
     protected final String txId;
+
+    private boolean isArchivalGroup;
+
+    private String interactionModel;
 
     protected FedoraResourceImpl(final FedoraId fedoraId,
                                  final String txId,
@@ -225,30 +236,24 @@ public class FedoraResourceImpl implements FedoraResource {
 
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
-        try {
-            final List<URI> types = new ArrayList<>();
-            final var headers = getSession().getHeaders(getFedoraId().asResourceId(), getMementoDatetime());
-            types.add(create(headers.getInteractionModel()));
-            // ldp:Resource is on all resources
-            types.add(create(RESOURCE.toString()));
-            types.add(create(FEDORA_RESOURCE.getURI()));
-            if (!forRdf) {
-                // These types are not exposed as RDF triples.
-                if (headers.isArchivalGroup()) {
-                    types.add(create(ARCHIVAL_GROUP.getURI()));
-                }
-                if (isMemento) {
-                    types.add(create(MEMENTO_TYPE));
-                } else if (isOriginalResource()) {
-                    types.addAll(List.of(create(VERSIONED_RESOURCE.getURI()), create(VERSIONING_TIMEGATE_TYPE)));
-                }
+        final List<URI> types = new ArrayList<>();
+        types.add(create(interactionModel));
+        // ldp:Resource is on all resources
+        types.add(RESOURCE_URI);
+        types.add(FEDORA_RESOURCE_URI);
+        if (!forRdf) {
+            // These types are not exposed as RDF triples.
+            if (isArchivalGroup) {
+                types.add(ARCHIVAL_GROUP_URI);
             }
-            return types;
-        } catch (final PersistentItemNotFoundException e) {
-            throw new ItemNotFoundException("Unable to retrieve headers for " + getId(), e);
-        } catch (final PersistentStorageException e) {
-            throw new RepositoryRuntimeException(e.getMessage(), e);
+            if (isMemento) {
+                types.add(MEMENTO_URI);
+            } else {
+                types.add(VERSIONED_RESOURCE_URI);
+                types.add(VERSIONING_TIMEGATE_URI);
+            }
         }
+        return types;
     }
 
     @Override
@@ -414,4 +419,17 @@ public class FedoraResourceImpl implements FedoraResource {
         this.isMemento = isMemento;
     }
 
+    /**
+     * @param isArchivalGroup true if the resource is an AG
+     */
+    public void setIsArchivalGroup(final boolean isArchivalGroup) {
+        this.isArchivalGroup = isArchivalGroup;
+    }
+
+    /**
+     * @param interactionModel the resource's interaction model
+     */
+    public void setInteractionModel(final String interactionModel) {
+        this.interactionModel = interactionModel;
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -78,9 +78,14 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
 
     @Override
     public List<URI> getSystemTypes(final boolean forRdf) {
-        final var types = super.getSystemTypes(forRdf);
-        // NonRdfSource gets the ldp:Resource and adds ldp:RDFSource types.
-        types.add(RDF_SOURCE_URI);
+        var types = resolveSystemTypes(forRdf);
+
+        if (types == null) {
+            types = super.getSystemTypes(forRdf);
+            // NonRdfSource gets the ldp:Resource and adds ldp:RDFSource types.
+            types.add(RDF_SOURCE_URI);
+        }
+
         return types;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -43,6 +43,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
  */
 public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements NonRdfSourceDescription {
 
+    private static final URI RDF_SOURCE_URI = URI.create(RDF_SOURCE.getURI());
+
     /**
      * Construct a description resource
      *
@@ -78,7 +80,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     public List<URI> getSystemTypes(final boolean forRdf) {
         final var types = super.getSystemTypes(forRdf);
         // NonRdfSource gets the ldp:Resource and adds ldp:RDFSource types.
-        types.add(URI.create(RDF_SOURCE.getURI()));
+        types.add(RDF_SOURCE_URI);
         return types;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -202,6 +202,8 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setParentId(headers.getParent());
         resc.setEtag(headers.getStateToken());
         resc.setStateToken(headers.getStateToken());
+        resc.setIsArchivalGroup(headers.isArchivalGroup());
+        resc.setInteractionModel(headers.getInteractionModel());
 
         // If there's a version, then it's a memento
         if (version != null) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -37,6 +37,7 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,7 +117,7 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
     @Override
     public List<URI> getUserTypes() {
         // TimeMaps don't have user triples.
-        return List.of();
+        return Collections.emptyList();
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
@@ -23,6 +23,10 @@ import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Tombstone class
  *
@@ -47,5 +51,10 @@ public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
     @Override
     public FedoraId getFedoraId() {
         return this.originalResource.getFedoraId();
+    }
+
+    @Override
+    public List<URI> getUserTypes() {
+        return Collections.emptyList();
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -140,9 +140,6 @@ public class FedoraResourceImplTest {
         userModel.add(subject, type, createResource(exampleType));
         final var userStream = fromModel(subject.asNode(), userModel);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
-        when(psSession.getHeaders(eq(FEDORA_ID),any())).thenReturn(headers);
-        when(headers.getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
-        when(headers.isArchivalGroup()).thenReturn(false);
         when(psSession.getTriples(eq(FEDORA_ID), any())).thenReturn(userStream);
 
         final List<URI> expectedTypes = List.of(
@@ -155,6 +152,8 @@ public class FedoraResourceImplTest {
         );
 
         final var resource = new FedoraResourceImpl(FEDORA_ID, null, sessionManager, resourceFactory);
+        resource.setInteractionModel(BASIC_CONTAINER.toString());
+        resource.setIsArchivalGroup(false);
         final var resourceTypes = resource.getTypes();
 
         // Initial lengths are the same
@@ -179,9 +178,6 @@ public class FedoraResourceImplTest {
 
         when(resourceFactory.getResource((String)any(), eq(descriptionFedoraId))).thenReturn(description);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
-        when(psSession.getHeaders(eq(FEDORA_ID),any())).thenReturn(headers);
-        when(headers.getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
-        when(headers.isArchivalGroup()).thenReturn(false);
         when(psSession.getTriples(eq(descriptionFedoraId), any())).thenReturn(userStream);
 
         final List<URI> expectedTypes = List.of(
@@ -195,6 +191,8 @@ public class FedoraResourceImplTest {
         );
 
         final var resource = new BinaryImpl(FEDORA_ID, null, sessionManager, resourceFactory);
+        resource.setInteractionModel(NON_RDF_SOURCE.toString());
+        resource.setIsArchivalGroup(false);
         final var resourceTypes = resource.getTypes();
 
         // Initial lengths are the same


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3452

# What does this Pull Request do?

My original analysis was slightly off. The types _are_ cached in the FedoraResource currently. I was confused because I saw them being loaded so many times when I debugging, but this is just because the FedoraResource itself is not cached.

So, all this PR does is remove the need to reload the resource headers when computing system types, and moves the type URIs themselves to static fields.

# How should this be tested?

Everything should work the same as before, but with a few fewer loads of the resource headers.

# Interested parties
@fcrepo/committers
