### PR TITLE
changed content size to long

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -429,12 +429,7 @@ public class FedoraLdp extends ContentExposingResource {
             final var binaryType = requestContentType != null ? requestContentType : DEFAULT_NON_RDF_CONTENT_TYPE;
             final var contentType = extContent == null ? binaryType.toString() : extContent.getContentType();
             final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
-            final Long contentSize;
-            if (contentDisposition == null || contentDisposition.getSize() == -1) {
-                contentSize = null;
-            } else {
-                contentSize = contentDisposition.getSize();
-            }
+            final long contentSize = contentDisposition == null ? -1L : contentDisposition.getSize();
 
             if (resourceExists) {
                 replaceBinariesService.perform(transaction.getId(),
@@ -608,12 +603,7 @@ public class FedoraLdp extends ContentExposingResource {
             final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
             final var binaryType = requestContentType != null ? requestContentType : DEFAULT_NON_RDF_CONTENT_TYPE;
             final var contentType = extContent == null ? binaryType.toString() : extContent.getContentType();
-            final Long contentSize;
-            if (contentDisposition == null || contentDisposition.getSize() == -1) {
-                contentSize = null;
-            } else {
-                contentSize = contentDisposition.getSize();
-            }
+            final long contentSize = contentDisposition == null ? -1L : contentDisposition.getSize();
 
             createResourceService.perform(transaction.getId(),
                                           getUserPrincipal(),

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
@@ -73,11 +73,11 @@ public interface ResourceHeaders {
     String getFilename();
 
     /**
-     * Get the size in bytes of the content of this resource
+     * Get the size in bytes of the content of this resource. May be -1 if the size is unknown or there is no content.
      *
      * @return size
      */
-    Long getContentSize();
+    long getContentSize();
 
     /**
      * Get the list of all digest URIs recorded for this resource

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateNonRdfSourceOperationBuilder.java
@@ -39,7 +39,7 @@ public interface CreateNonRdfSourceOperationBuilder extends NonRdfSourceOperatio
     CreateNonRdfSourceOperationBuilder contentDigests(Collection<URI> digests);
 
     @Override
-    CreateNonRdfSourceOperationBuilder contentSize(Long size);
+    CreateNonRdfSourceOperationBuilder contentSize(long size);
 
     /**
      * Set the parent identifier of the resource

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperation.java
@@ -63,5 +63,5 @@ public interface NonRdfSourceOperation extends ResourceOperation {
     /**
      * @return The size in bytes of content associated with this resource.
      */
-    Long getContentSize();
+    long getContentSize();
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/NonRdfSourceOperationBuilder.java
@@ -57,7 +57,7 @@ public interface NonRdfSourceOperationBuilder extends ResourceOperationBuilder {
      * @param size size of the content in bytes
      * @return the builder
      */
-    NonRdfSourceOperationBuilder contentSize(Long size);
+    NonRdfSourceOperationBuilder contentSize(long size);
 
     @Override
     NonRdfSourceOperationBuilder userPrincipal(String userPrincipal);

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
@@ -48,7 +48,7 @@ public interface CreateResourceService {
      * @param externalContent The external content handler or null if none.
      */
     void perform(String txId, String userPrincipal, FedoraId fedoraId,
-            String contentType, String filename, Long contentSize, List<String> linkHeaders,
+            String contentType, String filename, long contentSize, List<String> linkHeaders,
             Collection<URI> digest, InputStream requestBody, ExternalContent externalContent);
 
     /**

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
@@ -51,6 +51,6 @@ public interface ReplaceBinariesService {
                  String contentType,
                  Collection<URI> digests,
                  InputStream contentBody,
-                 Long size,
+                 long size,
                  ExternalContent externalContent);
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperation.java
@@ -44,7 +44,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
 
     private Collection<URI> digests;
 
-    private Long contentSize;
+    private long contentSize = -1;
 
     /**
      * Constructor for external content.
@@ -111,7 +111,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
     }
 
     @Override
-    public Long getContentSize() {
+    public long getContentSize() {
         return contentSize;
     }
 
@@ -188,7 +188,7 @@ public abstract class AbstractNonRdfSourceOperation extends AbstractResourceOper
     /**
      * @param contentSize the contentSize to set
      */
-    protected void setContentSize(final Long contentSize) {
+    protected void setContentSize(final long contentSize) {
         this.contentSize = contentSize;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractNonRdfSourceOperationBuilder.java
@@ -45,7 +45,7 @@ public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSour
 
     protected Collection<URI> digests;
 
-    protected Long contentSize;
+    protected long contentSize = -1;
 
     protected String userPrincipal;
 
@@ -93,7 +93,7 @@ public abstract class AbstractNonRdfSourceOperationBuilder implements NonRdfSour
     }
 
     @Override
-    public NonRdfSourceOperationBuilder contentSize(final Long size) {
+    public NonRdfSourceOperationBuilder contentSize(final long size) {
         this.contentSize = size;
         return this;
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderImpl.java
@@ -73,7 +73,7 @@ public class CreateNonRdfSourceOperationBuilderImpl extends AbstractNonRdfSource
     }
 
     @Override
-    public CreateNonRdfSourceOperationBuilder contentSize(final Long size) {
+    public CreateNonRdfSourceOperationBuilder contentSize(final long size) {
         return (CreateNonRdfSourceOperationBuilder) super.contentSize(size);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -80,7 +80,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
     @Override
     public void perform(final String txId, final String userPrincipal, final FedoraId fedoraId,
                           final String contentType, final String filename,
-                          final Long contentSize, final List<String> linkHeaders, final Collection<URI> digest,
+                          final long contentSize, final List<String> linkHeaders, final Collection<URI> digest,
                           final InputStream requestBody, final ExternalContent externalContent) {
         final PersistentStorageSession pSession = this.psManager.getSession(txId);
         checkAclLinkHeader(linkHeaders);
@@ -90,7 +90,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         final CreateNonRdfSourceOperationBuilder builder;
         String mimeType = contentType;
-        Long size = contentSize;
+        long size = contentSize;
         if (externalContent == null || externalContent.isCopy()) {
             var contentInputStream = requestBody;
             if (externalContent != null) {
@@ -102,7 +102,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         } else {
             builder = nonRdfSourceOperationFactory.createExternalBinaryBuilder(fedoraId,
                     externalContent.getHandling(), externalContent.getURI());
-            if (contentSize == null) {
+            if (contentSize == -1L) {
                 size = externalContent.getContentSize();
             }
             if (!digest.isEmpty()) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+
 import static java.lang.String.format;
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -62,13 +63,13 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                         final String contentType,
                         final Collection<URI> digests,
                         final InputStream contentBody,
-                        final Long contentSize,
+                        final long contentSize,
                         final ExternalContent externalContent) {
         try {
             final PersistentStorageSession pSession = this.psManager.getSession(txId);
 
             String mimeType = contentType;
-            Long size = contentSize;
+            long size = contentSize;
             final NonRdfSourceOperationBuilder builder;
             if (externalContent == null || externalContent.isCopy()) {
                 var contentInputStream = contentBody;
@@ -83,7 +84,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                         externalContent.getHandling(),
                         externalContent.getURI());
 
-                if (contentSize == null) {
+                if (contentSize == -1L) {
                     size = externalContent.getContentSize();
                 }
                 if (!digests.isEmpty()) {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/CreateNonRdfSourceOperationBuilderTest.java
@@ -84,7 +84,7 @@ public class CreateNonRdfSourceOperationBuilderTest {
 
     @Test
     public void testSize() {
-        final Long filesize = 123l;
+        final long filesize = 123l;
         final NonRdfSourceOperation op = internalBuilder.contentSize(filesize).build();
         assertEquals(filesize, op.getContentSize());
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/operations/UpdateNonRdfSourceOperationBuilderTest.java
@@ -45,7 +45,7 @@ public class UpdateNonRdfSourceOperationBuilderTest {
 
     private final String FILENAME = "someFile.txt";
 
-    private final Long FILESIZE = 123L;
+    private final long FILESIZE = 123L;
 
     private final Collection<URI> DIGESTS = asList(URI.create("urn:sha1:1234abcd"), URI.create("urn:md5:zyxw9876"));
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -554,7 +554,7 @@ public class CreateResourceServiceImplTest {
     }
 
     private void assertBinaryPropertiesPresent(final ResourceOperation operation, final String exMimetype,
-            final String exFilename, final Long exContentSize, final Collection<URI> exDigests) {
+            final String exFilename, final long exContentSize, final Collection<URI> exDigests) {
         final var nonRdfOperation = (NonRdfSourceOperation) operation;
         assertEquals(exContentSize, nonRdfOperation.getContentSize());
         assertEquals(exFilename, nonRdfOperation.getFilename());

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImplTest.java
@@ -175,7 +175,7 @@ public class ReplaceBinariesServiceImplTest {
         when(externalContent.getContentType()).thenReturn(MIME_TYPE);
 
         service.perform(TX_ID, USER_PRINCIPAL, FEDORA_ID, FILENAME, "application/octet-stream",
-                realDigests, null, null, externalContent);
+                realDigests, null, -1L, externalContent);
         verify(pSession).persist(operationCaptor.capture());
         final NonRdfSourceOperation op = operationCaptor.getValue();
 
@@ -227,7 +227,7 @@ public class ReplaceBinariesServiceImplTest {
     }
 
     private void assertPropertiesPopulated(final NonRdfSourceOperation op, final String exMimetype,
-            final String exFilename, final Long exContentSize, final Collection<URI> exDigests) {
+            final String exFilename, final long exContentSize, final Collection<URI> exDigests) {
         assertEquals(exMimetype, op.getMimeType());
         assertEquals(exFilename, op.getFilename());
         assertEquals(exContentSize, op.getContentSize());

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
@@ -129,7 +129,7 @@ public class ResourceHeaderUtils {
      * @param digests digests
      */
     public static void populateBinaryHeaders(final ResourceHeadersImpl headers, final String mimetype,
-            final String filename, final Long filesize, final Collection<URI> digests) {
+            final String filename, final long filesize, final Collection<URI> digests) {
         headers.setMimeType(mimetype);
         headers.setDigests(digests);
         headers.setFilename(filename);

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
@@ -43,7 +43,7 @@ public class ResourceHeadersImpl implements ResourceHeaders {
 
     private String filename;
 
-    private Long contentSize;
+    private long contentSize;
 
     private Collection<URI> digests;
 
@@ -140,14 +140,14 @@ public class ResourceHeadersImpl implements ResourceHeaders {
     }
 
     @Override
-    public Long getContentSize() {
+    public long getContentSize() {
         return contentSize;
     }
 
     /**
      * @param contentSize the contentSize to set
      */
-    public void setContentSize(final Long contentSize) {
+    public void setContentSize(final long contentSize) {
         this.contentSize = contentSize;
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -162,7 +162,7 @@ abstract class AbstractPersister implements Persister {
 
         // Existing size and digests must be cleared so they can be populated for the new content
         headers.setDigests(new ArrayList<>());
-        headers.setContentSize(null);
+        headers.setContentSize(-1);
 
         ResourceHeaderUtils.touchModificationHeaders(headers, operation.getUserPrincipal(), now);
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
@@ -210,7 +210,7 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
     }
 
     @Override
-    public Long getContentSize() {
+    public long getContentSize() {
         return kernelHeaders.getContentSize();
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -120,7 +120,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize());
         assertTrue("Headers did not contain default digest",
                 headers.getDigests().contains(CONTENT_SHA512));
     }
@@ -145,7 +145,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize());
         assertTrue("Headers did not contain md5 digest",
                 headers.getDigests().contains(CONTENT_MD5));
         assertTrue("Headers did not contain sha1 digest",
@@ -170,7 +170,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(rescId, headers.getId());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize());
         assertTrue("Headers did not contain default digest",
                 headers.getDigests().contains(CONTENT_SHA512));
     }
@@ -226,7 +226,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertNull(headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(UPDATED_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(UPDATED_CONTENT.length(), headers.getContentSize());
         assertEquals("Only one digest expected", 1, headers.getDigests().size());
         assertTrue("Headers did not contain default digest",
                 headers.getDigests().contains(UPDATED_SHA512));
@@ -262,7 +262,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("test.txt", headers.getFilename());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize());
         assertTrue("Headers did not contain default digest",
                 headers.getDigests().contains(CONTENT_SHA512));
     }
@@ -301,7 +301,7 @@ public class NonRdfSourcesPersistenceIT {
         assertEquals(rescId, headers.getParent());
         assertEquals(NON_RDF_SOURCE.getURI(), headers.getInteractionModel());
         assertEquals("text/plain", headers.getMimeType());
-        assertEquals(BINARY_CONTENT.length(), headers.getContentSize().longValue());
+        assertEquals(BINARY_CONTENT.length(), headers.getContentSize());
         assertTrue("Headers did not contain default digest",
                 headers.getDigests().contains(CONTENT_SHA512));
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersisterTest.java
@@ -95,7 +95,7 @@ public class CreateNonRdfSourcePersisterTest {
 
     private static final String EXTERNAL_HANDLING = "proxy";
 
-    private static final Long EXTERNAL_CONTENT_SIZE = 526632L;
+    private static final long EXTERNAL_CONTENT_SIZE = 526632L;
 
     private CreateNonRdfSourcePersister persister;
 
@@ -115,7 +115,7 @@ public class CreateNonRdfSourcePersisterTest {
                 CreateResourceOperation.class));
         when(nonRdfSourceOperation.getUserPrincipal()).thenReturn(USER_PRINCIPAL);
         when(nonRdfSourceOperation.getResourceId()).thenReturn(RESOURCE_ID);
-        when(nonRdfSourceOperation.getContentSize()).thenReturn(null);
+        when(nonRdfSourceOperation.getContentSize()).thenReturn(-1L);
         when(nonRdfSourceOperation.getType()).thenReturn(CREATE);
         when(((CreateResourceOperation)nonRdfSourceOperation).getParentId()).thenReturn(ROOT_RESOURCE_ID);
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -741,7 +741,7 @@ public class OcflPersistentStorageSessionTest {
 
         final var contentStream = new ByteArrayInputStream(content.getBytes());
         when(binOperation.getContentStream()).thenReturn(contentStream);
-        when(binOperation.getContentSize()).thenReturn(null);
+        when(binOperation.getContentSize()).thenReturn(-1L);
         when(binOperation.getResourceId()).thenReturn(resourceId);
         when(((CreateResourceOperation) binOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(binOperation.getType()).thenReturn(CREATE);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersisterTest.java
@@ -102,7 +102,7 @@ public class UpdateNonRdfSourcePersisterTest {
                 CreateResourceOperation.class));
         when(nonRdfSourceOperation.getUserPrincipal()).thenReturn(USER_PRINCIPAL);
         when(nonRdfSourceOperation.getResourceId()).thenReturn(RESOURCE_ID);
-        when(nonRdfSourceOperation.getContentSize()).thenReturn(null);
+        when(nonRdfSourceOperation.getContentSize()).thenReturn(-1L);
 
         when(psSession.findOrCreateSession(anyString())).thenReturn(session);
         when(index.getMapping(eq(SESSION_ID), any())).thenReturn(mapping);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3524

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/20**

# What does this Pull Request do?

Changes the type of `contentSize` from `Long` to `long`. `-1L` indicates that content size is unknown or there is no content. This will avoid further NPE bugs related to content size.

# How should this be tested?

No visible changes. Everything should still work. If you have migrated content with a null `contentSize`, such as in the linked ticket, then you should not get NPEs.

# Interested parties
@fcrepo/committers
