### PR TITLE
More integration tests

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1435,6 +1435,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertNotEquals("ETags should not be the same", binaryEtag1, binaryEtag2);
         assertNotEquals("Last-Modified should not be the same", binaryLastModed1, binaryLastModed2);
 
+        final HttpGet get6 = new HttpGet(binaryLocation);
+        get6.addHeader("If-Match", binaryEtag1);
+        assertEquals("Expected 412 Precondition Failed", PRECONDITION_FAILED.getStatusCode(), getStatus(get6));
+
+        final HttpGet get7 = new HttpGet(binaryLocation);
+        get7.addHeader("If-Unmodified-Since", binaryLastModed1);
+        assertEquals("Expected 412 Precondition Failed", PRECONDITION_FAILED.getStatusCode(), getStatus(get7));
+
         // Next, check headers for the description; they should also have changed
         final HttpHead head2 = new HttpHead(descLocation);
         try (final CloseableHttpResponse response = execute(head2)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -821,7 +821,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         if (!expected.equals(actual)) {
             // Make 2 additional URIs by parsing the memento label and adding/subtracting 1 second.
             final String expectedUriPrefix = expected.substring(0, expected.lastIndexOf("/"));
-            final String expectedDateString = expected.substring(expected.lastIndexOf("/"));
+            final String expectedDateString = expected.substring(expected.lastIndexOf("/") + 1);
             final Instant expectedInstant = Instant.from(MEMENTO_LABEL_FORMATTER.parse(expectedDateString));
             final List<String> allowed = List.of(
                     expectedUriPrefix + MEMENTO_LABEL_FORMATTER.format(expectedInstant.minusSeconds(1)),


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3223

# What does this Pull Request do?
Another iteration on re-enabling integration tests.

# How should this be tested?

Ensure the changes made to the tests (or application) are correct.

In this exciting episode:
1. When adding a blank node to a resource's graph, we no longer allow you to directly access the blank node as a URI (I was not aware you could ever do that). Instead we just check that the blank node is part of the resource's graph.
1. We ensure that GET -> PUT interactions omit server managed triples.
1. We change the expectations for binary and binary description ETags. They used to be separate and so changing one would not affect the other. They now a linked together.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
