### PR TITLE
configured to use resource headers cache

### DIFF
--- a/fcrepo-auth-common/src/test/resources/application.properties
+++ b/fcrepo-auth-common/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false

--- a/fcrepo-auth-webac/src/test/resources/application.properties
+++ b/fcrepo-auth-webac/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 # application-wide default properties can be defined here
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false

--- a/fcrepo-auth-webac/src/test/resources/spring-test/application.properties
+++ b/fcrepo-auth-webac/src/test/resources/spring-test/application.properties
@@ -1,2 +1,3 @@
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
@@ -45,13 +45,13 @@ import java.time.Duration;
 public class MetricsConfig {
 
     @Value("${fcrepo.metrics.enable:false}")
-    private boolean enableMetrics;
+    private boolean metricsEnabled;
 
     @Bean
     public MeterRegistry meterRegistry() {
         final MeterRegistry registry;
 
-        if (enableMetrics) {
+        if (metricsEnabled) {
             registry = new PrometheusMeterRegistry(new PrometheusConfig() {
                 @Override
                 public Duration step() {
@@ -96,6 +96,13 @@ public class MetricsConfig {
             return ((PrometheusMeterRegistry) meterRegistry).getPrometheusRegistry();
         }
         return CollectorRegistry.defaultRegistry;
+    }
+
+    /**
+     * @return whether metrics are enabled
+     */
+    public boolean isMetricsEnabled() {
+        return metricsEnabled;
     }
 
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -83,6 +83,15 @@ public class OcflPropsConfig {
     @Value("${fcrepo.ocfl.s3.prefix:}")
     private String ocflS3Prefix;
 
+    @Value("${fcrepo.resource-header-cache.enable:true}")
+    private boolean resourceHeadersCacheEnabled;
+
+    @Value("${fcrepo.resource-header-cache.max-size:512}")
+    private long resourceHeadersCacheMaxSize;
+
+    @Value("${fcrepo.resource-header-cache.expire-after-seconds:600}")
+    private long resourceHeadersCacheExpireAfterSeconds;
+
     @PostConstruct
     private void postConstruct() throws IOException {
         storage = Storage.fromString(storageStr);
@@ -255,4 +264,46 @@ public class OcflPropsConfig {
         this.ocflS3Prefix = ocflS3Prefix;
     }
 
+    /**
+     * @return whether or not to enable the resource headers cache
+     */
+    public boolean isResourceHeadersCacheEnabled() {
+        return resourceHeadersCacheEnabled;
+    }
+
+    /**
+     * @param resourceHeadersCacheEnabled whether or not to enable the resource headers cache
+     */
+    public void setResourceHeadersCacheEnabled(final boolean resourceHeadersCacheEnabled) {
+        this.resourceHeadersCacheEnabled = resourceHeadersCacheEnabled;
+    }
+
+    /**
+     * @return maximum number or resource headers in cache
+     */
+    public long getResourceHeadersCacheMaxSize() {
+        return resourceHeadersCacheMaxSize;
+    }
+
+    /**
+     * @param resourceHeadersCacheMaxSize maximum number of resource headers in cache
+     */
+    public void setResourceHeadersCacheMaxSize(final long resourceHeadersCacheMaxSize) {
+        this.resourceHeadersCacheMaxSize = resourceHeadersCacheMaxSize;
+    }
+
+    /**
+     * @return number of seconds to wait before expiring a resource header from the cache
+     */
+    public long getResourceHeadersCacheExpireAfterSeconds() {
+        return resourceHeadersCacheExpireAfterSeconds;
+    }
+
+    /**
+     * @param resourceHeadersCacheExpireAfterSeconds
+     *      number of seconds to wait before expiring a resource header from the cache
+     */
+    public void setResourceHeadersCacheExpireAfterSeconds(final long resourceHeadersCacheExpireAfterSeconds) {
+        this.resourceHeadersCacheExpireAfterSeconds = resourceHeadersCacheExpireAfterSeconds;
+    }
 }

--- a/fcrepo-http-api/src/test/resources/application.properties
+++ b/fcrepo-http-api/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false

--- a/fcrepo-jms/src/test/resources/application.properties
+++ b/fcrepo-jms/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -75,9 +75,9 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     }
 
     @Override
-    public void writeResource(final ResourceHeaders headers, final InputStream content) {
-        writeTimer.record(() -> {
-            exec(() -> inner.writeResource(headers, content));
+    public ResourceHeaders writeResource(final ResourceHeaders headers, final InputStream content) {
+        return MetricsHelper.time(writeTimer, () -> {
+            return exec(() -> inner.writeResource(headers, content));
         });
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManager.java
@@ -62,17 +62,18 @@ public class OcflPersistentSessionManager implements PersistentStorageSessionMan
 
     @Override
     public PersistentStorageSession getSession(final String sessionId) {
-        LOGGER.debug("Getting storage session {}", sessionId);
-
         if (sessionId == null) {
             throw new IllegalArgumentException("session id must be non-null");
         }
 
-        return sessionMap.computeIfAbsent(sessionId, key -> new OcflPersistentStorageSessionMetrics(
-                new OcflPersistentStorageSession(
-                        key,
-                        ocflIndex,
-                        objectSessionFactory)));
+        return sessionMap.computeIfAbsent(sessionId, key -> {
+            LOGGER.debug("Creating storage session {}", sessionId);
+            return new OcflPersistentStorageSessionMetrics(
+                    new OcflPersistentStorageSession(
+                            key,
+                            ocflIndex,
+                            objectSessionFactory));
+        });
     }
 
     @Override

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
@@ -24,6 +24,7 @@ import org.fcrepo.persistence.common.ResourceHeadersImpl;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 
@@ -35,21 +36,22 @@ import java.util.Objects;
 public class ResourceHeadersAdapter implements ResourceHeaders {
 
     private final ResourceHeadersImpl kernelHeaders;
-    private final org.fcrepo.storage.ocfl.ResourceHeaders storageHeaders;
+    private final org.fcrepo.storage.ocfl.ResourceHeaders.Builder storageHeaders;
 
     /**
      * Default constructor
      */
     public ResourceHeadersAdapter() {
         kernelHeaders = new ResourceHeadersImpl();
-        storageHeaders = new org.fcrepo.storage.ocfl.ResourceHeaders();
+        storageHeaders = org.fcrepo.storage.ocfl.ResourceHeaders.builder();
     }
 
     /**
      * @param storageHeaders storage headers to adapt
      */
     public ResourceHeadersAdapter(final org.fcrepo.storage.ocfl.ResourceHeaders storageHeaders) {
-        this.storageHeaders = Objects.requireNonNull(storageHeaders, "storageHeaders cannot be null");
+        this.storageHeaders = org.fcrepo.storage.ocfl.ResourceHeaders
+                .builder(Objects.requireNonNull(storageHeaders, "storageHeaders cannot be null"));
         this.kernelHeaders = new ResourceHeadersImpl();
 
         if (storageHeaders.getId() != null) {
@@ -64,7 +66,8 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
         kernelHeaders.setCreatedBy(storageHeaders.getCreatedBy());
         kernelHeaders.setCreatedDate(storageHeaders.getCreatedDate());
         kernelHeaders.setDeleted(storageHeaders.isDeleted());
-        kernelHeaders.setDigests(storageHeaders.getDigests());
+        kernelHeaders.setDigests(new ArrayList<>(storageHeaders.getDigests()));
+        this.storageHeaders.withDigests(kernelHeaders.getDigests());
         kernelHeaders.setExternalHandling(storageHeaders.getExternalHandling());
         kernelHeaders.setExternalUrl(storageHeaders.getExternalUrl());
         kernelHeaders.setFilename(storageHeaders.getFilename());
@@ -81,37 +84,37 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public ResourceHeadersAdapter(final ResourceHeadersImpl kernelHeaders) {
         this.kernelHeaders = Objects.requireNonNull(kernelHeaders, "kernelHeaders cannot be null");
-        this.storageHeaders = new org.fcrepo.storage.ocfl.ResourceHeaders();
+        this.storageHeaders = org.fcrepo.storage.ocfl.ResourceHeaders.builder();
 
         if (kernelHeaders.getId() != null) {
-            storageHeaders.setId(kernelHeaders.getId().getFullId());
+            storageHeaders.withId(kernelHeaders.getId().getFullId());
         }
         if (kernelHeaders.getParent() != null) {
-            storageHeaders.setParent(kernelHeaders.getParent().getFullId());
+            storageHeaders.withParent(kernelHeaders.getParent().getFullId());
         }
-        storageHeaders.setArchivalGroup(kernelHeaders.isArchivalGroup());
-        storageHeaders.setContentPath(kernelHeaders.getContentPath());
-        storageHeaders.setContentSize(kernelHeaders.getContentSize());
-        storageHeaders.setCreatedBy(kernelHeaders.getCreatedBy());
-        storageHeaders.setCreatedDate(kernelHeaders.getCreatedDate());
-        storageHeaders.setDeleted(kernelHeaders.isDeleted());
-        storageHeaders.setDigests(kernelHeaders.getDigests());
-        storageHeaders.setExternalHandling(kernelHeaders.getExternalHandling());
-        storageHeaders.setExternalUrl(kernelHeaders.getExternalUrl());
-        storageHeaders.setFilename(kernelHeaders.getFilename());
-        storageHeaders.setInteractionModel(kernelHeaders.getInteractionModel());
-        storageHeaders.setLastModifiedBy(kernelHeaders.getLastModifiedBy());
-        storageHeaders.setLastModifiedDate(kernelHeaders.getLastModifiedDate());
-        storageHeaders.setMimeType(kernelHeaders.getMimeType());
-        storageHeaders.setObjectRoot(kernelHeaders.isObjectRoot());
-        storageHeaders.setStateToken(kernelHeaders.getStateToken());
+        storageHeaders.withArchivalGroup(kernelHeaders.isArchivalGroup());
+        storageHeaders.withContentPath(kernelHeaders.getContentPath());
+        storageHeaders.withContentSize(kernelHeaders.getContentSize());
+        storageHeaders.withCreatedBy(kernelHeaders.getCreatedBy());
+        storageHeaders.withCreatedDate(kernelHeaders.getCreatedDate());
+        storageHeaders.withDeleted(kernelHeaders.isDeleted());
+        storageHeaders.withDigests(kernelHeaders.getDigests());
+        storageHeaders.withExternalHandling(kernelHeaders.getExternalHandling());
+        storageHeaders.withExternalUrl(kernelHeaders.getExternalUrl());
+        storageHeaders.withFilename(kernelHeaders.getFilename());
+        storageHeaders.withInteractionModel(kernelHeaders.getInteractionModel());
+        storageHeaders.withLastModifiedBy(kernelHeaders.getLastModifiedBy());
+        storageHeaders.withLastModifiedDate(kernelHeaders.getLastModifiedDate());
+        storageHeaders.withMimeType(kernelHeaders.getMimeType());
+        storageHeaders.withObjectRoot(kernelHeaders.isObjectRoot());
+        storageHeaders.withStateToken(kernelHeaders.getStateToken());
     }
 
     /**
      * @return the headers as storage headers
      */
     public org.fcrepo.storage.ocfl.ResourceHeaders asStorageHeaders() {
-        return storageHeaders;
+        return storageHeaders.build();
     }
 
     /**
@@ -138,7 +141,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setId(final FedoraId id) {
         kernelHeaders.setId(id);
-        storageHeaders.setId(idToString(id));
+        storageHeaders.withId(idToString(id));
     }
 
     @Override
@@ -151,7 +154,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setParent(final FedoraId parent) {
         kernelHeaders.setParent(parent);
-        storageHeaders.setParent(idToString(parent));
+        storageHeaders.withParent(idToString(parent));
     }
 
     @Override
@@ -164,7 +167,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setStateToken(final String stateToken) {
         kernelHeaders.setStateToken(stateToken);
-        storageHeaders.setStateToken(stateToken);
+        storageHeaders.withStateToken(stateToken);
     }
 
     @Override
@@ -177,7 +180,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setInteractionModel(final String interactionModel) {
         kernelHeaders.setInteractionModel(interactionModel);
-        storageHeaders.setInteractionModel(interactionModel);
+        storageHeaders.withInteractionModel(interactionModel);
     }
 
     @Override
@@ -190,7 +193,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setMimeType(final String mimeType) {
         kernelHeaders.setMimeType(mimeType);
-        storageHeaders.setMimeType(mimeType);
+        storageHeaders.withMimeType(mimeType);
     }
 
     @Override
@@ -203,7 +206,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setFilename(final String filename) {
         kernelHeaders.setFilename(filename);
-        storageHeaders.setFilename(filename);
+        storageHeaders.withFilename(filename);
     }
 
     @Override
@@ -216,7 +219,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setContentSize(final Long contentSize) {
         kernelHeaders.setContentSize(contentSize);
-        storageHeaders.setContentSize(contentSize);
+        storageHeaders.withContentSize(contentSize);
     }
 
     @Override
@@ -229,7 +232,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setDigests(final Collection<URI> digests) {
         kernelHeaders.setDigests(digests);
-        storageHeaders.setDigests(digests);
+        storageHeaders.withDigests(digests);
     }
 
     @Override
@@ -242,7 +245,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setExternalHandling(final String externalHandling) {
         kernelHeaders.setExternalHandling(externalHandling);
-        storageHeaders.setExternalHandling(externalHandling);
+        storageHeaders.withExternalHandling(externalHandling);
     }
 
     @Override
@@ -255,7 +258,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setCreatedDate(final Instant createdDate) {
         kernelHeaders.setCreatedDate(createdDate);
-        storageHeaders.setCreatedDate(createdDate);
+        storageHeaders.withCreatedDate(createdDate);
     }
 
     @Override
@@ -268,7 +271,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setCreatedBy(final String createdBy) {
         kernelHeaders.setCreatedBy(createdBy);
-        storageHeaders.setCreatedBy(createdBy);
+        storageHeaders.withCreatedBy(createdBy);
     }
 
     @Override
@@ -281,7 +284,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setLastModifiedDate(final Instant lastModifiedDate) {
         kernelHeaders.setLastModifiedDate(lastModifiedDate);
-        storageHeaders.setLastModifiedDate(lastModifiedDate);
+        storageHeaders.withLastModifiedDate(lastModifiedDate);
     }
 
     @Override
@@ -294,7 +297,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setLastModifiedBy(final String lastModifiedBy) {
         kernelHeaders.setLastModifiedBy(lastModifiedBy);
-        storageHeaders.setLastModifiedBy(lastModifiedBy);
+        storageHeaders.withLastModifiedBy(lastModifiedBy);
     }
 
     /**
@@ -302,7 +305,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setExternalUrl(final String externalUrl) {
         kernelHeaders.setExternalUrl(externalUrl);
-        storageHeaders.setExternalUrl(externalUrl);
+        storageHeaders.withExternalUrl(externalUrl);
     }
 
     @Override
@@ -316,7 +319,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setArchivalGroup(final boolean flag) {
         kernelHeaders.setArchivalGroup(flag);
-        storageHeaders.setArchivalGroup(flag);
+        storageHeaders.withArchivalGroup(flag);
     }
 
     @Override
@@ -329,7 +332,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setObjectRoot(final boolean flag) {
         kernelHeaders.setObjectRoot(flag);
-        storageHeaders.setObjectRoot(flag);
+        storageHeaders.withObjectRoot(flag);
     }
 
     @Override
@@ -347,7 +350,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setDeleted(final boolean deleted) {
         kernelHeaders.setDeleted(deleted);
-        storageHeaders.setDeleted(deleted);
+        storageHeaders.withDeleted(deleted);
     }
 
     /**
@@ -373,7 +376,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
      */
     public void setContentPath(final String contentPath) {
         kernelHeaders.setContentPath(contentPath);
-        storageHeaders.setContentPath(contentPath);
+        storageHeaders.withContentPath(contentPath);
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImplTest.java
@@ -39,6 +39,7 @@ import org.fcrepo.search.api.SearchParameters;
 import org.fcrepo.search.api.SearchResult;
 import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
+import org.fcrepo.storage.ocfl.cache.NoOpCache;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -122,7 +123,9 @@ public class IndexBuilderImplTest {
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
         final var ocflObjectSessionFactory = new DefaultOcflObjectSessionFactory(repository,
                 tempFolder.newFolder().toPath(),
-                objectMapper, CommitType.NEW_VERSION,
+                objectMapper,
+                new NoOpCache<>(),
+                CommitType.NEW_VERSION,
                 "Fedora 6 test", "fedoraAdmin", "info:fedora/fedoraAdmin");
 
         sessionManager = new OcflPersistentSessionManager();

--- a/fcrepo-persistence-ocfl/src/test/resources/application.properties
+++ b/fcrepo-persistence-ocfl/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 # Set the Fedora home location for tests
 fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3453

This PR depends on this PR https://github.com/fcrepo-exts/fcrepo-storage-ocfl/pull/11, and it will not build until the other PR has been committed.

# What does this Pull Request do?

Configures Fedora to cache resource headers by default. Throughout the lifetime of a request a resource's headers are read repeatedly. This cache is intended to reduce some of this overhead at the cost of memory. This is particularly important when the storage layer is in S3.

# How should this be tested?

There should be no behavior changes in Fedora. If you run Fedora with either of the following flags you will be able to see the cache in action: `-Dfcrepo.log.storage=trace -Dfcrepo.metrics.enable=true`.

The first should produce caching related log messages, and the second enables metrics collection. The cache metrics can be inspected if you configure [metrics collection](https://wiki.lyrasis.org/display/FEDORA6x/Metrics).

# Interested parties
@fcrepo/committers
