### PR TITLE
Added exception handler around link type code in case rel string is i…

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -39,6 +39,7 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
+import javax.ws.rs.BadRequestException;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.Link;
@@ -236,9 +237,15 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
      * @return a list of LINK headers with rel="type"
      */
     private List<String> getTypes(final List<String> headers) {
-        return getLinkHeaders(headers) == null ? emptyList() : getLinkHeaders(headers).stream()
-                .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
-                .map(URI::toString).collect(Collectors.toList());
+        final List hdrobjs = getLinkHeaders(headers);
+        try {
+            return hdrobjs == null ? emptyList() : getLinkHeaders(headers).stream()
+                    //.filter(p -> p.getRel() != null)
+                    .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
+                    .map(URI::toString).collect(Collectors.toList());
+        } catch ( Exception e ) {
+            throw new BadRequestException("Invalid type found");
+        }
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -240,7 +240,6 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         final List hdrobjs = getLinkHeaders(headers);
         try {
             return hdrobjs == null ? emptyList() : getLinkHeaders(headers).stream()
-                    //.filter(p -> p.getRel() != null)
                     .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
                     .map(URI::toString).collect(Collectors.toList());
         } catch ( Exception e ) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -237,9 +237,9 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
      * @return a list of LINK headers with rel="type"
      */
     private List<String> getTypes(final List<String> headers) {
-        final List hdrobjs = getLinkHeaders(headers);
+        final List<Link> hdrobjs = getLinkHeaders(headers);
         try {
-            return hdrobjs == null ? emptyList() : getLinkHeaders(headers).stream()
+            return hdrobjs == null ? emptyList() : hdrobjs.stream()
                     .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
                     .map(URI::toString).collect(Collectors.toList());
         } catch ( Exception e ) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -243,7 +243,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
                     .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
                     .map(URI::toString).collect(Collectors.toList());
         } catch ( Exception e ) {
-            throw new BadRequestException("Invalid type found");
+            throw new BadRequestException("Invalid Link header type found",e);
         }
     }
 


### PR DESCRIPTION
…nvalid.

produces 400 bad request exception/status

- getTypes() in CreateResourceServiceImpl.java uses java stream to parse the
  rel type in a link header. if the rel type is invalid or corrupt, it causes
  a stack trace in the server as it equals a null string object that it tries
  to operate upon. The fix is to add an exception handler around the parsing
  code to throw a 400 bad request exception that should pass back a 400 status
  to the client.

Resolves https://jira.lyrasis.org/browse/FCREPO-3367

**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: (link)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
A brief description of what the intended result of the PR will be and/or what problem it solves.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
