### PR TITLE
Display root resource/ACL correctly in HTML UI

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -573,33 +573,5 @@ public class FedoraAclIT extends AbstractResourceIT {
         final var getHtml = getObjMethod(FCR_ACL);
         getHtml.addHeader(ACCEPT, "text/html");
         assertEquals(OK.getStatusCode(), getStatus(getHtml));
-
-        final String aclBody = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
-                "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n" +
-                "\n" +
-                "<#writeAccess> a acl:Authorization ;\n" +
-                "    acl:mode acl:Read, acl:Write ;\n" +
-                "    acl:agent foaf:Agent ;\n" +
-                "    acl:accessTo <" + serverAddress + "> ;\n" +
-                "    acl:default <" + serverAddress + "> .";
-        final var putAcl = putObjMethod(FCR_ACL);
-        putAcl.addHeader(CONTENT_TYPE, "text/turtle");
-        putAcl.setEntity(new StringEntity(aclBody));
-        assertEquals(CREATED.getStatusCode(), getStatus(putAcl));
-
-        final Node customAclSubject = createURI(serverAddress + FCR_ACL + "#writeAccess");
-
-        final var getTurtle2 = getObjMethod(FCR_ACL);
-        getTurtle.addHeader(ACCEPT, "text/turtle");
-        try (final var response = execute(getTurtle2)) {
-            assertEquals(OK.getStatusCode(), getStatus(response));
-            final var graph = getDataset(response).asDatasetGraph();
-            assertTrue(graph.contains(ANY, customAclSubject, aclMode, aclRead));
-            assertTrue(graph.contains(ANY, customAclSubject, aclMode, aclWrite));
-        }
-
-        final var getHtml2 = getObjMethod(FCR_ACL);
-        getHtml.addHeader(ACCEPT, "text/html");
-        assertEquals(OK.getStatusCode(), getStatus(getHtml2));
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1023,8 +1023,9 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
         final CloseableHttpClient customClient = createClient(true);
 
-        createVersionedContainer(id);
-        final String version1Uri = createLDPRSMementoWithExistingBody(id);
+        final String uri = createVersionedContainer(id);
+
+        final String version1Uri = postForMemento(uri);
 
         TimeUnit.SECONDS.sleep(1);
 
@@ -1034,7 +1035,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         TimeUnit.SECONDS.sleep(1);
 
         putVersionedContainer(id, "update", true);
-        final String version2Uri = createLDPRSMementoWithExistingBody(id);
+        final String version2Uri = postForMemento(uri);
 
         assertNotEquals("mementos should be different", version1Uri, version2Uri);
 
@@ -1047,6 +1048,8 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             verifyMementoUri("Did not get Location header", version1Uri, response.getFirstHeader(LOCATION).getValue());
             assertEquals("Did not get Content-Length == 0", "0", response.getFirstHeader(CONTENT_LENGTH).getValue());
         }
+
+        TimeUnit.SECONDS.sleep(1);
 
         // Request datetime more recent than both mementos
         final String afterDatetime = MEMENTO_RFC_1123_FORMATTER.format(Instant.now().atZone(ZoneOffset.UTC));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3424

# What does this Pull Request do?
HTML UI performs extra processing to allow interactions so we load the resource we are looking at, for "fake" resources like the default ACL this fails to load. Handle this more cleanly.

# How should this be tested?

Build PR, browse to `http://localhost:8080/rest/fcr:acl` with a web browser. See the results. Use cURL for alternate serializations and still see the results. Put a new default ACL and see it displays too.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
