### PR TITLE
Return RepositoryRoot as system type

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -104,6 +104,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
@@ -4992,5 +4993,22 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals(OK.getStatusCode(), getStatus(getObjMethod(ghostId)));
         // 'a/b/c' does not exist
         assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObjMethod(deepId)));
+    }
+
+    @Test
+    public void testRepositoryRootTypes() throws Exception {
+        final HttpGet getRoot = new HttpGet(serverAddress);
+        final Node rootNode = createURI(serverAddress);
+        try (final CloseableHttpResponse response = execute(getRoot)) {
+            final Dataset dataset = getDataset(response);
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), REPOSITORY_ROOT.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), RESOURCE.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), FEDORA_RESOURCE.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), RDF_SOURCE.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), CONTAINER.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), FEDORA_CONTAINER.asNode()));
+            assertTrue(graph.contains(ANY, rootNode, type.asNode(), BASIC_CONTAINER.asNode()));
+        }
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -48,6 +48,7 @@ import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
@@ -250,6 +251,9 @@ public class FedoraResourceImpl implements FedoraResource {
             // ldp:Resource is on all resources
             types.add(RESOURCE_URI);
             types.add(FEDORA_RESOURCE_URI);
+            if (getFedoraId().isRepositoryRoot()) {
+                types.add(create(REPOSITORY_ROOT.getURI()));
+            }
             if (!forRdf) {
                 // These types are not exposed as RDF triples.
                 if (isArchivalGroup) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -66,6 +66,7 @@ public class FedoraResourceImpl implements FedoraResource {
     private static final URI MEMENTO_URI = create(MEMENTO_TYPE);
     private static final URI VERSIONED_RESOURCE_URI = create(VERSIONED_RESOURCE.getURI());
     private static final URI VERSIONING_TIMEGATE_URI = create(VERSIONING_TIMEGATE_TYPE);
+    private static final URI REPOSITORY_ROOT_URI = create(REPOSITORY_ROOT.getURI());
 
     private final PersistentStorageSessionManager pSessionManager;
 
@@ -252,7 +253,7 @@ public class FedoraResourceImpl implements FedoraResource {
             types.add(RESOURCE_URI);
             types.add(FEDORA_RESOURCE_URI);
             if (getFedoraId().isRepositoryRoot()) {
-                types.add(create(REPOSITORY_ROOT.getURI()));
+                types.add(REPOSITORY_ROOT_URI);
             }
             if (!forRdf) {
                 // These types are not exposed as RDF triples.

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -18,14 +18,10 @@
 package org.fcrepo.persistence.ocfl;
 
 
-import org.apache.jena.graph.Triple;
-import org.apache.jena.vocabulary.RDF;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
-import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
@@ -35,13 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 
 /**
  * This class is responsible for initializing the repository on start-up.
@@ -80,23 +73,16 @@ public class RepositoryInitializer {
                 session.getHeaders(root, null);
             } catch (PersistentItemNotFoundException e) {
                 LOGGER.info("Repository root ({}) not found. Creating...", root);
-                final Stream<Triple> repositoryRootTriples = Stream.of(
-                        new Triple(createURI(root.getFullId()), RDF.type.asNode(), REPOSITORY_ROOT.asNode())
-                );
-
-                final RdfStream repositoryRootStream = new DefaultRdfStream(createURI(root.getFullId()),
-                        repositoryRootTriples);
                 final RdfSourceOperation operation = this.operationFactory.createBuilder(root,
                         BASIC_CONTAINER.getURI())
-                        .parentId(root)
-                        .triples(repositoryRootStream).build();
+                        .parentId(root).build();
 
                 session.persist(operation);
                 session.commit();
                 LOGGER.info("Successfully create repository root ({}).", root);
             }
 
-        } catch (PersistentStorageException ex) {
+        } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(ex.getMessage(), ex);
         }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3422

# What does this Pull Request do?
Currently when the repository is reinitialized the root resource is created with the RepositoryRoot type as user rdf. So it returns as a user type. This removes that and returns it as a system type.

# How should this be tested?

Before GETting the root resource should return the triple in the RDF but not the headers. Now it should appear as both.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
