### PR TITLE
Check for deleted resources before creating new ones

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizingRealm.java
@@ -243,7 +243,7 @@ public class WebACAuthorizingRealm extends AuthorizingRealm {
         } catch (final PathNotFoundException exc) {
             log.debug("Resource {} not found getting container", fedoraId.getFullIdPath());
             final FedoraId containerId =
-                    containmentIndex.getContainerIdByPath(TransactionUtils.openTxId(transaction()), fedoraId);
+                    containmentIndex.getContainerIdByPath(TransactionUtils.openTxId(transaction()), fedoraId, false);
             log.debug("Attempting to get FedoraResource for {}", fedoraId.getFullIdPath());
             try {
                 log.debug("Got FedoraResource for {}", containerId.getFullIdPath());

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -131,7 +131,7 @@ public class FedoraAcl extends ContentExposingResource {
         LOGGER.info("PUT acl resource '{}'", externalPath());
 
         final FedoraId aclId = identifierConverter().pathToInternalId(externalPath()).asAcl();
-        final boolean exists = doesResourceExist(transaction(), aclId);
+        final boolean exists = doesResourceExist(transaction(), aclId, false);
 
         final MediaType contentType =
             requestContentType == null ? RDFMediaType.TURTLE_TYPE : valueOf(getSimpleContentType(requestContentType));
@@ -246,7 +246,7 @@ public class FedoraAcl extends ContentExposingResource {
 
         final FedoraId originalId = identifierConverter().pathToInternalId(externalPath());
         final FedoraId aclId = originalId.asAcl();
-        final boolean exists = doesResourceExist(transaction(), aclId);
+        final boolean exists = doesResourceExist(transaction(), aclId, false);
 
         if (!exists) {
             if (originalId.isRepositoryRoot()) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -90,10 +90,12 @@ abstract public class FedoraBaseResource extends AbstractResource {
     /**
      * @param transaction the transaction in which to check
      * @param fedoraId identifier of the object to check
+     * @param includeDeleted Whether to check for deleted resources too.
      * @return Returns true if an object with the provided id exists
      */
-    protected boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId) {
-        return resourceHelper.doesResourceExist(transaction, fedoraId);
+    protected boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId,
+                                        final boolean includeDeleted) {
+        return resourceHelper.doesResourceExist(transaction, fedoraId, includeDeleted);
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -393,7 +393,7 @@ public class FedoraLdp extends ContentExposingResource {
         final String interactionModel = checkInteractionModel(links);
 
         final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
-        final boolean resourceExists = doesResourceExist(transaction, fedoraId);
+        final boolean resourceExists = doesResourceExist(transaction, fedoraId, true);
 
         if (resourceExists) {
 
@@ -808,7 +808,7 @@ public class FedoraLdp extends ContentExposingResource {
         final FedoraId fullTestPath = fedoraId.resolve(pid);
         hasRestrictedPath(fullTestPath.getFullIdPath());
 
-        if (doesResourceExist(transaction(), fullTestPath) || isGhostNode(transaction(), fullTestPath)) {
+        if (doesResourceExist(transaction(), fullTestPath, true) || isGhostNode(transaction(), fullTestPath)) {
             LOGGER.debug("Resource with path {} already exists or is an immutable resource; minting new path instead",
                     fullTestPath);
             return mintNewPid(fedoraId, null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -305,7 +305,7 @@ public class FedoraLdpTest {
         when(mockContainer.getDescribedResource()).thenReturn(mockContainer);
         when(mockContainer.getFedoraId()).thenReturn(pathId);
 
-        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(false);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId, true)).thenReturn(false);
 
         when(mockNonRdfSourceDescription.getEtagValue()).thenReturn("");
         when(mockNonRdfSourceDescription.getStateToken()).thenReturn("");
@@ -1024,7 +1024,7 @@ public class FedoraLdpTest {
         final Container mockObject = (Container)setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("PUT");
         when(resourceFactory.getResource(mockTransaction, pathId)).thenReturn(mockObject);
-        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId, true)).thenReturn(true);
 
         final Response actual = testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
@@ -1039,7 +1039,7 @@ public class FedoraLdpTest {
 
         when(mockHttpConfiguration.putRequiresIfMatch()).thenReturn(true);
         when(resourceFactory.getResource(mockTransaction, pathId)).thenReturn(mockContainer);
-        when(resourceHelper.doesResourceExist(mockTransaction, pathId)).thenReturn(true);
+        when(resourceHelper.doesResourceExist(mockTransaction, pathId, true)).thenReturn(true);
 
         testObj.createOrReplaceObjectRdf(NTRIPLES_TYPE,
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
@@ -204,5 +205,19 @@ public class FedoraTombstonesIT extends AbstractResourceIT {
 
         final HttpGet finalGet = new HttpGet(agPath);
         assertEquals(NOT_FOUND.getStatusCode(), getStatus(finalGet));
+    }
+
+    @Test
+    public void testNoChildrenOfTombstone() throws Exception {
+        final String uri;
+        try (final var response = execute(postObjMethod())) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            uri = getLocation(response);
+        }
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(uri)));
+        assertEquals(GONE.getStatusCode(), getStatus(new HttpPut(uri)));
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(new HttpPut(uri + "/" + getRandomUniqueId())));
+        assertEquals(BAD_REQUEST.getStatusCode(), getStatus(new HttpPut(uri + "/" + getRandomUniqueId() + "/" +
+                getRandomUniqueId())));
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -107,17 +107,19 @@ public interface ContainmentIndex {
      *
      * @param txId The transaction id, or null if no transaction
      * @param fedoraId The resource's FedoraId.
+     * @param includeDeleted Include deleted resources in the search.
      * @return True if it is in the index.
      */
-    boolean resourceExists(final String txId, final FedoraId fedoraId);
+    boolean resourceExists(final String txId, final FedoraId fedoraId, final boolean includeDeleted);
 
     /**
      * Find the ID for the container of the provided resource by iterating up the path until you find a real resource.
      * @param txId The transaction id, or null if no transaction
      * @param fedoraId The resource's ID.
+     * @param checkDeleted Whether to include deleted resource (tombstones) in the search.
      * @return The container ID.
      */
-    FedoraId getContainerIdByPath(final String txId, final FedoraId fedoraId);
+    FedoraId getContainerIdByPath(final String txId, final FedoraId fedoraId, final boolean checkDeleted);
 
     /**
      * Truncates the containment index. This should only be called when rebuilding the index.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHelper.java
@@ -31,9 +31,11 @@ public interface ResourceHelper {
      * Check if a resource exists.
      * @param transaction The current transaction
      * @param fedoraId The internal identifier
+     * @param includeDeleted Whether to check for deleted resources too.
      * @return True if the identifier resolves to a resource.
      */
-    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId);
+    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId,
+                                     final boolean includeDeleted);
 
     /**
      * Is the resource a "ghost node". Ghost nodes are defined as a resource that does not exist, but whose URI is part

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -137,16 +137,16 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
     }
 
     @Override
-    public boolean resourceExists(final String txID, final FedoraId fedoraId) {
+    public boolean resourceExists(final String txID, final FedoraId fedoraId, final boolean includeDeleted) {
         return MetricsHelper.time(resourceExistsTimer, () -> {
-            return containmentIndexImpl.resourceExists(txID, fedoraId);
+            return containmentIndexImpl.resourceExists(txID, fedoraId, includeDeleted);
         });
     }
 
     @Override
-    public FedoraId getContainerIdByPath(final String txID, final FedoraId fedoraId) {
+    public FedoraId getContainerIdByPath(final String txID, final FedoraId fedoraId, final boolean checkDeleted) {
         return MetricsHelper.time(getContainerIdByPathTimer, () -> {
-            return containmentIndexImpl.getContainerIdByPath(txID, fedoraId);
+            return containmentIndexImpl.getContainerIdByPath(txID, fedoraId, checkDeleted);
         });
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceHelperImpl.java
@@ -57,14 +57,15 @@ public class ResourceHelperImpl implements ResourceHelper {
 
     @Override
     public boolean isGhostNode(final Transaction transaction, final FedoraId resourceId) {
-        if (!doesResourceExist(transaction, resourceId)) {
+        if (!doesResourceExist(transaction, resourceId, true)) {
             return containmentIndex.hasResourcesStartingWith(TransactionUtils.openTxId(transaction), resourceId);
         }
         return false;
     }
 
     @Override
-    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId) {
+    public boolean doesResourceExist(final Transaction transaction, final FedoraId fedoraId,
+                                     final boolean includeDeleted) {
         final String transactionId = TransactionUtils.openTxId(transaction);
         if (fedoraId.isRepositoryRoot()) {
             // Root always exists.
@@ -73,7 +74,7 @@ public class ResourceHelperImpl implements ResourceHelper {
         if (!(fedoraId.isMemento() || fedoraId.isAcl())) {
             // containment index doesn't handle versions and only tells us if the resource (not acl) is there,
             // so don't bother checking for them.
-            return containmentIndex.resourceExists(transactionId, fedoraId);
+            return containmentIndex.resourceExists(transactionId, fedoraId, includeDeleted);
         } else {
 
             final PersistentStorageSession psSession = getSession(transactionId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -392,7 +392,7 @@ public class ReferenceServiceImpl implements ReferenceService {
      */
     private void recordEvent(final String txId, final String resourceId, final String userPrincipal) {
         final FedoraId fedoraId = FedoraId.create(resourceId);
-        if (this.containmentIndex.resourceExists(txId, fedoraId)) {
+        if (this.containmentIndex.resourceExists(txId, fedoraId, false)) {
             this.eventAccumulator.recordEventForOperation(txId, fedoraId, getOperation(fedoraId, userPrincipal));
         }
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -410,12 +410,12 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         stubObject("transaction2");
-        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
         containmentIndex.addContainedBy(transaction2.getId(), parent1.getFedoraId(), child1.getFedoraId());
         containmentIndex.commitTransaction(transaction2.getId());
-        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
+        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
     }
 
     @Test
@@ -424,29 +424,29 @@ public class ContainmentIndexImplTest {
         stubObject("child1");
         stubObject("transaction1");
         stubObject("transaction2");
-        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId(), false));
         // Only visible in the transaction.
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId(), false));
         // Rollback transaction.
         containmentIndex.rollbackTransaction(transaction1.getId());
-        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId(), false));
         // Add again in transaction.
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
-        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
-        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId(), false));
         // Commit and visible everywhere.
         containmentIndex.commitTransaction(transaction1.getId());
-        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId()));
+        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction2.getId(), child1.getFedoraId(), false));
     }
 
     @Test
