### PR TITLE
Alter ETag based on contained resources

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1582,7 +1582,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // If the child is created and deleted in the same second the eTag would be the same.
         // Wait to delete.
-        TimeUnit.MILLISECONDS.sleep(500);
+        TimeUnit.SECONDS.sleep(1);
 
         assertEquals("Child resource not deleted!", NO_CONTENT.getStatusCode(),
                 getStatus(new HttpDelete(serverAddress + child)));
@@ -1616,7 +1616,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // We use the last created time for the eTag, if 2 children are created in the same second there is no
         // difference, so we wait.
-        TimeUnit.MILLISECONDS.sleep(500);
+        TimeUnit.SECONDS.sleep(1);
 
         // Create another child
         final String otherChild;

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -20,7 +20,6 @@ package org.fcrepo.kernel.api;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import javax.annotation.Nonnull;
 
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.stream.Stream;
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -20,6 +20,7 @@ package org.fcrepo.kernel.api;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import javax.annotation.Nonnull;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.stream.Stream;
 
@@ -150,10 +151,10 @@ public interface ContainmentIndex {
     boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId);
 
     /**
-     * Generate a hash value of the current contained resources of the provided resource.
+     * Find the timestamp of the last child added or deleted
      * @param txId The transaction id, or null if no transaction.
      * @param fedoraId The ID of the containing resource to check.
-     * @return Unique hash of the current containment of non-deleted resources.
+     * @return Timestamp of last child added or deleted or null if none
      */
-    String containmentHash(final String txId, final FedoraId fedoraId);
+    Instant containmentLastUpdated(final String txId, final FedoraId fedoraId);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -148,4 +148,12 @@ public interface ContainmentIndex {
      * @return Are there any matching IDs.
      */
     boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId);
+
+    /**
+     * Generate a hash value of the current contained resources of the provided resource.
+     * @param txId The transaction id, or null if no transaction.
+     * @param fedoraId The ID of the containing resource to check.
+     * @return Unique hash of the current containment of non-deleted resources.
+     */
+    String containmentHash(final String txId, final FedoraId fedoraId);
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -399,7 +399,9 @@ public class ContainmentIndexImpl implements ContainmentIndex {
             OPERATION_COLUMN + " = 'add' AND " + TRANSACTION_ID_COLUMN + " = :transactionId UNION SELECT " +
             END_TIME_COLUMN + " as updated FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " + PARENT_COLUMN +
             " = :resourceId AND " + OPERATION_COLUMN + " = 'delete' AND " + TRANSACTION_ID_COLUMN +
-            " = :transactionId) x";
+            " = :transactionId UNION SELECT " + END_TIME_COLUMN +
+            " as updated FROM " + TRANSACTION_OPERATIONS_TABLE + " WHERE " + PARENT_COLUMN + " = :resourceId AND " +
+            OPERATION_COLUMN + " = 'add' AND " + TRANSACTION_ID_COLUMN + " = :transactionId) x";
 
     private static final String GET_UPDATED_RESOURCES = "SELECT DISTINCT " + PARENT_COLUMN + " FROM " +
             TRANSACTION_OPERATIONS_TABLE + " WHERE " + TRANSACTION_ID_COLUMN + " = :transactionId AND " +

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -69,6 +69,8 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
             DB, CONTAINMENT, OPERATION, "reset");
     private static final Timer hasResourcesStartingWithTimer = Metrics.timer(METRIC_NAME,
             DB, CONTAINMENT, OPERATION, "hasResourcesStartingWith");
+    private static final Timer containmentHashTimer = Metrics.timer(METRIC_NAME, DB, CONTAINMENT, OPERATION,
+            "containmentHash");
 
     @Autowired
     @Qualifier("containmentIndexImpl")
@@ -168,5 +170,11 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
     public boolean hasResourcesStartingWith(final String txId, final FedoraId fedoraId) {
         return MetricsHelper.time(hasResourcesStartingWithTimer, () ->
                 containmentIndexImpl.hasResourcesStartingWith(txId, fedoraId));
+    }
+
+    @Override
+    public String containmentHash(final String txId, final FedoraId fedoraId) {
+        return MetricsHelper.time(containmentHashTimer, () ->
+                containmentIndexImpl.containmentHash(txId, fedoraId));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -69,8 +69,8 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
             DB, CONTAINMENT, OPERATION, "reset");
     private static final Timer hasResourcesStartingWithTimer = Metrics.timer(METRIC_NAME,
             DB, CONTAINMENT, OPERATION, "hasResourcesStartingWith");
