### PR TITLE
Reflect autoversioning state in HTML UI

### DIFF
--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <osgi.import.packages>
+        org.fcrepo.config.*,
         org.fcrepo.http.commons.*,
         org.fcrepo.kernel.api.*,
         org.fcrepo.search.api.*,
@@ -62,6 +63,12 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-search-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-configs</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -120,12 +127,6 @@
     </dependency>
 
     <!-- test gear -->
-    <dependency>
-      <groupId>org.fcrepo</groupId>
-      <artifactId>fcrepo-configs</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-http-commons</artifactId>

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -66,6 +66,7 @@ import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
 import org.apache.velocity.tools.generic.EscapeTool;
 import org.apache.velocity.tools.generic.FieldTool;
+import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.http.api.FedoraLdp;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
@@ -105,6 +106,11 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
 
     @Inject
     private ResourceFactory resourceFactory;
+
+    @Inject
+    private OcflPropsConfig ocflPropsConfig;
+
+    private boolean autoVersioningEnabled;
 
     private HttpIdentifierConverter identifierConverter;
 
@@ -155,6 +161,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
         final Properties properties = new Properties();
         final String fcrepoHome = getProperty("fcrepo.home");
         final String velocityLog = getProperty("fcrepo.velocity.runtime.log");
+        autoVersioningEnabled = ocflPropsConfig.isAutoVersioningEnabled();
         if (velocityLog != null) {
             LOGGER.debug("Setting Velocity runtime log: {}", velocityLog);
             properties.setProperty("runtime.log", velocityLog);
@@ -209,6 +216,7 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
         context.put("isVersion", (resource != null && resource.isMemento()));
         context.put("isLDPNR", (resource != null &&
                 (resource instanceof Binary || !resource.getDescribedResource().equals(resource))));
+        context.put("autoVersioningEnabled", autoVersioningEnabled);
 
         // the contract of MessageBodyWriter<T> is _not_ to close the stream
         // after writing to it

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -87,18 +87,19 @@ WHERE { }
   </form>
 
   #if ( !$isRoot )
-	#if ( $isLDPNR )
 	  <h3>Versioning</h3>
+	#if ( $isLDPNR )
 	  <p>Versioning of binary resources is not currently available through the HTML UI.</p>
-	  <hr />
+	#elseif ($autoVersioningEnabled == true)
+	  <p>Autoversioning is enabled. Versions are created with each update to a resource.
+	  <h4><a id="view_versions" href="$topic/fcr:versions">View Versions</a></h4>
 	#elseif ($isOriginalResource == true)
       <form id="action_create_version" name="action_create_version" method="POST">
-        <h3>Versions</h3>
         <button id="create-version-button" type="submit" class="btn btn-primary">Create Version</button>
-        <h4><a id="view_versions" href="$topic/fcr:versions">View Versions</a></h4>
-        <hr />
       </form>
+      <h4><a id="view_versions" href="$topic/fcr:versions">View Versions</a></h4>
     #end
+    <hr />
 
     <form id="action_delete" name="action_delete">
       <h3>Delete Resource</h3>

--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -7,9 +7,6 @@
     <span class="glyphicon glyphicon-warning-sign"></span>
     This is a <strong>historic version</strong> and cannot be modified.
   </div>
-  <form id="action_remove_version" method="DELETE" action="$uriInfo.getAbsolutePath().toString()" data-redirect-after-submit="$helpers.getVersionSubjectUrl($uriInfo, $topic)/fcr:versions" >
-    <button type="submit" class="btn btn-danger standalone">Delete this Version</button>
-  </form>
 #else
   #if ($helpers.isRdfResource($rdf, $content, "http://fedora.info/definitions/v4/repository#", "Binary"))
     <a href="$content" class="btn btn-success btn-lg"><span class="glyphicon glyphicon-download"></span> Download Content</a><br/><br/>

--- a/fcrepo-webapp/src/main/webapp/static/css/common.css
+++ b/fcrepo-webapp/src/main/webapp/static/css/common.css
@@ -20,6 +20,7 @@ dl {
 
 dd {
     padding-left: 38px;
+    word-wrap: break-word;
 }
 
 .well dl {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3446

# What does this Pull Request do?
If autoversioning is enabled (as it is by default) then the "Create Version" button is replaced by the text "Autoversioning is enabled. Versions are created with each update to a resource." 

Versioning of binaries is still disabled from the HTML UI, though as binary and binary description versioning is now tied together we might be able to enable this.

Also includes a little CSS change as long binary checksum were breaking the HTML.
![Screen Shot 2020-10-14 at 11 13 24 AM](https://user-images.githubusercontent.com/2857697/96017930-349e7e80-0e10-11eb-9cb1-f80929976df5.png)


# How should this be tested?

Build this branch and run it. Make a container and see the new message.
Stop Fedora
Run again with `-Dfcrepo.autoversioning.enabled=false` and see the same object show the "Create Version" button.

The button **only** creates a version if something has changed. We will need to make sure this is clear to users of the HTML UI.

# Interested parties
@fcrepo/committers
