### PR TITLE
Remove fedora:TimeMap type

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -127,8 +127,6 @@ public final class RdfLexicon {
             createResource(REPOSITORY_NAMESPACE + "Pairtree");
     public static final Resource ARCHIVAL_GROUP =
             createResource(REPOSITORY_NAMESPACE + "ArchivalGroup");
-    public static final Resource TIME_MAP =
-            createResource(REPOSITORY_NAMESPACE + "TimeMap");
 
     // Linked Data Platform
     public static final Property PAGE =

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -68,7 +68,6 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
      */
     private static final List<URI> HEADER_ONLY_TYPES = Stream.concat(HEADER_AND_RDF_TYPES.stream(),
             List.of(
-                create(RdfLexicon.TIME_MAP.getURI()),
                 create(RdfLexicon.VERSIONING_TIMEMAP.getURI())
             ).stream()
     ).collect(Collectors.toList());

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
@@ -98,7 +98,6 @@ public class TimeMapImplTest {
     public void shouldHaveTimeMapTypes() {
         assertTrue(timeMap.getTypes().containsAll(
                 List.of(
-                URI.create(RdfLexicon.TIME_MAP.getURI()),
                 URI.create(RdfLexicon.VERSIONING_TIMEMAP.getURI())
                 ))
         );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3007

# What does this Pull Request do?
Removes the `fedora:TimeMap` type from the link headers of timemaps. `memento:TimeMap` exists in its place.

# How should this be tested?

1. Make an object (ie. `curl -i -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/test`)
1. Get the object's timemap (ie. `curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/fcr:versions`)
1. See two Timemap headers
     ```
     Link: <http://fedora.info/definitions/v4/repository#TimeMap>; rel="type"
     Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
     ```
1. Build this PR, do the GET again and see only one header
    ```
     Link: <http://mementoweb.org/ns#TimeMap>; rel="type"
    ```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
