### PR TITLE
Fix travis postgres issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ jobs:
             - postgresql-client-12
       env:
         - DB=postgresql
-        - DB_PORT=5432
+        - DB_PORT=5433
         - ITEST=true
       before_script:
-        - psql -c 'CREATE DATABASE fcrepo;' -U postgres
+        - psql -p $DB_PORT -c 'CREATE DATABASE fcrepo;' -U postgres
     - name: ITests - MariaDB
       os: linux
       dist: trusty


### PR DESCRIPTION
# What does this Pull Request do?

Fix the travis postgres build. The build broke because travis decided to include the newly released Postgres 13 in the image by default.

# How should this be tested?

The ci build should pass.

# Interested parties
@fcrepo/committers
