### PR TITLE
Combine all SMT exceptions together and provide valid constraints

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -49,6 +49,7 @@ import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -118,7 +119,7 @@ public class HttpRdfService {
                                      final MediaType contentType, final HttpIdentifierConverter idTranslator,
                                      final boolean lenientHandling)
                                      throws RepositoryRuntimeException, BadRequestException {
-        final List<Exception> exceptions = new ArrayList<>();
+        final List<ConstraintViolationException> exceptions = new ArrayList<>();
         final Model model = parseBodyAsModel(stream, contentType, extResourceId);
         final List<Statement> insertStatements = new ArrayList<>();
         final StmtIterator stmtIterator = model.listStatements();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -49,11 +49,12 @@ import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
-import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedMediaTypeException;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.slf4j.Logger;
@@ -117,7 +118,7 @@ public class HttpRdfService {
                                      final MediaType contentType, final HttpIdentifierConverter idTranslator,
                                      final boolean lenientHandling)
                                      throws RepositoryRuntimeException, BadRequestException {
-
+        final List<Exception> exceptions = new ArrayList<>();
         final Model model = parseBodyAsModel(stream, contentType, extResourceId);
         final List<Statement> insertStatements = new ArrayList<>();
         final StmtIterator stmtIterator = model.listStatements();
@@ -128,29 +129,37 @@ public class HttpRdfService {
                 // Remove any statement that touches a server managed property or namespace.
                 stmtIterator.remove();
             } else {
-                checkForDisallowedRdf(stmt);
-                if (stmt.getSubject().isURIResource()) {
-                    final String originalSubj = stmt.getSubject().getURI();
-                    final String subj = idTranslator.inExternalDomain(originalSubj) ?
-                            idTranslator.toInternalId(originalSubj) : originalSubj;
+                try {
+                    checkForDisallowedRdf(stmt);
+                    if (stmt.getSubject().isURIResource()) {
+                        final String originalSubj = stmt.getSubject().getURI();
+                        final String subj = idTranslator.inExternalDomain(originalSubj) ?
+                                idTranslator.toInternalId(originalSubj) : originalSubj;
 
-                    RDFNode obj = stmt.getObject();
-                    if (stmt.getObject().isURIResource()) {
-                        final String objString = stmt.getObject().asResource().getURI();
-                        if (idTranslator.inExternalDomain(objString)) {
-                            obj = model.getResource(idTranslator.toInternalId(objString));
+                        RDFNode obj = stmt.getObject();
+                        if (stmt.getObject().isURIResource()) {
+                            final String objString = stmt.getObject().asResource().getURI();
+                            if (idTranslator.inExternalDomain(objString)) {
+                                obj = model.getResource(idTranslator.toInternalId(objString));
+                            }
                         }
-                    }
 
-                    if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
-                        insertStatements.add(new StatementImpl(model.getResource(subj), stmt.getPredicate(), obj));
+                        if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
+                            insertStatements.add(new StatementImpl(model.getResource(subj), stmt.getPredicate(), obj));
 
-                        stmtIterator.remove();
+                            stmtIterator.remove();
+                        }
+                    } else {
+                        log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
                     }
-                } else {
-                    log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
+                } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+                    exceptions.add(exc);
                 }
             }
+        }
+
+        if (!exceptions.isEmpty()) {
+            throw new MultipleConstraintViolationException(exceptions);
         }
 
         model.add(insertStatements);
@@ -265,8 +274,8 @@ public class HttpRdfService {
                     String.format("Invalid rdf:type: %s", triple.getObject()));
         } else if (restrictedType.test(triple)) {
             // The object of a rdf:type triple has a restricted namespace.
-            throw new InteractionModelViolationException(
-                    String.format("Changing this resource's interaction model to %s is not allowed",
+            throw new ServerManagedTypeException(
+                    String.format("The server managed type (%s) cannot be modified by the client.",
                             triple.getObject()));
         } else if (isManagedPredicate.test(createProperty(triple.getPredicate().getURI()))) {
             // The predicate is server managed.

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -45,7 +45,10 @@ import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.slf4j.Logger;
 
 /**
@@ -63,6 +66,8 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
     public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter) {
         idTranslator = identifierConverter;
     }
+
+    private List<Exception> exceptions = new ArrayList<>();
 
     @Override
     public void visit(final UpdateDataInsert update) {
@@ -106,6 +111,7 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
             sourceQuads = ((UpdateData) update).getQuads();
         }
         final List<Quad> newQuads = translateQuads(sourceQuads);
+        assertNoExceptions();
         final Update newUpdate = makeUpdate(update.getClass(), newQuads);
         newUpdates.add(newUpdate);
     }
@@ -123,11 +129,18 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         final List<Quad> deleteQuads = (update.hasDeleteClause() ? translateQuads(update.getDeleteQuads()) :
                 Collections.emptyList());
         deleteQuads.forEach(q -> newUpdate.getDeleteAcc().addQuad(q));
+        assertNoExceptions();
 
         final Element where = update.getWherePattern();
         final Element newElement = processElements(where);
         newUpdate.setElement(newElement);
         newUpdates.add(newUpdate);
+    }
+
+    private void assertNoExceptions() {
+        if (!exceptions.isEmpty()) {
+            throw new MultipleConstraintViolationException(exceptions);
+        }
     }
 
     /**
@@ -145,7 +158,11 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
             final var tripleIter = ((ElementPathBlock) element).patternElts();
             tripleIter.forEachRemaining(t -> {
                 if (t.isTriple()) {
-                    basicPattern.add(translateTriple(t.asTriple()));
+                    try {
+                        basicPattern.add(translateTriple(t.asTriple()));
+                    } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+                        exceptions.add(exc);
+                    }
                 }
             });
             return new ElementPathBlock(basicPattern);
@@ -161,12 +178,17 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
     private List<Quad> translateQuads(final List<Quad> quadsList) {
         final List<Quad> newQuads = new ArrayList<>();
         for (final Quad q : quadsList) {
-            final Node subject = translateId(q.getSubject());
-            final Node object = translateId(q.getObject());
-            checkTripleForDisallowed(q.asTriple());
-            final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
-            LOGGER.trace("Translated quad is: {}", quad);
-            newQuads.add(quad);
+            try {
+                final Node subject = translateId(q.getSubject());
+                final Node object = translateId(q.getObject());
+                checkTripleForDisallowed(q.asTriple());
+                final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
+                LOGGER.trace("Translated quad is: {}", quad);
+                newQuads.add(quad);
+            } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+                // Swallow these exceptions to throw together later.
+                exceptions.add(exc);
+            }
         }
         return newQuads;
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -45,6 +45,7 @@ import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
@@ -67,7 +68,7 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         idTranslator = identifierConverter;
     }
 
-    private List<Exception> exceptions = new ArrayList<>();
+    private List<ConstraintViolationException> exceptions = new ArrayList<>();
 
     @Override
     public void visit(final UpdateDataInsert update) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -124,12 +124,12 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         final UpdateModify newUpdate = new UpdateModify();
         final List<Quad> insertQuads = (update.hasInsertClause() ? translateQuads(update.getInsertQuads()) :
                 Collections.emptyList());
-        insertQuads.forEach(q -> newUpdate.getInsertAcc().addQuad(q));
-
         final List<Quad> deleteQuads = (update.hasDeleteClause() ? translateQuads(update.getDeleteQuads()) :
                 Collections.emptyList());
-        deleteQuads.forEach(q -> newUpdate.getDeleteAcc().addQuad(q));
         assertNoExceptions();
+
+        insertQuads.forEach(q -> newUpdate.getInsertAcc().addQuad(q));
+        deleteQuads.forEach(q -> newUpdate.getDeleteAcc().addQuad(q));
 
         final Element where = update.getWherePattern();
         final Element newElement = processElements(where);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -103,8 +103,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -236,12 +236,12 @@ public abstract class AbstractResourceIT {
         logger.debug("Executing: " + req.getMethod() + " to " + req.getURI());
         try {
             return client.execute(req);
-        } catch (NoHttpResponseException e) {
+        } catch (final NoHttpResponseException e) {
             // sometimes the server is slow starting up -- retry once
             try {
                 TimeUnit.SECONDS.sleep(2);
                 return client.execute(req);
-            } catch (InterruptedException e2) {
+            } catch (final InterruptedException e2) {
                 throw new RuntimeException(e2);
             }
         }
@@ -448,7 +448,7 @@ public abstract class AbstractResourceIT {
     }
 
     protected static InputStream streamModel(final Model model, final RDFFormat format) throws IOException {
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             RDFDataMgr.write(bos, model, format);
             return new ByteArrayInputStream(bos.toByteArray());
         }
@@ -469,7 +469,7 @@ public abstract class AbstractResourceIT {
         }
 
         if (linkHeaders != null && linkHeaders.length > 0) {
-            for (String linkHeader : linkHeaders) {
+            for (final String linkHeader : linkHeaders) {
                 httpPost.addHeader(LINK, linkHeader);
             }
         }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
@@ -51,19 +51,18 @@ public abstract class ConstraintExceptionMapper<T extends ConstraintViolationExc
     public static Link buildConstraintLink(final ConstraintViolationException e,
                                            final ServletContext context,
                                            final UriInfo uriInfo) {
-        return buildConstraintLink(e.getClass().toString(),
-                context, uriInfo);
+        return buildConstraintLink(e.getClass(), context, uriInfo);
     }
 
     /**
      * Creates a constrainedBy link header with the appropriate RDF URL for the exception.
      *
-     * @param className the classname of the exception to build the link for.
+     * @param clazz the class of the exception to build the link for.
      * @param context ServletContext ServletContext that we're running in.
      * @param uriInfo UriInfo UriInfo from the ExceptionMapper.
      * @return Link A http://www.w3.org/ns/ldp#constrainedBy link header
      */
-    public static Link buildConstraintLink(final String className,
+    public static Link buildConstraintLink(final Class<? extends ConstraintViolationException> clazz,
                                            final ServletContext context,
                                            final UriInfo uriInfo) {
         String path = context.getContextPath();
@@ -73,7 +72,7 @@ public abstract class ConstraintExceptionMapper<T extends ConstraintViolationExc
 
         final String constraintURI = uriInfo == null ? "" : String.format("%s://%s%s%s%s.rdf",
                 uriInfo.getBaseUri().getScheme(), uriInfo.getBaseUri().getAuthority(), path,
-                CONSTRAINT_DIR, className.substring(className.lastIndexOf('.') + 1));
+                CONSTRAINT_DIR, clazz.getName().substring(clazz.getName().lastIndexOf('.') + 1));
         return Link.fromUri(constraintURI).rel(CONSTRAINED_BY.getURI()).build();
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConstraintExceptionMapper.java
@@ -51,7 +51,21 @@ public abstract class ConstraintExceptionMapper<T extends ConstraintViolationExc
     public static Link buildConstraintLink(final ConstraintViolationException e,
                                            final ServletContext context,
                                            final UriInfo uriInfo) {
+        return buildConstraintLink(e.getClass().toString(),
+                context, uriInfo);
+    }
 
+    /**
+     * Creates a constrainedBy link header with the appropriate RDF URL for the exception.
+     *
+     * @param className the classname of the exception to build the link for.
+     * @param context ServletContext ServletContext that we're running in.
+     * @param uriInfo UriInfo UriInfo from the ExceptionMapper.
+     * @return Link A http://www.w3.org/ns/ldp#constrainedBy link header
+     */
+    public static Link buildConstraintLink(final String className,
+                                           final ServletContext context,
+                                           final UriInfo uriInfo) {
         String path = context.getContextPath();
         if (path.equals("/")) {
             path = "";
@@ -59,7 +73,7 @@ public abstract class ConstraintExceptionMapper<T extends ConstraintViolationExc
 
         final String constraintURI = uriInfo == null ? "" : String.format("%s://%s%s%s%s.rdf",
                 uriInfo.getBaseUri().getScheme(), uriInfo.getBaseUri().getAuthority(), path,
-                CONSTRAINT_DIR, e.getClass().toString().substring(e.getClass().toString().lastIndexOf('.') + 1));
+                CONSTRAINT_DIR, className.substring(className.lastIndexOf('.') + 1));
         return Link.fromUri(constraintURI).rel(CONSTRAINED_BY.getURI()).build();
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.status;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
+import org.slf4j.Logger;
+
+/**
+ * Mapper to display all the various constrainedby links and messages.
+ * @author whikloj
+ */
+@Provider
+public class MultipleConstraintViolationExceptionMapper extends
+        ConstraintExceptionMapper<MultipleConstraintViolationException> implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(MultipleConstraintViolationExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Context
+    private ServletContext context;
+
+    @Override
+    public Response toResponse(final MultipleConstraintViolationException e) {
+        debugException(this, e, LOGGER);
+
+        final String msg = e.getMessage();
+        final Set<String> exceptionClasses = e.getExceptionTypes().stream().map(Exception::getClass)
+                .map(Class::getName).collect(Collectors.toSet());
+        final Response.ResponseBuilder response = status(CONFLICT).entity(msg).type(TEXT_PLAIN_WITH_CHARSET);
+        for (final String clazz : exceptionClasses ) {
+            final Link link = buildConstraintLink(clazz, context, uriInfo);
+            response.links(link);
+        }
+        return response.build();
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.slf4j.Logger;
 
@@ -55,8 +56,8 @@ public class MultipleConstraintViolationExceptionMapper extends
 
         final String msg = e.getMessage();
         final Response.ResponseBuilder response = status(CONFLICT).entity(msg).type(TEXT_PLAIN_WITH_CHARSET);
-        final Link[] constraintLinks = e.getExceptionTypes().stream().map(Exception::getClass)
-                .map(Class::getName).distinct().map(c -> buildConstraintLink(c, context, uriInfo))
+        final Link[] constraintLinks = e.getExceptionTypes().stream().map(ConstraintViolationException::getClass)
+                .distinct().map(c -> buildConstraintLink(c, context, uriInfo))
                 .toArray(Link[]::new);
         return response.links(constraintLinks).build();
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/MultipleConstraintViolationExceptionMapper.java
@@ -30,9 +30,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.slf4j.Logger;
 
@@ -57,14 +54,11 @@ public class MultipleConstraintViolationExceptionMapper extends
         debugException(this, e, LOGGER);
 
         final String msg = e.getMessage();
-        final Set<String> exceptionClasses = e.getExceptionTypes().stream().map(Exception::getClass)
-                .map(Class::getName).collect(Collectors.toSet());
         final Response.ResponseBuilder response = status(CONFLICT).entity(msg).type(TEXT_PLAIN_WITH_CHARSET);
-        for (final String clazz : exceptionClasses ) {
-            final Link link = buildConstraintLink(clazz, context, uriInfo);
-            response.links(link);
-        }
-        return response.build();
+        final Link[] constraintLinks = e.getExceptionTypes().stream().map(Exception::getClass)
+                .map(Class::getName).distinct().map(c -> buildConstraintLink(c, context, uriInfo))
+                .toArray(Link[]::new);
+        return response.links(constraintLinks).build();
     }
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MultipleConstraintViolationException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MultipleConstraintViolationException.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Wrapper to hold multiple constraint violation exceptions for later reporting.
+ * @author whikloj
+ */
+public class MultipleConstraintViolationException extends ConstraintViolationException {
+
+    private Set<Exception> exceptionTypes = new HashSet<>();
+
+    private String fullMessage = "";
+
+    public Set<Exception> getExceptionTypes() {
+        return exceptionTypes;
+    }
+
+    public MultipleConstraintViolationException(final List<Exception> exceptions) {
+        super("There are multiple exceptions");
+        for (final Exception exception : exceptions) {
+            exceptionTypes.add(exception);
+            fullMessage += exception.getMessage() + "\n";
+        }
+    }
+
+    @Override
+    public String getMessage() {
+        return fullMessage;
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MultipleConstraintViolationException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/MultipleConstraintViolationException.java
@@ -27,17 +27,17 @@ import java.util.Set;
  */
 public class MultipleConstraintViolationException extends ConstraintViolationException {
 
-    private Set<Exception> exceptionTypes = new HashSet<>();
+    private Set<ConstraintViolationException> exceptionTypes = new HashSet<>();
 
     private String fullMessage = "";
 
-    public Set<Exception> getExceptionTypes() {
+    public Set<ConstraintViolationException> getExceptionTypes() {
         return exceptionTypes;
     }
 
-    public MultipleConstraintViolationException(final List<Exception> exceptions) {
+    public MultipleConstraintViolationException(final List<ConstraintViolationException> exceptions) {
         super("There are multiple exceptions");
-        for (final Exception exception : exceptions) {
+        for (final ConstraintViolationException exception : exceptions) {
             exceptionTypes.add(exception);
             fullMessage += exception.getMessage() + "\n";
         }

--- a/fcrepo-webapp/src/test/java/org/fcrepo/webapp/ConstraintExceptionsTest.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/webapp/ConstraintExceptionsTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.webapp;
 
+import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.junit.Assert;
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.junit.Test;
@@ -36,7 +37,8 @@ public class ConstraintExceptionsTest {
         final Reflections reflections = new Reflections("org.fcrepo");
         final Set<Class<? extends ConstraintViolationException>> subTypes =
                 reflections.getSubTypesOf(ConstraintViolationException.class);
-
+        // Multiple is a wrapper to hold other constraint violations, it has no static file.
+        subTypes.remove(MultipleConstraintViolationException.class);
         subTypes.add(ConstraintViolationException.class);
 
         for (final Class c : subTypes) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3257

# What does this Pull Request do?
Combines all exceptions related to internal constraints around server managed types and properties together into one response.

# How should this be tested?

Previously if you put more than one invalid statement in your RDF you would only get an error for the first statement to get checked.

Now you will get all messages together.

This also modifies the old behaviour if your RDF mixes altering managed types and managed properties. In Fedora 5 you get a constrainedby link to a [generic description](https://github.com/fcrepo/fcrepo/blob/6d902757fc7d6d09ccbb77c51cdfb3fee6d60c7c/fcrepo-webapp/src/main/webapp/static/constraints/ConstraintViolationException.rdf).

In this PR you will actually get 2 constrainedby link headers.

### Examples:
#### Modifying a restricted type
Fedora 5:
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d "<> a <http://www.w3.org/ns/ldp#BasicContainer> ." http://localhost:8080/rest                                                                   
HTTP/1.1 409 Conflict
Date: Thu, 15 Oct 2020 18:08:29 GMT
Set-Cookie: JSESSIONID=6y7hooff2bkv12sz19tvpqj13;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:08:29 GMT
Link: <http://localhost:8080/static/constraints/ServerManagedTypeException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 146
Server: Jetty(9.3.25.v20180904)

The http://www.w3.org/1999/02/22-rdf-syntax-ns#type predicate may not take an object in the server managed namespaces (http://www.w3.org/ns/ldp#).
```
Fedora 6
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d "<> a <http://www.w3.org/ns/ldp#BasicContainer> ." http://localhost:8080/rest
HTTP/1.1 409 Conflict
Date: Thu, 15 Oct 2020 18:04:22 GMT
Set-Cookie: JSESSIONID=node0hgxhzyp322ff1dwrfy45k2pjl0.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:04:22 GMT
Content-Type: text/plain;charset=utf-8
Link: <http://localhost:8080/static/constraints/ServerManagedTypeException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Length: 100
Server: Jetty(9.4.24.v20191120)

The server managed type (http://www.w3.org/ns/ldp#BasicContainer) cannot be modified by the client.
```

#### Modifying a restricted property
Fedora 5
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d " @prefix ldp: <http://www.w3.org/ns/ldp#> . <> ldp:contains <http://example.org/something> ." http://localhost:8080/rest                       
HTTP/1.1 409 Conflict
Date: Thu, 15 Oct 2020 18:12:53 GMT
Set-Cookie: JSESSIONID=3tih5s9o32p8iwtoh2qbezj3;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:12:53 GMT
Link: <http://localhost:8080/static/constraints/ServerManagedPropertyException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 99
Server: Jetty(9.3.25.v20180904)

The server managed predicates (http://www.w3.org/ns/ldp#contains) cannot be modified by the client.
```
Fedora 6
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d " @prefix ldp: <http://www.w3.org/ns/ldp#> . <> ldp:contains <http://example.org/something> ." http://localhost:8080/rest 
HTTP/1.1 409 Conflict
Date: Thu, 15 Oct 2020 18:05:59 GMT
Set-Cookie: JSESSIONID=node03wazzy6a3o6r1lzywn29w6iar2.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:05:59 GMT
Content-Type: text/plain;charset=utf-8
Link: <http://localhost:8080/static/constraints/ServerManagedPropertyException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Length: 99
Server: Jetty(9.4.24.v20191120)

The server managed predicate (http://www.w3.org/ns/ldp#contains) cannot be modified by the client.
```

#### Modify both a restricted type and property
Fedora 5
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d " @prefix ldp: <http://www.w3.org/ns/ldp#> . <> a ldp:BasicContainer ; ldp:contains <http://example.org/something> ." http://localhost:8080/rest
HTTP/1.1 400 Bad Request
Date: Thu, 15 Oct 2020 18:08:41 GMT
Set-Cookie: JSESSIONID=nl1dd096z11mo8f2gatmeug6;Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:08:41 GMT
Link: <http://localhost:8080/static/constraints/ConstraintViolationException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 247
Server: Jetty(9.3.25.v20180904)

The server managed predicates (http://www.w3.org/ns/ldp#contains) cannot be modified by the client.,
The http://www.w3.org/1999/02/22-rdf-syntax-ns#type predicate may not take an object in the server managed namespaces (http://www.w3.org/ns/ldp#).
```
Fedora 6
```
> curl -i -ufedoraAdmin:fedoraAdmin -XPOST -H"Content-type: text/turtle" -d " @prefix ldp: <http://www.w3.org/ns/ldp#> . <> a ldp:BasicContainer ; ldp:contains <http://example.org/something> ." http://localhost:8080/rest
HTTP/1.1 409 Conflict
Date: Thu, 15 Oct 2020 18:05:29 GMT
Set-Cookie: JSESSIONID=node06cqvc3kw2q9k1m9x8wsw921v81.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 14-Oct-2020 18:05:29 GMT
Content-Type: text/plain;charset=utf-8
Link: <http://localhost:8080/static/constraints/ServerManagedPropertyException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Link: <http://localhost:8080/static/constraints/ServerManagedTypeException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Length: 199
Server: Jetty(9.4.24.v20191120)

The server managed predicate (http://www.w3.org/ns/ldp#contains) cannot be modified by the client.
The server managed type (http://www.w3.org/ns/ldp#BasicContainer) cannot be modified by the client.
```

# Interested parties
@fcrepo/committers