@@ -528,8 +528,8 @@ public class ContainmentIndexImplTest {
         assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(null, fedoraID));
+        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(null, fedoraID, false));
     }
 
     /**
@@ -546,8 +546,8 @@ public class ContainmentIndexImplTest {
         assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(parent1.getFedoraId().getFullId(),
                 containmentIndex.getContainedBy(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId()));
-        assertTrue(containmentIndex.resourceExists(null, fedoraID));
+        assertTrue(containmentIndex.resourceExists(null, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(null, fedoraID, false));
     }
 
     @Test
@@ -558,11 +558,11 @@ public class ContainmentIndexImplTest {
 
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), child1.getFedoraId());
 
-        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
+        assertTrue(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
 
         containmentIndex.reset();
 
-        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId()));
+        assertFalse(containmentIndex.resourceExists(transaction1.getId(), child1.getFedoraId(), false));
     }
 
     @Test
@@ -595,6 +595,24 @@ public class ContainmentIndexImplTest {
         // That resource's ID starts with the ID we are checking.
         assertTrue(subPathId.getFullId().startsWith(parent1.getFedoraId().getFullId()));
         assertTrue(containmentIndex.hasResourcesStartingWith(transaction1.getId(), parent1.getFedoraId()));
+    }
+
+    @Test
+    public void testDeletedResourceExists() {
+        stubObject("parent1");
+        stubObject("transaction1");
+        containmentIndex.addContainedBy(transaction1.getId(), FedoraId.getRepositoryRootId(), parent1.getFedoraId());
+        containmentIndex.commitTransaction(transaction1.getId());
+        assertTrue(containmentIndex.resourceExists(null, parent1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(null, parent1.getFedoraId(), true));
+        containmentIndex.removeContainedBy(transaction1.getId(), FedoraId.getRepositoryRootId(), parent1.getFedoraId());
+        containmentIndex.commitTransaction(transaction1.getId());
+        assertFalse(containmentIndex.resourceExists(null, parent1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(null, parent1.getFedoraId(), true));
+        containmentIndex.purgeResource(transaction1.getId(), parent1.getFedoraId());
+        containmentIndex.commitTransaction(transaction1.getId());
+        assertFalse(containmentIndex.resourceExists(null, parent1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(null, parent1.getFedoraId(), true));
     }
 }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceHelperImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ResourceHelperImplTest.java
@@ -102,9 +102,9 @@ public class ResourceHelperImplTest {
     @Test
     public void doesResourceExist_Exists_WithSession() throws Exception {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
-        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, fedoraId);
+        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, fedoraId, false);
         assertTrue(answerIn);
-        final boolean answerOut = resourceHelper.doesResourceExist(null, fedoraId);
+        final boolean answerOut = resourceHelper.doesResourceExist(null, fedoraId, false);
         assertFalse(answerOut);
     }
 
@@ -112,9 +112,9 @@ public class ResourceHelperImplTest {
     public void doesResourceExist_Exists_Description_WithSession() {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
         final FedoraId descId = fedoraId.asDescription();
-        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, descId);
+        final boolean answerIn = resourceHelper.doesResourceExist(mockTx, descId, false);
         assertTrue(answerIn);
-        final boolean answerOut = resourceHelper.doesResourceExist(null, descId);
+        final boolean answerOut = resourceHelper.doesResourceExist(null, descId, false);
         assertFalse(answerOut);
     }
 
@@ -122,7 +122,7 @@ public class ResourceHelperImplTest {
     public void doesResourceExist_Exists_WithoutSession() throws Exception {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
         containmentIndex.commitTransaction(mockTx.getId());
-        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId);
+        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId, false);
         assertTrue(answer);
     }
 
@@ -131,33 +131,33 @@ public class ResourceHelperImplTest {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
         containmentIndex.commitTransaction(mockTx.getId());
         final FedoraId descId = fedoraId.asDescription();
-        final boolean answer = resourceHelper.doesResourceExist(null, descId);
+        final boolean answer = resourceHelper.doesResourceExist(null, descId, false);
         assertTrue(answer);
     }
 
     @Test
     public void doesResourceExist_DoesntExist_WithSession() throws Exception {
-        final boolean answer = resourceHelper.doesResourceExist(mockTx, fedoraId);
+        final boolean answer = resourceHelper.doesResourceExist(mockTx, fedoraId, false);
         assertFalse(answer);
     }
 
     @Test
     public void doesResourceExist_DoesntExists_Description_WithSession() {
         final FedoraId descId = fedoraId.asDescription();
-        final boolean answer = resourceHelper.doesResourceExist(mockTx, descId);
+        final boolean answer = resourceHelper.doesResourceExist(mockTx, descId, false);
         assertFalse(answer);
     }
 
     @Test
     public void doesResourceExist_DoesntExist_WithoutSession() throws Exception {
-        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId);
+        final boolean answer = resourceHelper.doesResourceExist(null, fedoraId, false);
         assertFalse(answer);
     }
 
     @Test
     public void doesResourceExist_DoesntExists_Description_WithoutSession() {
         final FedoraId descId = fedoraId.asDescription();
-        final boolean answer = resourceHelper.doesResourceExist(null, descId);
+        final boolean answer = resourceHelper.doesResourceExist(null, descId, false);
         assertFalse(answer);
     }
 
@@ -168,7 +168,7 @@ public class ResourceHelperImplTest {
     public void doesResourceExist_Exception_WithSession() throws Exception {
         when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
                 .thenThrow(PersistentSessionClosedException.class);
-        resourceHelper.doesResourceExist(mockTx, fedoraMementoId);
+        resourceHelper.doesResourceExist(mockTx, fedoraMementoId, false);
     }
 
     /**
@@ -178,7 +178,7 @@ public class ResourceHelperImplTest {
     public void doesResourceExist_Exception_WithoutSession() throws Exception {
         when(psSession.getHeaders(fedoraMementoId, fedoraMementoId.getMementoInstant()))
                 .thenThrow(PersistentSessionClosedException.class);
-        resourceHelper.doesResourceExist(null, fedoraMementoId);
+        resourceHelper.doesResourceExist(null, fedoraMementoId, false);
     }
 
     /**
@@ -188,17 +188,17 @@ public class ResourceHelperImplTest {
     public void testGhostNodeFailure() {
         containmentIndex.addContainedBy(mockTx.getId(), rootId, fedoraId);
         // Inside the transaction the resource exists, so its not a ghost node.
-        assertTrue(resourceHelper.doesResourceExist(mockTx, fedoraId));
+        assertTrue(resourceHelper.doesResourceExist(mockTx, fedoraId, false));
         assertFalse(resourceHelper.isGhostNode(mockTx, fedoraId));
         // Outside the transaction the resource does not exist.
-        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId, false));
         // Because there are no other items it is not a ghost node.
         assertFalse(resourceHelper.isGhostNode(null, fedoraId));
 
         containmentIndex.commitTransaction(mockTx.getId());
 
         // Now it exists outside the transaction.
-        assertTrue(resourceHelper.doesResourceExist(null, fedoraId));
+        assertTrue(resourceHelper.doesResourceExist(null, fedoraId, false));
         // So it can't be a ghost node.
         assertFalse(resourceHelper.isGhostNode(null, fedoraId));
     }
@@ -210,17 +210,17 @@ public class ResourceHelperImplTest {
     public void testGhostNodeSuccess() {
         final var resourceId = fedoraId.resolve("the/child/path");
         containmentIndex.addContainedBy(mockTx.getId(), rootId, resourceId);
-        assertTrue(resourceHelper.doesResourceExist(mockTx, resourceId));
-        assertFalse(resourceHelper.doesResourceExist(mockTx, fedoraId));
+        assertTrue(resourceHelper.doesResourceExist(mockTx, resourceId, false));
+        assertFalse(resourceHelper.doesResourceExist(mockTx, fedoraId, false));
         assertTrue(resourceHelper.isGhostNode(mockTx, fedoraId));
-        assertFalse(resourceHelper.doesResourceExist(null, resourceId));
-        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        assertFalse(resourceHelper.doesResourceExist(null, resourceId, false));
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId, false));
         assertFalse(resourceHelper.isGhostNode(null, fedoraId));
 
         containmentIndex.commitTransaction(mockTx.getId());
 
-        assertTrue(resourceHelper.doesResourceExist(null, resourceId));
-        assertFalse(resourceHelper.doesResourceExist(null, fedoraId));
+        assertTrue(resourceHelper.doesResourceExist(null, resourceId, false));
+        assertFalse(resourceHelper.doesResourceExist(null, fedoraId,false));
         assertTrue(resourceHelper.isGhostNode(null, fedoraId));
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -124,7 +124,7 @@ public class IndexBuilderImpl implements IndexBuilder {
     }
 
     private boolean repoRootContainmentExists() {
-        return containmentIndex.resourceExists(null, FedoraId.getRepositoryRootId());
+        return containmentIndex.resourceExists(null, FedoraId.getRepositoryRootId(), false);
     }
 
     private boolean repoContainsObjects() {

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexUpdater.java
@@ -77,7 +77,7 @@ public class SearchIndexUpdater {
         try {
             final var fedoraId = event.getFedoraId();
             final var types = event.getTypes();
-            if (types.contains(RESOURCE_DELETION) && !resourceHelper.doesResourceExist(null, fedoraId)) {
+            if (types.contains(RESOURCE_DELETION) && !resourceHelper.doesResourceExist(null, fedoraId, false)) {
                 this.searchIndex.removeFromIndex(fedoraId);
             } else if (types.contains(RESOURCE_CREATION) || types.contains(RESOURCE_MODIFICATION)) {
                 final var session = persistentStorageSessionManager.getReadOnlySession();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3523

# What does this Pull Request do?
Currently you can create a resource as a child of a tombstone because when looking for parents we don't check for deleted resources. The changes here make it so you can (depending on the need) check for only active resources or check for both active or deleted resources.

In some use cases (like the search index and inbound references) we don't want deleted resources to count, but in the CRUD areas a tombstone is a thing and should be returned and dealt with.

# How should this be tested?

The simplest use case is (as described in the ticket)
* `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/box`
* `curl -i -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8080/rest/box`
* `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/box/bin`

Before this PR, the last command will create a new resource under the tombstone. With this PR it should return a 400 Bad Request.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
