### PR TITLE
Embedded Resource representation

### DIFF
--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -2156,7 +2156,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testGetWithEmbededResourcesOk() throws Exception {
+    public void testGetWithEmbeddedResourcesOk() throws Exception {
         final String targetResource = "/rest/" + getRandomUniqueId();
         final String childResource = targetResource + "/" + getRandomUniqueId();
         final String username = "user88";
@@ -2178,6 +2178,7 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(OK.getStatusCode(), getStatus(getAdminChild));
     }
 
+    @Test
     public void testGetWithEmbeddedResourceDenied() throws Exception {
         final String targetResource = "/rest/" + getRandomUniqueId();
         final String childResource = targetResource + "/" + getRandomUniqueId();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/url/HttpApiResources.java
@@ -31,7 +31,6 @@ import org.fcrepo.http.commons.api.rdf.UriAwareResourceModelFactory;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 
 import org.springframework.stereotype.Component;
 
@@ -47,27 +46,26 @@ public class HttpApiResources implements UriAwareResourceModelFactory {
 
     @Override
     public Model createModelForResource(final FedoraResource resource,
-        final UriInfo uriInfo, final IdentifierConverter<Resource,FedoraResource> idTranslator) {
+        final UriInfo uriInfo) {
 
         final Model model = createDefaultModel();
 
-        final Resource s = idTranslator.reverse().convert(resource);
+        final Resource s = createResource(resource.getFedoraId().getFullId());
 
         if (resource.hasType(REPOSITORY_ROOT.getURI())) {
             addRepositoryStatements(uriInfo, model, s);
         }
 
         if (resource instanceof NonRdfSourceDescription && !resource.isMemento()) {
-            addContentStatements(idTranslator, (Binary)resource.getDescribedResource(), model);
+            addContentStatements((Binary)resource.getDescribedResource(), model);
         }
         return model;
     }
 
-    private static void addContentStatements(final IdentifierConverter<Resource,FedoraResource> idTranslator,
-                                             final Binary resource,
+    private static void addContentStatements(final Binary resource,
                                              final Model model) {
         // fcr:fixity
-        final Resource subject = idTranslator.reverse().convert(resource);
+        final Resource subject = createResource(resource.getFedoraId().getFullId());
         model.add(subject, HAS_FIXITY_SERVICE, createResource(subject.getURI() +
                 "/fcr:fixity"));
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -80,6 +80,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
@@ -3836,7 +3837,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String id = getRandomUniqueId();
         final String binaryId = "binary0";
         final String preferEmbed =
-                "return=representation; include=\"http://www.w3.org/ns/oa#PreferContainedDescriptions\"";
+                "return=representation; include=\"" + EMBED_CONTAINED + "\"";
 
         assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
         assertEquals(CREATED.getStatusCode(), getStatus(putDSMethod(id, binaryId, "some test content")));
@@ -3866,7 +3867,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String level1 = id + "/" + getRandomUniqueId();
         final String level2 = level1 + "/" + getRandomUniqueId();
         final String preferEmbed =
-                "return=representation; include=\"http://www.w3.org/ns/oa#PreferContainedDescriptions\"";
+                "return=representation; include=\"" + EMBED_CONTAINED + "\"";
 
         assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
 
@@ -3890,7 +3891,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue("Property on child binary should be found!" + graphStore, graphStore.contains(ANY,
                     createURI(serverAddress + level1),
                     title.asNode(), createLiteral("First level")));
-            assertFalse("Property from embeded resource's own child should not be found.",
+            assertFalse("Property from embedded resource's own child should not be found.",
                     graphStore.contains(ANY,
                             createURI(serverAddress + level2),
                             title.asNode(), createLiteral("Second level")

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpTripleUtil.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpTripleUtil.java
@@ -28,10 +28,8 @@ import java.util.Map;
 
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.RdfStream;
@@ -64,19 +62,17 @@ public class HttpTripleUtil implements ApplicationContextAware {
      * @param rdfStream the source stream we'll add named models to
      * @param resource the FedoraResourceImpl in question
      * @param uriInfo a JAX-RS UriInfo object to build URIs to resources
-     * @param idTranslator the id translator
      * @return an RdfStream with the added triples
      */
     public RdfStream addHttpComponentModelsForResourceToStream(final RdfStream rdfStream,
-            final FedoraResource resource, final UriInfo uriInfo,
-            final IdentifierConverter<Resource,FedoraResource> idTranslator) {
+            final FedoraResource resource, final UriInfo uriInfo) {
 
         LOGGER.debug("Adding additional HTTP context triples to stream");
         return new DefaultRdfStream(rdfStream.topic(), concat(rdfStream, getUriAwareTripleFactories().entrySet()
                     .stream().flatMap(e -> {
             LOGGER.debug("Adding response information using: {}", e.getKey());
-            return stream(spliteratorUnknownSize(e.getValue().createModelForResource(resource, uriInfo,
-                        idTranslator).listStatements(), IMMUTABLE), false).map(Statement::asTriple);
+            return stream(spliteratorUnknownSize(e.getValue().createModelForResource(resource, uriInfo)
+                    .listStatements(), IMMUTABLE), false).map(Statement::asTriple);
         })));
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/UriAwareResourceModelFactory.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/UriAwareResourceModelFactory.java
@@ -19,9 +19,7 @@ package org.fcrepo.http.commons.api.rdf;
 
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.models.FedoraResource;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 
 import org.apache.jena.rdf.model.Model;
 
@@ -40,9 +38,7 @@ public interface UriAwareResourceModelFactory {
      *
      * @param resource the resource
      * @param uriInfo the uri info
-     * @param idTranslator the id translator
      * @return model containing triples for the given resource
      */
-    Model createModelForResource(final FedoraResource resource,
-            final UriInfo uriInfo, final IdentifierConverter<Resource,FedoraResource> idTranslator);
+    Model createModelForResource(final FedoraResource resource, final UriInfo uriInfo);
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -30,13 +30,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.fcrepo.http.commons.domain.PreferTag;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
 
 /**
  * A subclass of {@link PreferTag} that contemplates the possible preferences for Linked Data Platform requests.
  *
  * @author ajs6f
  */
-public class LdpPreferTag extends PreferTag {
+public class LdpPreferTag extends PreferTag implements LdpTriplePreferences {
+
+    private final boolean getMinimal;
 
     private final boolean membership;
 
@@ -65,10 +68,10 @@ public class LdpPreferTag extends PreferTag {
         final List<String> includes = asList(include.orElse(" ").split(" "));
         final List<String> omits = asList(omit.orElse(" ").split(" "));
 
-        final boolean minimal = preferTag.getValue().equals("minimal") || received.orElse("").equals("minimal");
+        getMinimal = preferTag.getValue().equals("minimal") || received.orElse("").equals("minimal");
 
         final boolean preferMinimalContainer = (!omits.contains(PREFER_MINIMAL_CONTAINER.toString()) &&
-                (includes.contains(PREFER_MINIMAL_CONTAINER.toString()) || minimal));
+                (includes.contains(PREFER_MINIMAL_CONTAINER.toString()) || getMinimal));
 
         noMinimal = omits.contains(PREFER_MINIMAL_CONTAINER.toString());
 
@@ -84,45 +87,40 @@ public class LdpPreferTag extends PreferTag {
         embed = includes.contains(EMBED_CONTAINED.toString());
 
         managedProperties = includes.contains(PREFER_SERVER_MANAGED.toString())
-                || (!omits.contains(PREFER_SERVER_MANAGED.toString()) && !minimal);
+                || (!omits.contains(PREFER_SERVER_MANAGED.toString()) && !getMinimal);
     }
 
-    /**
-     * @return Whether this prefer tag demands membership triples.
-     */
+    @Override
+    public boolean getMinimal() {
+        return getMinimal;
+    }
+
+    @Override
     public boolean prefersMembership() {
         return membership;
     }
 
-    /**
-     * @return Whether this prefer tag demands containment triples.
-     */
+    @Override
     public boolean prefersContainment() {
         return containment;
     }
 
-    /**
-     * @return Whether this prefer tag demands references triples.
-     */
+    @Override
     public boolean prefersReferences() {
         return references;
     }
-    /**
-     * @return Whether this prefer tag demands embedded triples.
-     */
+
+    @Override
     public boolean prefersEmbed() {
         return embed;
     }
-    /**
-     * @return Whether this prefer tag demands server managed properties.
-     */
+
+    @Override
     public boolean prefersServerManaged() {
         return managedProperties;
     }
 
-    /**
-     * @return Whether this prefer tag demands no minimal container, ie. no user RDF.
-     */
+    @Override
     public boolean preferNoUserRdf() {
         return noMinimal;
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpTripleUtilTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpTripleUtilTest.java
@@ -28,9 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import javax.ws.rs.core.UriInfo;
 
-import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.kernel.api.RdfStream;
-import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.junit.Before;
@@ -50,12 +48,8 @@ public class HttpTripleUtilTest {
 
     private HttpTripleUtil testObj;
 
-
     @Mock
     private UriInfo mockUriInfo;
-
-    @Mock
-    private IdentifierConverter<Resource,FedoraResource> mockSubjects;
 
     @Mock
     private UriAwareResourceModelFactory mockBean1;
@@ -79,18 +73,18 @@ public class HttpTripleUtilTest {
     public void shouldAddTriplesFromRegisteredBeans() {
         final Map<String, UriAwareResourceModelFactory> mockBeans = of("doesnt", mockBean1, "matter", mockBean2);
         when(mockContext.getBeansOfType(UriAwareResourceModelFactory.class)).thenReturn(mockBeans);
-        when(mockBean1.createModelForResource(eq(mockResource), eq(mockUriInfo), eq(mockSubjects))).thenReturn(
+        when(mockBean1.createModelForResource(eq(mockResource), eq(mockUriInfo))).thenReturn(
                 createDefaultModel());
-        when(mockBean2.createModelForResource(eq(mockResource), eq(mockUriInfo), eq(mockSubjects))).thenReturn(
+        when(mockBean2.createModelForResource(eq(mockResource), eq(mockUriInfo))).thenReturn(
                 createDefaultModel());
 
         try (final RdfStream rdfStream = new DefaultRdfStream(createURI("info:subject"))) {
 
-            assertTrue(testObj.addHttpComponentModelsForResourceToStream(rdfStream, mockResource, mockUriInfo,
-                    mockSubjects).count() >= 0);
+            assertTrue(testObj.addHttpComponentModelsForResourceToStream(rdfStream, mockResource, mockUriInfo)
+                    .count() >= 0);
 
-            verify(mockBean1).createModelForResource(eq(mockResource), eq(mockUriInfo), eq(mockSubjects));
-            verify(mockBean2).createModelForResource(eq(mockResource), eq(mockUriInfo), eq(mockSubjects));
+            verify(mockBean1).createModelForResource(eq(mockResource), eq(mockUriInfo));
+            verify(mockBean2).createModelForResource(eq(mockResource), eq(mockUriInfo));
         }
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.rdf;
+
+/**
+ * Kernel level API to hold the LdpPreferTag decisions.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public interface LdpTriplePreferences {
+
+    /**
+     * @return Whether to return a minimal container.
+     */
+    boolean getMinimal();
+
+    /**
+     * @return Whether this prefer tag demands membership triples.
+     */
+    boolean prefersMembership();
+
+    /**
+     * @return Whether this prefer tag demands containment triples.
+     */
+    boolean prefersContainment();
+
+    /**
+     * @return Whether this prefer tag demands references triples.
+     */
+    boolean prefersReferences();
+
+    /**
+     * @return Whether this prefer tag demands embedded triples.
+     */
+    boolean prefersEmbed();
+
+    /**
+     * @return Whether this prefer tag demands server managed properties.
+     */
+    boolean prefersServerManaged();
+
+    /**
+     * @return Whether this prefer tag demands no minimal container, ie. no user RDF.
+     */
+    boolean preferNoUserRdf();
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ResourceTripleService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ResourceTripleService.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.services;
+
+import java.util.stream.Stream;
+
+import org.apache.jena.graph.Triple;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
+
+/**
+ * Service to call other services to return a desired set of triples.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public interface ResourceTripleService {
+
+    /**
+     * Return the triples for the resource based on the Prefer: header preferences
+     * @param tx The transaction or null if none.
+     * @param resource the resource to get triples for.
+     * @param preferences the preferences asked for.
+     * @param limit limit on the number of children to display.
+     * @return a stream of triples.
+     */
+    Stream<Triple> getResourceTriples(final Transaction tx, final FedoraResource resource,
+                                      final LdpTriplePreferences preferences, final int limit);
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.impl.models;
 
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
@@ -197,5 +198,10 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
         }
 
         return types;
+    }
+
+    @Override
+    public RdfStream getTriples() {
+        return getDescription().getTriples();
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static java.util.stream.Stream.empty;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.jena.graph.Triple;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
+import org.fcrepo.kernel.api.services.ContainmentTriplesService;
+import org.fcrepo.kernel.api.services.ManagedPropertiesService;
+import org.fcrepo.kernel.api.services.MembershipService;
+import org.fcrepo.kernel.api.services.ReferenceService;
+import org.fcrepo.kernel.api.services.ResourceTripleService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementation of the ResourceTripleService
+ * @author whikloj
+ * @since 6.0.0
+ */
+@Component
+public class ResourceTripleServiceImpl implements ResourceTripleService {
+
+    @Inject
+    private ManagedPropertiesService managedPropertiesService;
+
+    @Inject
+    private ContainmentTriplesService containmentTriplesService;
+
+    @Autowired
+    @Qualifier("referenceService")
+    private ReferenceService referenceService;
+
+    @Inject
+    private MembershipService membershipService;
+
+    @Override
+    public Stream<Triple> getResourceTriples(final Transaction tx, final FedoraResource resource,
+                                             final LdpTriplePreferences preferences, final int limit) {
+        final List<Stream<Triple>> streams = new ArrayList<>();
+
+        if (!preferences.preferNoUserRdf()) {
+            // provide user RDF only if we didn't receive an omit=ldp:PreferMinimalContainer
+            streams.add(resource.getTriples());
+        }
+        if (preferences.getMinimal()) {
+            if (preferences.prefersServerManaged())  {
+                streams.add(this.managedPropertiesService.get(resource));
+                //TODO Implement minimal return preference (https://jira.lyrasis.org/browse/FCREPO-3334)
+                //streams.add(getTriples(resource, MINIMAL));
+            }
+        } else {
+
+            // Additional server-managed triples about this resource
+            if (preferences.prefersServerManaged()) {
+                streams.add(this.managedPropertiesService.get(resource));
+            }
+
+            // containment triples about this resource
+            if (preferences.prefersContainment()) {
+                if (limit == -1) {
+                    streams.add(this.containmentTriplesService.get(tx, resource));
+                } else {
+                    streams.add(this.containmentTriplesService.get(tx, resource).limit(limit));
+                }
+            }
+
+            // LDP container membership triples for this resource
+            if (preferences.prefersMembership()) {
+                streams.add(membershipService.getMembership(tx.getId(), resource.getFedoraId()));
+            }
+
+            // Include inbound references to this object
+            if (preferences.prefersReferences()) {
+                streams.add(referenceService.getInboundReferences(tx.getId(), resource));
+            }
+
+        }
+
+        return streams.stream().reduce(empty(), Stream::concat);
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3525

# What does this Pull Request do?
It adds WebAC checks for the contained resources when asking for the `http://www.w3.org/ns/oa#PreferContainedDescriptions` 
Adds a new `ResourceTripleService` that wraps the other services, so it can be called for the contained resources too.
Cleans up the UriAwareResourceModelFactory to remove references to the deprecated IdentifierConverter.

# How should this be tested?

1. Create a container and a child container.
1. Get the container with the `return=representation; include="http://www.w3.org/ns/oa#PreferContainedDescriptions"` Prefer header. 
1. See the child resource in the output.
1. Add an ACL to the container allowing access and add an ACL to the child container disallowing access to a user.
1. Retry the above request as the user. Get denied access.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
