### PR TITLE
read-only session expires old object sessions

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
@@ -88,15 +88,6 @@ public class ResourceHelperImpl implements ResourceHelper {
             } catch (final PersistentStorageException e) {
                 // Other error, pass along.
                 throw new RepositoryRuntimeException(e.getMessage(), e);
-            } finally {
-                if (transactionId == null) {
-                    // Commit session (if read-only) so it doesn't hang around.
-                    try {
-                        psSession.commit();
-                    } catch (final PersistentStorageException e) {
-                        LOGGER.error("Error committing session, message: {}", e.getMessage());
-                    }
-                }
             }
         }
     }

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -123,6 +123,10 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
     <!-- test gear -->
     <dependency>

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
@@ -46,6 +47,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.ByteArrayInputStream;
 import java.nio.file.Path;
@@ -67,7 +69,9 @@ import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.create
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -107,7 +111,7 @@ public class OcflPersistentStorageSessionTest {
     @Mock
     private OcflObjectSession objectSession2;
 
-    private org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory objectSessionFactory;
+    private DefaultOcflObjectSessionFactory objectSessionFactory;
 
     private static final FedoraId ROOT_OBJECT_ID = FedoraId.create("info:fedora/resource1");
 
@@ -185,7 +189,7 @@ public class OcflPersistentStorageSessionTest {
     private void mockMappingAndIndex(final String ocflObjectId, final FedoraId resourceId, final FedoraId rootObjectId,
                                      final FedoraOcflMapping mapping) throws FedoraOcflMappingNotFoundException {
         mockMapping(ocflObjectId, rootObjectId, mapping);
-        when(index.getMapping(anyString(), eq(resourceId))).thenReturn(mapping);
+        when(index.getMapping(any(), eq(resourceId))).thenReturn(mapping);
     }
 
     private void mockMapping(final String ocflObjectId, final FedoraId rootObjectId, final FedoraOcflMapping mapping) {
@@ -687,6 +691,39 @@ public class OcflPersistentStorageSessionTest {
         final var result = IOUtils.toString(session.getBinaryContent(RESOURCE_ID, null), UTF_8);
 
         assertEquals(BINARY_CONTENT, result);
+    }
+
+    @Test
+    public void readOnlySessionShouldExpireObjectSessions() throws Exception {
+        mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, RESOURCE_ID, mapping);
+
+        // create resource
+        final Node resourceUri = createURI(RESOURCE_ID.getFullId());
+
+        final var dcTitleTriple = Triple.create(resourceUri, DC.title.asNode(), createLiteral("my title"));
+        final Stream<Triple> userTriples = Stream.of(dcTitleTriple);
+        final DefaultRdfStream userStream = new DefaultRdfStream(resourceUri, userTriples);
+        mockResourceOperation(rdfSourceOperation, userStream, USER_PRINCIPAL, RESOURCE_ID);
+        session.persist(rdfSourceOperation);
+        session.commit();
+
+        // read-only read resource
+        final var sessionMap = Caffeine.newBuilder()
+                .maximumSize(512)
+                .expireAfterAccess(1, TimeUnit.SECONDS)
+                .<String, OcflObjectSession>build()
+                .asMap();
+
+        final var readOnlySession = new OcflPersistentStorageSession(null, index, objectSessionFactory);
+        ReflectionTestUtils.setField(readOnlySession, "sessionMap", sessionMap);
+
+        readOnlySession.getHeaders(RESOURCE_ID, null);
+
+        assertTrue(sessionMap.containsKey(RESOURCE_ID.getFullId()));
+
+        TimeUnit.SECONDS.sleep(2);
+
+        assertFalse(sessionMap.containsKey(RESOURCE_ID.getFullId()));
     }
 
     private NonRdfSourceOperation mockNonRdfSourceOperation(final String content,

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
         <version>0.8.1</version>
       </dependency>
       <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>2.8.5</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3456

# What does this Pull Request do?

The read-only session now expires object sessions that have not been accessed within 10 minutes.

# How should this be tested?

Fedora should work the same, and the load test should not see the accumulation of object sessions within the read-only session.

# Interested parties
@fcrepo/committers
