### PR TITLE
fix storage session leak

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -100,6 +100,11 @@ public class TransactionManagerImpl implements TransactionManager {
                     LOGGER.error("Failed to rollback expired transaction {}", tx.getId(), e);
                 }
             }
+
+            if (tx.hasExpired()) {
+                // By this point the session as already been committed or rolledback by the transaction
+                pSessionManager.removeSession(tx.getId());
+            }
         }
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -17,14 +17,6 @@
  */
 package org.fcrepo.kernel.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
-
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
@@ -40,6 +32,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * <p>TransactionTest class.</p>
@@ -166,6 +167,11 @@ public class TransactionManagerImplTest {
         testTxManager.cleanupClosedTransactions();
 
         // verify that closed transactions cleanedup
+
+        verify(pssManager).removeSession(commitTx.getId());
+        verify(pssManager).removeSession(rollbackTx.getId());
+        verify(pssManager, never()).removeSession(continuingTx.getId());
+
         try {
             testTxManager.get(commitTx.getId());
             fail("Committed transaction was not cleaned up");
@@ -203,6 +209,7 @@ public class TransactionManagerImplTest {
         }
 
         verify(psSession).rollback();
+        verify(pssManager).removeSession(expiringTx.getId());
 
         testTxManager.cleanupClosedTransactions();
 

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSessionManager.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSessionManager.java
@@ -42,4 +42,12 @@ public interface PersistentStorageSessionManager {
      */
     PersistentStorageSession getReadOnlySession();
 
+    /**
+     * Removes the indicated session. If the session does not exist, null is returned.
+     *
+     * @param sessionId the id of the session to remove
+     * @return the session, if it exists
+     */
+    PersistentStorageSession removeSession(final String sessionId);
+
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
@@ -62,6 +62,7 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
 
     @Override
     public PersistentStorageSession getSession(final String sessionId) {
+        LOGGER.debug("Getting storage session {}", sessionId);
 
         if (sessionId == null) {
             throw new IllegalArgumentException("session id must be non-null");
@@ -92,4 +93,9 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
         return localSession;
     }
 
+    @Override
+    public PersistentStorageSession removeSession(final String sessionId) {
+        LOGGER.debug("Removing storage session {}", sessionId);
+        return sessionMap.remove(sessionId);
+    }
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManagerTest.java
@@ -31,6 +31,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.io.IOException;
 
 import static java.util.UUID.randomUUID;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
@@ -80,6 +82,13 @@ public class OcflPersistentSessionManagerTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNullSessionId() {
         this.sessionManager.getSession(null);
+    }
+
+    @Test
+    public void removeSession() {
+        final var session = sessionManager.removeSession(testSessionId);
+        assertSame(readWriteSession, session);
+        assertNull(sessionManager.removeSession(testSessionId));
     }
 
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3454

# What does this Pull Request do?

Removes the storage session that's associated to a transaction as part of transaction cleanup

# How should this be tested?

Everything should work the same as before but there should be a storage session related memory leak

# Interested parties
@fcrepo/committers