-    private static final Timer containmentHashTimer = Metrics.timer(METRIC_NAME, DB, CONTAINMENT, OPERATION,
-            "containmentHash");
+    private static final Timer containmentLastUpdateTimer = Metrics.timer(METRIC_NAME, DB, CONTAINMENT, OPERATION,
+            "containmentLastUpdated");
 
     @Autowired
     @Qualifier("containmentIndexImpl")
@@ -173,8 +173,8 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
     }
 
     @Override
-    public String containmentHash(final String txId, final FedoraId fedoraId) {
-        return MetricsHelper.time(containmentHashTimer, () ->
-                containmentIndexImpl.containmentHash(txId, fedoraId));
+    public Instant containmentLastUpdated(final String txId, final FedoraId fedoraId) {
+        return MetricsHelper.time(containmentLastUpdateTimer, () ->
+                containmentIndexImpl.containmentLastUpdated(txId, fedoraId));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+
 import java.time.Instant;
 import java.util.stream.Stream;
 
@@ -50,6 +51,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_WEBAC_ACL_URI;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 
 /**
@@ -201,9 +204,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setLastModifiedBy(headers.getLastModifiedBy());
         resc.setLastModifiedDate(headers.getLastModifiedDate());
         resc.setParentId(headers.getParent());
-        final String containmentHash = containmentIndex.containmentHash(transactionId, resc.getFedoraId());
-        final String newState = (containmentHash == null ? headers.getStateToken() :
-                DigestUtils.md5Hex(headers.getStateToken() + containmentHash).toUpperCase());
+        final Instant containmentUpdated = containmentIndex.containmentLastUpdated(transactionId, resc.getFedoraId());
+        final String newState = (containmentUpdated == null ? headers.getStateToken() :
+                DigestUtils.md5Hex(headers.getStateToken() + ISO_INSTANT.format(containmentUpdated)).toUpperCase());
         resc.setEtag(newState);
         resc.setStateToken(headers.getStateToken());
         resc.setIsArchivalGroup(headers.isArchivalGroup());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -27,9 +27,11 @@ import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ResourceTypeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.ResourceFactory;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
@@ -201,11 +203,7 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setLastModifiedBy(headers.getLastModifiedBy());
         resc.setLastModifiedDate(headers.getLastModifiedDate());
         resc.setParentId(headers.getParent());
-        final Instant containmentUpdated = containmentIndex.containmentLastUpdated(transactionId, resc.getFedoraId());
-        final String newState = (containmentUpdated == null ? headers.getStateToken() :
-                DigestUtils.md5Hex(headers.getStateToken() + formatUpdatedInstant(containmentUpdated))
-                        .toUpperCase());
-        resc.setEtag(newState);
+        resc.setEtag(getStateToken(transactionId, headers, resc));
         resc.setStateToken(headers.getStateToken());
         resc.setIsArchivalGroup(headers.isArchivalGroup());
         resc.setInteractionModel(headers.getInteractionModel());
@@ -253,6 +251,26 @@ public class ResourceFactoryImpl implements ResourceFactory {
                     throw new PathNotFoundRuntimeException(e.getMessage(), e);
                 }
             });
+    }
+
+    /**
+     * Get the state token from the headers or altered by containment.
+     * @param transactionId the transaction id.
+     * @param headers The resource headers
+     * @param resource The resource
+     * @return The state token.
+     */
+    private String getStateToken(final String transactionId, final ResourceHeaders headers,
+                                 final FedoraResource resource) {
+        if (resource instanceof Container && ! (resource instanceof WebacAcl)) {
+            final Instant containmentUpdated = containmentIndex.containmentLastUpdated(transactionId,
+                    resource.getFedoraId());
+             if (containmentUpdated != null) {
+                 return DigestUtils.md5Hex(headers.getStateToken() + formatUpdatedInstant(containmentUpdated))
+                         .toUpperCase();
+             }
+        }
+        return headers.getStateToken();
     }
 
     private String formatUpdatedInstant(final Instant update) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -52,9 +52,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import static java.time.format.DateTimeFormatter.ISO_INSTANT;
-
-
 /**
  * Implementation of ResourceFactory interface.
  *
@@ -206,7 +203,8 @@ public class ResourceFactoryImpl implements ResourceFactory {
         resc.setParentId(headers.getParent());
         final Instant containmentUpdated = containmentIndex.containmentLastUpdated(transactionId, resc.getFedoraId());
         final String newState = (containmentUpdated == null ? headers.getStateToken() :
-                DigestUtils.md5Hex(headers.getStateToken() + ISO_INSTANT.format(containmentUpdated)).toUpperCase());
+                DigestUtils.md5Hex(headers.getStateToken() + formatUpdatedInstant(containmentUpdated))
+                        .toUpperCase());
         resc.setEtag(newState);
         resc.setStateToken(headers.getStateToken());
         resc.setIsArchivalGroup(headers.isArchivalGroup());
@@ -255,5 +253,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
                     throw new PathNotFoundRuntimeException(e.getMessage(), e);
                 }
             });
+    }
+
+    private String formatUpdatedInstant(final Instant update) {
+        return update.getEpochSecond() + "." + update.getNano();
     }
 }

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS containment (
     fedora_id varchar(503) NOT NULL PRIMARY KEY,
     parent varchar(503) NOT NULL,
     start_time timestamp NOT NULL,
-    end_time timestamp NULL
+    end_time timestamp NULL,
+    updated timestamp NULL
 );
 
 -- Create an index to speed searches for children of a parent.

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-containment.sql
@@ -5,9 +5,9 @@
 CREATE TABLE IF NOT EXISTS containment (
     fedora_id varchar(503) NOT NULL PRIMARY KEY,
     parent varchar(503) NOT NULL,
-    start_time timestamp NOT NULL,
-    end_time timestamp NULL,
-    updated timestamp NULL
+    start_time datetime NOT NULL,
+    end_time datetime NULL,
+    updated datetime NULL
 );
 
 -- Create an index to speed searches for children of a parent.
@@ -28,8 +28,8 @@ CREATE INDEX IF NOT EXISTS containment_idx4
 CREATE TABLE IF NOT EXISTS containment_transactions (
     fedora_id varchar(503) NOT NULL,
     parent varchar(503) NOT NULL,
-    start_time timestamp NULL,
-    end_time timestamp NULL,
+    start_time datetime NULL,
+    end_time datetime NULL,
     transaction_id varchar(255) NOT NULL,
     operation varchar(10) NOT NULL
 );

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
@@ -5,9 +5,9 @@
 CREATE TABLE IF NOT EXISTS containment (
     fedora_id varchar(503) PRIMARY KEY,
     parent varchar(503) NOT NULL,
-    start_time timestamp NOT NULL,
-    end_time timestamp NULL,
-    updated timestamp NULL
+    start_time datetime NOT NULL,
+    end_time datetime NULL,
+    updated datetime NULL
 );
 
 -- Create an index to speed searches for children of a parent.
@@ -43,8 +43,8 @@ EXECUTE stmt;
 CREATE TABLE IF NOT EXISTS containment_transactions (
     fedora_id varchar(503) NOT NULL,
     parent varchar(503) NOT NULL,
-    start_time timestamp NULL,
-    end_time timestamp NULL,
+    start_time datetime NULL,
+    end_time datetime NULL,
     transaction_id varchar(255) NOT NULL,
     operation varchar(10) NOT NULL
 );

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-containment.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS containment (
     fedora_id varchar(503) PRIMARY KEY,
     parent varchar(503) NOT NULL,
     start_time timestamp NOT NULL,
-    end_time timestamp NULL
+    end_time timestamp NULL,
+    updated timestamp NULL
 );
 
 -- Create an index to speed searches for children of a parent.

--- a/fcrepo-kernel-impl/src/main/resources/sql/postgres-containment.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/postgres-containment.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS containment (
     fedora_id varchar(503) NOT NULL PRIMARY KEY,
     parent varchar(503) NOT NULL,
     start_time timestamp NOT NULL,
-    end_time timestamp NULL
+    end_time timestamp NULL,
+    updated timestamp NULL
 );
 
 -- Create an index to speed searches for children of a parent.

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -44,6 +44,7 @@ import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMAT
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -669,30 +670,41 @@ public class ContainmentIndexImplTest {
     }
 
     @Test
-    public void testChecksum() {
+    public void testChecksum() throws Exception {
         stubObject("parent1");
         stubObject("transaction1");
-        final String emptyHash = containmentIndex.containmentHash(null, parent1.getFedoraId());
+        // Need to add a containment record for the parent to hold the updated value.
+        containmentIndex.addContainedBy(transaction1.getId(), FedoraId.getRepositoryRootId(), parent1.getFedoraId());
+        final var empty = containmentIndex.containmentLastUpdated(null, parent1.getFedoraId());
+        assertNull(empty);
+        // Wait a half second as the ETag is based on the highest value of any child's start_time or end_time.
+        TimeUnit.MILLISECONDS.sleep(500);
         final var firstBorn = parent1.getFedoraId().resolve("child1");
         containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), firstBorn);
         assertEquals(1, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
         assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
-        final String firstHash = containmentIndex.containmentHash(transaction1.getId(), parent1.getFedoraId());
-        assertNotEquals(emptyHash, firstHash);
+        final var first = containmentIndex.containmentLastUpdated(transaction1.getId(), parent1.getFedoraId());
+        assertNotNull(first);
+        assertNotEquals(empty, first);
+
         containmentIndex.commitTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
-        assertEquals(firstHash, containmentIndex.containmentHash(null, parent1.getFedoraId()));
+        assertEquals(first, containmentIndex.containmentLastUpdated(null, parent1.getFedoraId()));
+
+        // Wait half a second, all these children will share a start_time.
+        TimeUnit.MILLISECONDS.sleep(500);
         for (var i = 0; i < 30; i += 1) {
             final var kidId = parent1.getFedoraId().resolve("child-" + i);
             containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), kidId);
         }
         assertEquals(31, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
-        final String allHash = containmentIndex.containmentHash(transaction1.getId(), parent1.getFedoraId());
-        assertNotEquals(emptyHash, allHash);
-        assertNotEquals(firstHash, allHash);
+        final var allTime = containmentIndex.containmentLastUpdated(transaction1.getId(), parent1.getFedoraId());
+        assertNotEquals(empty, allTime);
+        assertNotEquals(first, allTime);
+
         containmentIndex.rollbackTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
-        assertEquals(firstHash, containmentIndex.containmentHash(null, parent1.getFedoraId()));
+        assertEquals(first, containmentIndex.containmentLastUpdated(null, parent1.getFedoraId()));
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -692,7 +692,7 @@ public class ContainmentIndexImplTest {
         assertEquals(first, containmentIndex.containmentLastUpdated(null, parent1.getFedoraId()));
 
         // Wait half a second, all these children will share a start_time.
-        TimeUnit.MILLISECONDS.sleep(500);
+        TimeUnit.SECONDS.sleep(1);
         for (var i = 0; i < 30; i += 1) {
             final var kidId = parent1.getFedoraId().resolve("child-" + i);
             containmentIndex.addContainedBy(transaction1.getId(), parent1.getFedoraId(), kidId);
@@ -705,6 +705,20 @@ public class ContainmentIndexImplTest {
         containmentIndex.rollbackTransaction(transaction1.getId());
         assertEquals(1, containmentIndex.getContains(null, parent1.getFedoraId()).count());
         assertEquals(first, containmentIndex.containmentLastUpdated(null, parent1.getFedoraId()));
+
+        TimeUnit.SECONDS.sleep(1);
+
+        containmentIndex.removeContainedBy(transaction1.getId(), parent1.getFedoraId(), firstBorn);
+        assertEquals(0, containmentIndex.getContains(transaction1.getId(), parent1.getFedoraId()).count());
+        assertNotEquals(first, containmentIndex.containmentLastUpdated(transaction1.getId(), parent1.getFedoraId()));
+        assertNotEquals(allTime, containmentIndex.containmentLastUpdated(transaction1.getId(), parent1.getFedoraId()));
+
+        containmentIndex.commitTransaction(transaction1.getId());
+        assertEquals(0, containmentIndex.getContains(null, parent1.getFedoraId()).count());
+        final var last = containmentIndex.containmentLastUpdated(null, parent1.getFedoraId());
+        assertNotNull(last);
+        assertNotEquals(first, last);
+        assertNotEquals(allTime, last);
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3541

# What does this Pull Request do?
We don't change the ETag when a container has a new or deleted contained resource.  This attempts to fix that by generating a hash of all the children of the requested resource.

I think this might be slowing down ingest as I was creating 5,000 children of a single parent and it seemed to average about 0.14 per resource (which is slower than normal on my machine).

Also there is probably a limit to how many contained resources this might work with. Probably need the big test machine to see if and when this crashes.

# How should this be tested?

Create a container, note it's ETag and Last Modified time.
Create a child of the container, note it's ETag changes, but it's Last Modified is unchanged.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
