### PR TITLE
upgrade ocfl-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jgroups.version>4.0.13.Final</jgroups.version>
     <jsonld.version>0.12.1</jsonld.version>
     <logback.version>1.2.3</logback.version>
-    <ocfl-java.version>0.0.5-SNAPSHOT</ocfl-java.version>
+    <ocfl-java.version>0.0.6-SNAPSHOT</ocfl-java.version>
     <slf4j.version>1.7.25</slf4j.version>
     <snappy-java.version>1.1.7.2</snappy-java.version>
     <spring.version>5.2.7.RELEASE</spring.version>


### PR DESCRIPTION
**JIRA Ticket**: none

# What does this Pull Request do?

Upgrades the version of ocfl-java. This must be merged in conjunction with https://github.com/fcrepo-exts/fcrepo-storage-ocfl/pull/12. This will fix the ocfl-java memory leak that was recently discovered.

# How should this be tested?

Run the load test and you should not see resource accumulation in the InMemoryObjectLock.

# Interested parties
@fcrepo/committers
