### PR TITLE
Don't dump a stacktrace for a tombstone

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
@@ -43,7 +43,7 @@ public class TombstoneExceptionMapper implements
 
     @Override
     public Response toResponse(final TombstoneException e) {
-        debugException(this, e, LOGGER);
+        LOGGER.debug(e.getMessage());
         final Response.ResponseBuilder response = status(GONE)
                 .entity(e.getMessage());
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3515

# What does this Pull Request do?
Doesn't dump the stacktrace when you get a Tombstone (and we throw a TombstoneException). Instead just log the message.

# How should this be tested?

Start Fedora with DEBUG logging
Create a resource.
Delete the resource
Get the resource.

Check the Fedora logs.

Before see:
```
org.fcrepo.kernel.api.exception.TombstoneException: Discovered tombstone resource at /box, departed at: 2020-11-06T19:15:16.005957Z
	at org.fcrepo.http.api.ContentExposingResource.getResourceFromPath(ContentExposingResource.java:1059)
	at org.fcrepo.http.api.ContentExposingResource.resource(ContentExposingResource.java:437)
	at org.fcrepo.http.api.FedoraLdp.getResource(FedoraLdp.java:258)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:176)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:469)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:391)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:80)
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:253)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
       ...
```

After see:
```
DEBUG 14:50:40.709 (TombstoneExceptionMapper) Discovered tombstone resource at /box, departed at: 2020-11-06T19:15:16.005957Z
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
