### PR TITLE
Remove DELETE from Memento Allow header

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -543,7 +543,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         // Add Options headers
         final String options;
         if (resource.isMemento()) {
-            options = "GET,HEAD,OPTIONS,DELETE";
+            options = "GET,HEAD,OPTIONS";
         } else if (resource instanceof TimeMap) {
             options = "POST,HEAD,GET,OPTIONS";
             servletResponse.addHeader("Vary-Post", MEMENTO_DATETIME_HEADER);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1449,6 +1449,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertTrue("Should allow GET", methods.contains(HttpGet.METHOD_NAME));
         assertTrue("Should allow HEAD", methods.contains(HttpHead.METHOD_NAME));
         assertTrue("Should allow OPTIONS", methods.contains(HttpOptions.METHOD_NAME));
+        assertFalse("Should NOT allow DELETE", methods.contains(HttpDelete.METHOD_NAME));
     }
 
     private String createLDPRSMementoWithExistingBody(final String id) throws Exception {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1449,7 +1449,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         assertTrue("Should allow GET", methods.contains(HttpGet.METHOD_NAME));
         assertTrue("Should allow HEAD", methods.contains(HttpHead.METHOD_NAME));
         assertTrue("Should allow OPTIONS", methods.contains(HttpOptions.METHOD_NAME));
-        assertTrue("Should allow DELETE", methods.contains(HttpDelete.METHOD_NAME));
     }
 
     private String createLDPRSMementoWithExistingBody(final String id) throws Exception {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3479

# What does this Pull Request do?
Removed `DELETE` from the `Allow` header for Mementos.

# How should this be tested?

Create a resource, get the initial memento. 
The allow will be `GET,HEAD,OPTIONS,DELETE`
Pull in this PR, rebuild, restart.
Get the same Memento, allow will be `GET,HEAD,OPTIONS`

Also the API testsuite now skips test 4.2.6

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
