### PR TITLE
always create a memento regardless of resource state

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -183,11 +183,15 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testGetTimeMapResponse() throws Exception {
+    public void createMementoOnResourceWithNoUnversionedChanges() throws Exception {
+        final var v1 = now();
         createVersionedContainer(id);
+        TimeUnit.SECONDS.sleep(1);
 
+        final var v2 = now();
         createContainerMementoWithBody(subjectUri);
-        verifyTimemapResponse(subjectUri, id, now());
+
+        verifyTimemapResponse(subjectUri, id, new String[]{v1, v2}, v1, v2);
     }
 
     @Test
@@ -264,17 +268,14 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     public void testGetTimeMapResponseMultipleMementos() throws Exception {
         createVersionedContainer(id);
         final var v1 = now();
-        createMemento(subjectUri);
         TimeUnit.SECONDS.sleep(1);
 
         putVersionedContainer(id, "2", true);
         final var v2 = now();
-        createMemento(subjectUri);
         TimeUnit.SECONDS.sleep(1);
 
         putVersionedContainer(id, "3", true);
         final var v3 = now();
-        createMemento(subjectUri);
 
         verifyTimemapResponse(subjectUri, id, new String[] {v1, v2, v3}, v1, v3);
     }
@@ -912,6 +913,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         TimeUnit.SECONDS.sleep(1);
         final String mementoUri = createContainerMementoWithBody(descriptionUri);
         assertMementoUri(mementoUri, descriptionUri);
+        TimeUnit.SECONDS.sleep(1);
 
         setDescriptionProperty(id, null, DC.title.getURI(), "Updated");
         TimeUnit.SECONDS.sleep(1);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -49,6 +49,7 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     private static final String METRIC_NAME = "fcrepo.storage.ocfl.object";
     private static final String OPERATION = "operation";
     private static final Timer writeTimer = Metrics.timer(METRIC_NAME, OPERATION, "write");
+    private static final Timer writeHeadersTimer = Metrics.timer(METRIC_NAME, OPERATION, "writeHeaders");
     private static final Timer deleteContentTimer = Metrics.timer(METRIC_NAME, OPERATION, "deleteContent");
     private static final Timer deleteResourceTimer = Metrics.timer(METRIC_NAME, OPERATION, "deleteResource");
     private static final Timer containsResourceTimer = Metrics.timer(METRIC_NAME, OPERATION, "containsResource");
@@ -78,6 +79,13 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     public ResourceHeaders writeResource(final ResourceHeaders headers, final InputStream content) {
         return MetricsHelper.time(writeTimer, () -> {
             return exec(() -> inner.writeResource(headers, content));
+        });
+    }
+
+    @Override
+    public void writeHeaders(final ResourceHeaders headers) {
+        writeHeadersTimer.record(() -> {
+            exec(() -> inner.writeHeaders(headers));
         });
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3465

This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/19

# What does this Pull Request do?

Changes the memento creation behavior so that it always creates a memento on a resource regardless of whether or not that resource has outstanding, unversioned changes. This is inline with the behavior in F5.

# How should this be tested?

```
# 1. Create a resource
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/box -H'Link: <http://www.w3.org/ns/ldp#BasicContainer>;rel="type"' -v -H "Content-Type: text/turtle" -X PUT --data "<> <http://purl.org/dc/elements/1.1/title> 'Box'"

# 2. Inspect its mementos
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/box/fcr:versions

# 3. Create a new memento
curl -u fedoraAdmin:fedoraAdmin -X POST http://localhost:8080/rest/box/fcr:versions

# 4. Verify the new memento exists
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/box/fcr:versions
```

# Interested parties
@fcrepo/committers
