### PR TITLE
Clean up redeclarations of constants, add in final where appropriate

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerAuthToken.java
@@ -48,7 +48,7 @@ public class ContainerAuthToken implements AuthenticationToken {
         servletUser = new BasicUserPrincipal(servletUsername);
         log.debug("Setting servlet username {}", servletUsername);
         this.servletRoles = new HashSet<>();
-        for (String roleName : servletRoleNames) {
+        for (final String roleName : servletRoleNames) {
             log.debug("Adding servlet role {} to {}", roleName, servletUsername);
             this.servletRoles.add(new ContainerRolesPrincipal(roleName));
         }

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ServletContainerAuthFilter.java
@@ -71,7 +71,7 @@ public class ServletContainerAuthFilter implements Filter {
         if (servletUser != null) {
             log.debug("There is a servlet user: {}", servletUser.getName());
             final Set<String> roles = new HashSet<>();
-            for (String roleName : ROLE_NAMES) {
+            for (final String roleName : ROLE_NAMES) {
                 log.debug("Testing role {}", roleName);
                 if (httpRequest.isUserInRole(roleName)) {
                     log.debug("Servlet user {} has servlet role: {}", servletUser.getName(), roleName);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -27,7 +27,7 @@ import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_READ_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_MODE_WRITE_VALUE;
 import static org.fcrepo.http.api.FedoraAcl.ROOT_AUTHORIZATION_PROPERTY;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceFactory;
@@ -72,6 +72,7 @@ public class WebACRolesProviderTest {
 
     private static final String FEDORA_PREFIX = "info:fedora";
     private static final String FEDORA_URI_PREFIX = "file:///rest";
+    private static final URI FEDORA_RESOURCE_URI = URI.create(FEDORA_RESOURCE.getURI());
 
     @Mock
     private Transaction mockTransaction;
@@ -544,7 +545,7 @@ public class WebACRolesProviderTest {
 
         when(mockResource.getId()).thenReturn(FEDORA_ID_PREFIX);
         when(mockResource.getTypes()).thenReturn(
-                singletonList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
+                singletonList(FEDORA_RESOURCE_URI));
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockResource, mockTransaction);
 
@@ -559,7 +560,7 @@ public class WebACRolesProviderTest {
 
         when(mockResource.getId()).thenReturn(FEDORA_ID_PREFIX);
         when(mockResource.getTypes()).thenReturn(
-                singletonList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
+                singletonList(FEDORA_RESOURCE_URI));
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
 
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/logback-test.xml");
@@ -573,7 +574,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getAcl()).thenReturn(null);
         when(mockResource.getId()).thenReturn(FEDORA_ID_PREFIX);
         when(mockResource.getTypes()).thenReturn(
-                singletonList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
+                singletonList(FEDORA_RESOURCE_URI));
 
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/test-root-authorization.ttl");
         final Map<String, Collection<String>> roles = roleProvider.getRoles(mockResource, mockTransaction);

--- a/fcrepo-common/src/main/java/org/fcrepo/common/db/DbPlatform.java
+++ b/fcrepo-common/src/main/java/org/fcrepo/common/db/DbPlatform.java
@@ -56,7 +56,7 @@ public enum DbPlatform {
     }
 
     public static DbPlatform fromString(final String name) {
-        for (var platform : values()) {
+        for (final var platform : values()) {
             if (platform.name.equals(name)) {
                 return platform;
             }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -93,7 +93,7 @@ public class FedoraPropsConfig extends BasePropsConfig {
         LOGGER.debug("Fedora home data: {}", fedoraData);
         try {
             Files.createDirectories(fedoraHome);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new IOException(String.format("Failed to create Fedora home directory at %s." +
                     " Fedora home can be configured by setting the %s property.", fedoraHome, FCREPO_HOME_PROPERTY), e);
         }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/Storage.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/Storage.java
@@ -39,7 +39,7 @@ public enum Storage {
     }
 
     public static Storage fromString(final String value) {
-        for (var storage : values()) {
+        for (final var storage : values()) {
             if (storage.value.equalsIgnoreCase(value)) {
                 return storage;
             }

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
@@ -23,8 +23,9 @@ import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.kernel.api.RdfLexicon.ACTIVITY_STREAMS_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -77,8 +78,8 @@ public class EventSerializerTestBase {
         final Set<EventType> typeSet = new HashSet<>();
         typeSet.add(EventType.RESOURCE_MODIFICATION);
         final Set<String> resourceTypeSet = new HashSet<>();
-        resourceTypeSet.add(REPOSITORY_NAMESPACE + "Resource");
-        resourceTypeSet.add(REPOSITORY_NAMESPACE + "Container");
+        resourceTypeSet.add(FEDORA_RESOURCE.getURI());
+        resourceTypeSet.add(FEDORA_CONTAINER.getURI());
         resourceTypeSet.add("http://example.com/SampleType");
 
         when(mockEvent.getTypes()).thenReturn(typeSet);
@@ -111,8 +112,8 @@ public class EventSerializerTestBase {
 
         final Resource blankNode = null;
 
-        assertTrue(model.contains(resourceSubject, type, createResource(REPOSITORY_NAMESPACE + "Resource")));
-        assertTrue(model.contains(resourceSubject, type, createResource(REPOSITORY_NAMESPACE + "Container")));
+        assertTrue(model.contains(resourceSubject, type, FEDORA_RESOURCE));
+        assertTrue(model.contains(resourceSubject, type, FEDORA_CONTAINER));
         assertTrue(model.contains(resourceSubject, type, createResource(PROV_NAMESPACE + "Entity")));
         assertTrue(model.contains(resourceSubject, type, createResource("http://example.com/SampleType")));
         assertTrue(model.contains(eventSubject, type, createResource(EventType.RESOURCE_MODIFICATION.getType())));

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
@@ -31,8 +31,9 @@ import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -98,8 +99,8 @@ public class JsonLDSerializerTest extends EventSerializerTestBase {
             types.add(n.textValue());
         });
         assertEquals(types.size(), 4);
-        assertTrue(types.contains(REPOSITORY_NAMESPACE + "Resource"));
-        assertTrue(types.contains(REPOSITORY_NAMESPACE + "Container"));
+        assertTrue(types.contains(FEDORA_RESOURCE.getURI()));
+        assertTrue(types.contains(FEDORA_CONTAINER.getURI()));
         assertTrue(types.contains(PROV_NAMESPACE + "Entity"));
         assertTrue(types.contains("http://example.com/SampleType"));
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -193,10 +193,10 @@ public class ExternalContentHandler implements ExternalContent {
                 throw new ExternalMessageBodyException("Unable to access external binary at URI " + uri, e);
             }
         } else if ("http".equals(scheme) || "https".equals(scheme)) {
-            try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
                 final HttpHead httpHead = new HttpHead(uri);
                 httpHead.setHeader("Accept-Encoding", "identity");
-                try (CloseableHttpResponse response = httpClient.execute(httpHead)) {
+                try (final CloseableHttpResponse response = httpClient.execute(httpHead)) {
                     if (response.getStatusLine().getStatusCode() != SC_OK) {
                         throw new ExternalMessageBodyException("Unable to access external binary at URI " + uri
                                 + " received response " + response.getStatusLine().getStatusCode());

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -27,7 +27,8 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.inject.Inject;
@@ -98,9 +99,9 @@ public class FedoraFixity extends ContentExposingResource {
             throw new NotFoundException(resource() + " is not a binary");
         }
 
-        final Link.Builder resourceLink = Link.fromUri(LDP_NAMESPACE + "Resource").rel("type");
+        final Link.Builder resourceLink = Link.fromUri(RESOURCE.getURI()).rel("type");
         servletResponse.addHeader(LINK, resourceLink.build().toString());
-        final Link.Builder rdfSourceLink = Link.fromUri(LDP_NAMESPACE + "RDFSource").rel("type");
+        final Link.Builder rdfSourceLink = Link.fromUri(RDF_SOURCE.getURI()).rel("type");
         servletResponse.addHeader(LINK, rdfSourceLink.build().toString());
 
         final Binary binaryResource = (Binary) resource();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSearch.java
@@ -95,7 +95,7 @@ public class FedoraSearch extends FedoraBaseResource {
         LOGGER.info("GET on search with conditions: {}, and fields: {}", conditions, fields);
         try {
             final var conditionList = new ArrayList<Condition>();
-            for (String condition : conditions) {
+            for (final String condition : conditions) {
                 final var parsedCondition = parse(condition, identifierConverter());
                 conditionList.add(parsedCondition);
             }
@@ -105,10 +105,10 @@ public class FedoraSearch extends FedoraBaseResource {
                 parsedFields = Arrays.asList(Condition.Field.values());
             } else {
                 parsedFields = new ArrayList<>();
-                for (String field : fields.split(",")) {
+                for (final String field : fields.split(",")) {
                     try {
                         parsedFields.add(Condition.Field.fromString(field));
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new InvalidQueryException("The field \"" + field + "\" is not a valid output field.");
                     }
                 }
@@ -181,7 +181,7 @@ public class FedoraSearch extends FedoraBaseResource {
         try {
             new URL(str);
             return true;
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             return false;
         }
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentPathValidatorTest.java
@@ -344,7 +344,7 @@ public class ExternalContentPathValidatorTest {
         Thread.sleep(5000);
 
         // Add a new allowed path
-        try (BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
+        try (final BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
             writer.write(dataUri + System.lineSeparator());
         }
 
@@ -367,7 +367,7 @@ public class ExternalContentPathValidatorTest {
     }
 
     private void addAllowedPath(final String allowed) throws Exception {
-        try (BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
+        try (final BufferedWriter writer = Files.newBufferedWriter(allowListFile.toPath(), APPEND)) {
             writer.write(allowed + System.lineSeparator());
         }
         validator.init();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -124,8 +124,9 @@ import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
@@ -415,7 +416,7 @@ public class FedoraLdpTest {
         assertTrue("Should have a Preference-Applied header", mockResponse.containsHeader("Preference-Applied"));
         assertTrue("Should have a Vary header", mockResponse.containsHeader("Vary"));
         assertTrue("Should be an LDP Resource",
-                mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE + "Resource>; rel=\"type\""));
+                mockResponse.getHeaders(LINK).contains("<" + RESOURCE + ">; rel=\"type\""));
     }
 
     @Test
@@ -627,7 +628,7 @@ public class FedoraLdpTest {
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
         assertTrue("Should be an LDP Resource",
-                mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE + "Resource>; rel=\"type\""));
+                mockResponse.getHeaders(LINK).contains("<" + RESOURCE + ">; rel=\"type\""));
 
         try (final RdfNamespacedStream entity = (RdfNamespacedStream) actual.getEntity()) {
             final Model model = entity.stream.collect(toModel());
@@ -790,7 +791,7 @@ public class FedoraLdpTest {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
-                new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferContainment\""));
+                new MultiPrefer("return=representation; omit=\"" + PREFER_CONTAINMENT + "\""));
         final Response actual = testObj.getResource( null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
@@ -808,7 +809,7 @@ public class FedoraLdpTest {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
-                new MultiPrefer("return=representation; omit=\"" + LDP_NAMESPACE + "PreferMembership\""));
+                new MultiPrefer("return=representation; omit=\"" + PREFER_MEMBERSHIP + "\""));
         final Response actual = testObj.getResource(null);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
@@ -857,7 +858,7 @@ public class FedoraLdpTest {
 
     private void assertShouldBeAnLDPNonRDFSource() {
         assertTrue("Should be an LDP NonRDFSource",
-                mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE + "NonRDFSource>; rel=\"type\""));
+                mockResponse.getHeaders(LINK).contains("<" + NON_RDF_SOURCE + ">; rel=\"type\""));
         assertShouldNotAdvertiseAcceptPostFlavors();
     }
 
@@ -876,8 +877,8 @@ public class FedoraLdpTest {
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
         final Response actual = testObj.getResource(null);
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
-        assertTrue("Should be an LDP NonRDFSource", mockResponse.getHeaders(LINK).contains("<" + LDP_NAMESPACE +
-                "NonRDFSource>; rel=\"type\""));
+        assertTrue("Should be an LDP NonRDFSource", mockResponse.getHeaders(LINK).contains("<" +
+                NON_RDF_SOURCE + ">; rel=\"type\""));
         assertShouldContainLinkToBinaryDescription();
         assertEquals(new URI(url), actual.getLocation());
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraSearchTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraSearchTest.java
@@ -60,13 +60,13 @@ public class FedoraSearchTest {
     public void testValidConditionsForFedoraId() throws InvalidConditionExpressionException {
         final var conditions = new ArrayList<String>();
         final var objects = new String[]{"test", "/test", uriBase + "/test", FEDORA_ID_PREFIX + "/test"};
-        for (String object : objects) {
-            for (Condition.Operator operator : Condition.Operator.values()) {
+        for (final String object : objects) {
+            for (final Condition.Operator operator : Condition.Operator.values()) {
                 conditions.add(FEDORA_ID.name().toLowerCase() + operator.getStringValue() + object);
             }
         }
 
-        for (String condition : conditions) {
+        for (final String condition : conditions) {
             final var con = FedoraSearch.parse(condition, converter);
             assertNotNull(con.getField());
             assertNotNull(con.getOperator());
@@ -89,12 +89,12 @@ public class FedoraSearchTest {
         final var conditions = new ArrayList<String>();
         final var object = "test";
         Arrays.stream(Condition.Field.values()).filter(x -> !x.equals(FEDORA_ID)).forEach(field -> {
-            for (Condition.Operator operator : Condition.Operator.values()) {
+            for (final Condition.Operator operator : Condition.Operator.values()) {
                 conditions.add(field.name().toLowerCase() + operator.getStringValue() + object);
             }
         });
 
-        for (String condition : conditions) {
+        for (final String condition : conditions) {
             final var con = FedoraSearch.parse(condition, converter);
             assertNotNull(con.getField());
             assertNotNull(con.getOperator());
@@ -111,11 +111,11 @@ public class FedoraSearchTest {
                 "fedora_id==/test"
         };
 
-        for (String condition : conditions) {
+        for (final String condition : conditions) {
             try {
                 FedoraSearch.parse(condition, converter);
                 fail("Condition should have failed: " + condition);
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
             }
         }
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProviderTest.java
@@ -24,7 +24,9 @@ import static java.util.Collections.singletonMap;
 import static java.util.stream.Stream.of;
 import static javax.ws.rs.core.MediaType.TEXT_HTML_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -88,10 +90,10 @@ public class StreamingBaseHtmlProviderTest {
     public void setup() throws Exception {
 
         final Stream<Triple> triples = of(new Triple(createURI("test:subject"), createURI("test:predicate"),
-                createLiteral("test:object")), new Triple(createURI("test:subject"), type.asNode(), createURI(
-                        REPOSITORY_NAMESPACE + "Binary")));
-        final Stream<Triple> triples2 = of(new Triple(createURI("test:subject2"), type.asNode(), createURI(
-                REPOSITORY_NAMESPACE + "Container")));
+                createLiteral("test:object")), new Triple(createURI("test:subject"), type.asNode(),
+                FEDORA_BINARY.asNode()));
+        final Stream<Triple> triples2 = of(new Triple(createURI("test:subject2"), type.asNode(),
+                FEDORA_CONTAINER.asNode()));
         @SuppressWarnings("resource")
         final DefaultRdfStream stream = new DefaultRdfStream(createURI("test:subject"), triples);
         @SuppressWarnings("resource")
@@ -149,7 +151,7 @@ public class StreamingBaseHtmlProviderTest {
                 return "I am pretending to merge a template for you.";
             }
         }).when(mockTemplate).merge(isA(Context.class), isA(Writer.class));
-        setField(testProvider, "templatesMap", singletonMap(REPOSITORY_NAMESPACE + "Binary",
+        setField(testProvider, "templatesMap", singletonMap(FEDORA_BINARY.getURI(),
                 mockTemplate));
         testProvider.writeTo(testData, RdfNamespacedStream.class, mock(Type.class),
                 new Annotation[]{}, MediaType.valueOf("text/html"),
@@ -203,7 +205,7 @@ public class StreamingBaseHtmlProviderTest {
         }).when(mockTemplate).merge(isA(Context.class), isA(Writer.class));
 
         setField(testProvider, "templatesMap",
-                 ImmutableMap.of(REPOSITORY_NAMESPACE + "Container", mockTemplate));
+                 ImmutableMap.of(FEDORA_CONTAINER.getURI(), mockTemplate));
         testProvider.writeTo(testData2, RdfNamespacedStream.class, mock(Type.class),
                 new Annotation[] {}, MediaType
                         .valueOf("text/html"),

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentPathValidatorIT.java
@@ -94,7 +94,7 @@ public class ExternalContentPathValidatorIT extends AbstractResourceIT {
     }
 
     private static void addAllowedPath(final File allowedFile, final String allowed) throws Exception {
-        try (BufferedWriter writer = Files.newBufferedWriter(allowedFile.toPath(), APPEND)) {
+        try (final BufferedWriter writer = Files.newBufferedWriter(allowedFile.toPath(), APPEND)) {
             writer.write(allowed + System.lineSeparator());
         }
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -30,11 +30,11 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.vocabulary.RDF.type;
 import static org.fcrepo.http.api.FedoraAcl.ROOT_AUTHORIZATION_PROPERTY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
-import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -131,8 +131,8 @@ public class FedoraAclIT extends AbstractResourceIT {
             final DatasetGraph graph = dataset.asDatasetGraph();
             assertTrue(graph.contains(ANY,
                                       createURI(aclLocation),
-                                      createURI(RDF_NAMESPACE + "type"),
-                                      createURI(LDP_NAMESPACE + "RDFSource")));
+                                      type.asNode(),
+                                      RDF_SOURCE.asNode()));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraCrudConcurrentIT.java
@@ -62,7 +62,7 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
 
         final int[] numThreadsToTest = {2, 4, 8, 16, 32};
         logger.info("# Start CRUD concurrent performance testing...");
-        for (int aNumThreadsToTest : numThreadsToTest) {
+        for (final int aNumThreadsToTest : numThreadsToTest) {
             startCrudConcurrentPerformanceTest(aNumThreadsToTest);
         }
     }
@@ -247,7 +247,7 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
     }
 
     private static void startThreads(final List<HttpRunner> tasks) throws InterruptedException {
-        for (HttpRunner task : tasks) {
+        for (final HttpRunner task : tasks) {
 
             final Thread thread = new Thread(task);
             thread.run();
@@ -296,7 +296,7 @@ public class FedoraCrudConcurrentIT extends AbstractResourceIT {
                             taskName, request.getURI().toString(),
                             statusCode, String.valueOf(responseTime));
                 assertEquals(taskName + " exited abnormally.", expectedStatusCode, statusCode);
-            } catch (IOException e) {
+            } catch (final IOException e) {
                 logger.error("Error {} {} got IOException: {}", taskName, request.getURI().toString(), e.getMessage());
             } finally {
                 request.releaseConnection();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -91,11 +91,11 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.INSERTED_CONTENT_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.IS_MEMBER_OF_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMENTO_TYPE;
@@ -216,7 +216,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final Node DC_IDENTIFIER = DC_11.identifier.asNode();
 
-    private static final String LDP_RESOURCE_LINK_HEADER = "<" + LDP_NAMESPACE + "Resource>; rel=\"type\"";
+    private static final String LDP_RESOURCE_LINK_HEADER = "<" + RESOURCE.getURI() + ">; rel=\"type\"";
 
     private static final Node rdfType = type.asNode();
 
@@ -2296,7 +2296,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(getObjMethod(id))) {
             try (final CloseableDataset dataset = getDataset(response)) {
                 assertTrue("Didn't find child node!", dataset.asDatasetGraph().contains(ANY,
-                        createURI(location), createURI(LDP_NAMESPACE + "contains"), createURI(location + "/c")));
+                        createURI(location), CONTAINS.asNode(), createURI(location + "/c")));
 
                 final Collection<String> links = getLinkHeaders(response);
                 assertTrue("Didn't find LDP resource link header!", links.contains(LDP_RESOURCE_LINK_HEADER));
@@ -2312,7 +2312,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(getObjMethod(id))) {
             try (final CloseableDataset dataset = getDataset(response)) {
                 assertTrue("Didn't find child node!", dataset.asDatasetGraph().contains(ANY,
-                        createURI(location), createURI(LDP_NAMESPACE + "contains"), createURI(location + "/c")));
+                        createURI(location), CONTAINS.asNode(), createURI(location + "/c")));
             }
         }
 
@@ -2321,7 +2321,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response1 = execute(getObjMethod(id))) {
             try (final CloseableDataset dataset = getDataset(response1)) {
                 assertFalse("Found child node!", dataset.asDatasetGraph().contains(ANY,
-                        createURI(location), createURI(LDP_NAMESPACE + "contains"), createURI(location + "/c")));
+                        createURI(location), CONTAINS.asNode(), createURI(location + "/c")));
             }
         }
     }
@@ -2451,7 +2451,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObjectAndClose(id);
         final String location = serverAddress + id;
         final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
         put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         assertEquals(CREATED.getStatusCode(), getStatus(put));
@@ -2485,7 +2485,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObjectAndClose(id);
         final String location = serverAddress + id;
         final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
         put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         assertEquals(CREATED.getStatusCode(), getStatus(put));
@@ -2528,7 +2528,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObjectAndClose(id);
         final String location = serverAddress + id;
         final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
         put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         assertEquals(CREATED.getStatusCode(), getStatus(put));
@@ -2614,7 +2614,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         patch.setHeader(CONTENT_TYPE, "application/sparql-update");
         final String updateString =
                 "INSERT DATA { <> a <" + DIRECT_CONTAINER.getURI() + "> ; <" + MEMBERSHIP_RESOURCE.getURI() +
-                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .}";
+                        "> <> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .}";
         patch.setEntity(new StringEntity(updateString));
         assertEquals("Patch with sparql update created direct container from basic container!",
                 CONFLICT.getStatusCode(), getStatus(patch));
@@ -2719,14 +2719,14 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // attempt to change basic container to direct container
         final String ttl2 = "<> a <" + DIRECT_CONTAINER.getURI() + "> ; <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put2 = putObjMethod(pid + "/a", "text/turtle", ttl2);
         assertEquals("Changed the basic container ixn to Direct Container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put2));
 
         // create direct container
         final String ttl = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put = putObjMethod(pid + "/b", "text/turtle", ttl);
         put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         assertEquals(CREATED.getStatusCode(), getStatus(put));
@@ -2741,7 +2741,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // attempt to change direct container to basic container
         final String ttl3 = "<> a <" + BASIC_CONTAINER.getURI() +
-                "> ; <http://purl.org/dc/elements/1.1/title> \"this is a title\".";
+                "> ; <" + title + "> \"this is a title\".";
         final HttpPut put3 = putObjMethod(pid + "/b", "text/turtle", ttl3);
         assertEquals("Changed the direct container ixn to basic container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put3));
@@ -2750,7 +2750,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String ttl4 = "<> a <" + INDIRECT_CONTAINER.getURI()
                 + "> ; <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
                 + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
-                + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
+                + "<" + INSERTED_CONTENT_RELATION + "> <info:proxy/for> .\n";
         final HttpPut put4 = putObjMethod(pid + "/b", "text/turtle", ttl4);
         assertEquals("Changed the direct container ixn to indirect container through PUT with RDF content!",
                 CONFLICT.getStatusCode(), getStatus(put4));
@@ -2767,7 +2767,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObjectAndClose(pid + "/c");
 
         final String ttl1 = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put1 = putObjMethod(pid + "/a", "text/turtle", ttl1);
         put1.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         put1.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
@@ -2776,13 +2776,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // create direct container
         final String ttl = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
-                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_NAMESPACE + "member> .";
+                "> <" + resource + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
         final HttpPut put = putObjMethod(pid + "/b", "text/turtle", ttl);
         put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         assertEquals(CREATED.getStatusCode(), getStatus(put));
         assertTrue(getLinkHeaders(getObjMethod(pid + "/b")).contains(DIRECT_CONTAINER_LINK_HEADER));
 
-        final String ttl2 = "<> <http://purl.org/dc/elements/1.1/title> \"this is a title\"";
+        final String ttl2 = "<> <" + title + "> \"this is a title\"";
         final HttpPut put2 = putObjMethod(pid + "/b", "text/turtle", ttl2);
         put2.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
         put2.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
@@ -2791,7 +2791,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         final String ttl3 = "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
                 + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
-                + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
+                + "<" + INSERTED_CONTENT_RELATION + "> <info:proxy/for> .\n";
         final HttpPut put3 = putObjMethod(pid + "/b", "text/turtle", ttl3);
         put3.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
         put3.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
@@ -3469,9 +3469,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 final Resource nodeUri = createResource(location);
                 final String lastmodString = response.getFirstHeader("Last-Modified").getValue();
                 final Optional<Instant> createdDateTriples =
-                        getDateFromModel(model, nodeUri, createProperty(REPOSITORY_NAMESPACE + "created"));
+                        getDateFromModel(model, nodeUri, CREATED_DATE);
                 final Optional<Instant> lastmodDateTriples =
-                        getDateFromModel(model, nodeUri, createProperty(REPOSITORY_NAMESPACE + "lastModified"));
+                        getDateFromModel(model, nodeUri, LAST_MODIFIED_DATE);
                 assertTrue(createdDateTriples.isPresent());
                 assertTrue(lastmodDateTriples.isPresent());
                 // Reformatting lastModified header to ensure consistent formatting between it and fedora timestamps
@@ -3590,9 +3590,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final DatasetGraph graphStore = dataset.asDatasetGraph();
             final Node resource = createURI(location);
             assertTrue("Expected to have container t", graphStore.contains(ANY,
-                    resource, createURI(LDP_NAMESPACE + "contains"), createURI(location + "/a")));
+                    resource, CONTAINS.asNode(), createURI(location + "/a")));
             assertTrue("Expected to have container b", graphStore.contains(ANY,
-                    resource, createURI(LDP_NAMESPACE + "contains"), createURI(location + "/b")));
+                    resource, CONTAINS.asNode(), createURI(location + "/b")));
             assertTrue("Expected member relation", graphStore.contains(ANY,
                     resource, createURI("info:some/relation"), createURI(location + "/a/1")));
             assertTrue("Expected other member relation", graphStore.contains(ANY,
@@ -3621,7 +3621,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String indirectContainer;
         final String ttl = "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
                 + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
-                + "<" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n";
+                + "<" + INSERTED_CONTENT_RELATION + "> <info:proxy/for> .\n";
         final HttpPut put = putObjMethod(containerId + "/t", "text/turtle", ttl);
         put.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
         try (final CloseableHttpResponse response = execute(put)) {
@@ -3647,7 +3647,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 final CloseableDataset dataset = getDataset(getResponse)) {
             final DatasetGraph graphStore = dataset.asDatasetGraph();
             assertTrue("Expected to have indirect container", graphStore.contains(ANY,
-                    createURI(container), createURI(LDP_NAMESPACE + "contains"), createURI(indirectContainer)));
+                    createURI(container), CONTAINS.asNode(), createURI(indirectContainer)));
 
             assertTrue("Expected to have resource: " + graphStore.toString(), graphStore.contains(ANY,
                     createURI(container), createURI("info:some/relation"), createURI(resource)));
@@ -3695,7 +3695,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String sparql = "INSERT DATA { "
                 + "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + "> .\n"
                 + "<> <" + IS_MEMBER_OF_RELATION + "> <info:some/relation> .\n"
-                + "<> <" + LDP_NAMESPACE + "insertedContentRelation> <info:proxy/for> .\n"
+                + "<> <" + INSERTED_CONTENT_RELATION + "> <info:proxy/for> .\n"
                 + " }";
         patch.setEntity(new StringEntity(sparql));
         assertEquals("Expected patch to succeed", NO_CONTENT.getStatusCode(), getStatus(patch));
@@ -3750,9 +3750,9 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 assertTrue(graphStore.contains(ANY,
                         createURI(location + "#abc"), createURI("info:test#label"), createLiteral("asdfg")));
                 assertFalse(graphStore.contains(ANY,
-                        createURI(location + "#abc"), createURI(REPOSITORY_NAMESPACE + "lastModified"), ANY));
+                        createURI(location + "#abc"), LAST_MODIFIED_DATE.asNode(), ANY));
                 assertFalse(graphStore.contains(ANY,
-                        createURI(location + "#abc"), rdfType, createURI(REPOSITORY_NAMESPACE + "Resource")));
+                        createURI(location + "#abc"), rdfType, FEDORA_RESOURCE.asNode()));
             }
         }
     }
@@ -3816,7 +3816,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         httpPut.addHeader(CONTENT_TYPE, "text/turtle");
         httpPut.setEntity(new StringEntity("<> a <" + DIRECT_CONTAINER.getURI() + ">;" +
                 "    <" + MEMBERSHIP_RESOURCE.getURI() + "> <> ;" +
-                "    <" + HAS_MEMBER_RELATION.getURI() + "> <" + LDP_NAMESPACE + "member> ;" +
+                "    <" + HAS_MEMBER_RELATION.getURI() + "> <" + LDP_MEMBER + "> ;" +
                 "    <info:x> <#hash-uri> ;" +
                 "    <info:x> [ <" + DCTITLE.getURI() + "> \"xyz\" ] . " +
                 "<#hash-uri>  <" + DCTITLE.getURI() + "> \"some-hash-uri\" ."));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -113,14 +113,14 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     @Test
     public void testBasicPutRoundtrip() throws IOException {
         final String subjectURI;
-        try (CloseableHttpResponse response = execute(postObjMethod())) {
+        try (final CloseableHttpResponse response = execute(postObjMethod())) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
         }
 
         final String body;
         final HttpGet get = new HttpGet(subjectURI);
-        try (CloseableHttpResponse response = execute(get)) {
+        try (final CloseableHttpResponse response = execute(get)) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             body = EntityUtils.toString(response.getEntity());
         }
@@ -136,13 +136,13 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     public void testCreateResourceWithSpecificCreationInformationIsAllowed() throws IOException {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
         final String subjectURI;
-        try (CloseableHttpResponse response = postResourceWithTTL(
+        try (final CloseableHttpResponse response = postResourceWithTTL(
                 getTTLThatUpdatesServerManagedTriples(providedUsername, providedDate, null, null))) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
         }
 
-        try (CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
+        try (final CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
             triples(subjectURI, dataset)
                     .mustHave(CREATED_BY.asNode(), createLiteral(providedUsername))
                     .mustHave(CREATED_DATE.asNode(), createDateTime(providedDate));
@@ -155,20 +155,20 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
-        try (CloseableHttpResponse response = postBinaryResource(serverAddress, "this is the binary")) {
+        try (final CloseableHttpResponse response = postBinaryResource(serverAddress, "this is the binary")) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
         }
 
         final String describedByURI = subjectURI + "/fcr:metadata";
 
-        try (CloseableHttpResponse response = putResourceWithTTL(describedByURI,
+        try (final CloseableHttpResponse response = putResourceWithTTL(describedByURI,
                 getTTLThatUpdatesServerManagedTriples(providedUsername, providedDate,
                                                       providedUsername, providedDate))) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
-        try (CloseableDataset dataset = getDataset(new HttpGet(describedByURI))) {
+        try (final CloseableDataset dataset = getDataset(new HttpGet(describedByURI))) {
             triples(subjectURI, dataset)
                     .mustHave(CREATED_BY.asNode(), createLiteral(providedUsername))
                     .mustHave(CREATED_DATE.asNode(), createDateTime(providedDate))
@@ -183,7 +183,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
-        try (CloseableHttpResponse response = postResourceWithTTL(
+        try (final CloseableHttpResponse response = postResourceWithTTL(
                 getTTLThatUpdatesServerManagedTriples(providedUsername, providedDate, null, null))) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
@@ -197,11 +197,11 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
                 "INSERT { <> fedora:created \"" + DatatypeConverter.printDateTime(updatedDate)
                         + "\"^^<http://www.w3.org/2001/XMLSchema#dateTime> }\n" +
                 "WHERE { }";
-        try (CloseableHttpResponse response = patchResource(subjectURI, sparqlUpdate)) {
+        try (final CloseableHttpResponse response = patchResource(subjectURI, sparqlUpdate)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
-        try (CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
+        try (final CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
             triples(subjectURI, dataset)
                     .mustHave(CREATED_BY.asNode(), createLiteral(providedUsername))
                     .mustHave(CREATED_DATE.asNode(), createDateTime(updatedDate));
@@ -214,7 +214,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
-        try (CloseableHttpResponse response = execute(postObjMethod())) {
+        try (final CloseableHttpResponse response = execute(postObjMethod())) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
         }
@@ -227,11 +227,11 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
                 " <> fedora:created \"" + DatatypeConverter.printDateTime(providedDate) +
                 "\"^^<http://www.w3.org/2001/XMLSchema#dateTime> }\n" +
                 "WHERE { }";
-        try (CloseableHttpResponse response = patchResource(subjectURI, sparqlUpdate)) {
+        try (final CloseableHttpResponse response = patchResource(subjectURI, sparqlUpdate)) {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
         }
 
-        try (CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
+        try (final CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
             triples(subjectURI, dataset)
                     .mustNotHave(CREATED_BY.asNode(), createLiteral(providedUsername))
                     .mustNotHave(CREATED_DATE.asNode(), createDateTime(updatedDate));
@@ -244,7 +244,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals("relaxed", System.getProperty(SERVER_MANAGED_PROPERTIES_MODE)); // sanity check
 
         final String subjectURI;
-        try (CloseableHttpResponse response = createObject()) {
+        try (final CloseableHttpResponse response = createObject()) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             subjectURI = getLocation(response);
         }
@@ -252,12 +252,12 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         providedDate = nowUTC();
         providedDate.add(Calendar.MONTH, 1);
 
-        try (CloseableHttpResponse response = putResourceWithTTL(subjectURI,
+        try (final CloseableHttpResponse response = putResourceWithTTL(subjectURI,
                 getTTLThatUpdatesServerManagedTriples(null, null, providedUsername, providedDate))) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
-        try (CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
+        try (final CloseableDataset dataset = getDataset(new HttpGet(subjectURI))) {
             triples(subjectURI, dataset)
                     .mustHave(LAST_MODIFIED_BY.asNode(), createLiteral(providedUsername))
                     .mustHave(LAST_MODIFIED_DATE.asNode(), createDateTime(providedDate));
@@ -275,7 +275,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
 
         // POST a resource with one user-managed triple
         final String containerURI;
-        try (CloseableHttpResponse response
+        try (final CloseableHttpResponse response
                      = postResourceWithTTL("<> <http://purl.org/dc/elements/1.1/title> 'title' .")) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             containerURI = getLocation(response);
@@ -284,7 +284,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         // POST a non-rdf child resource
         final String containedBinaryURI;
         final String containedBinaryDescriptionURI;
-        try (CloseableHttpResponse response = postBinaryResource(containerURI, "content")) {
+        try (final CloseableHttpResponse response = postBinaryResource(containerURI, "content")) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
             containedBinaryURI = getLocation(response);
             containedBinaryDescriptionURI = containedBinaryURI + "/fcr:metadata";
@@ -292,21 +292,21 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
 
         // export the RDF of the container
         final String containerBody;
-        try (CloseableHttpResponse response = execute(new HttpGet(containerURI))) {
+        try (final CloseableHttpResponse response = execute(new HttpGet(containerURI))) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             containerBody = EntityUtils.toString(response.getEntity());
         }
 
         // export the RDF of the child
         final String containedBinaryDescriptionBody;
-        try (CloseableHttpResponse response = execute(new HttpGet(containedBinaryDescriptionURI))) {
+        try (final CloseableHttpResponse response = execute(new HttpGet(containedBinaryDescriptionURI))) {
             assertEquals(OK.getStatusCode(), getStatus(response));
             containedBinaryDescriptionBody = EntityUtils.toString(response.getEntity());
         }
 
 
         // delete the container and its tombstone
-        try (CloseableHttpResponse response = execute(new HttpDelete(containerURI))) {
+        try (final CloseableHttpResponse response = execute(new HttpDelete(containerURI))) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
             try (final CloseableHttpResponse r2 = execute(new HttpGet(containerURI))) {
                 final Link tombstone = Link.valueOf(r2.getFirstHeader(LINK).getValue());
@@ -319,17 +319,17 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         // post the container from the export
         final String containerRdf = filterRdf(containerBody, CREATED_BY, CREATED_DATE, LAST_MODIFIED_BY,
                 LAST_MODIFIED_DATE, createProperty("http://purl.org/dc/elements/1.1/title"));
-        try (CloseableHttpResponse response = postResourceWithTTL(containerURI, containerRdf)) {
+        try (final CloseableHttpResponse response = postResourceWithTTL(containerURI, containerRdf)) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
         }
 
         // post the binary then patch its metadata to match the export
-        try (CloseableHttpResponse response = postBinaryResource(containerURI,
+        try (final CloseableHttpResponse response = postBinaryResource(containerURI,
                 containedBinaryURI.substring(containerURI.length() + 1), "content")) {
             assertEquals(CREATED.getStatusCode(), getStatus(response));
         }
         final String sparqlUpdate;
-        try (CloseableDataset d = getDataset(new HttpGet(containedBinaryDescriptionURI))) {
+        try (final CloseableDataset d = getDataset(new HttpGet(containedBinaryDescriptionURI))) {
             final Model model = createDefaultModel();
             model.read(new ByteArrayInputStream(containedBinaryDescriptionBody.getBytes()), "", "N3");
             final GraphDifferencer diff = new GraphDifferencer(model,
@@ -338,7 +338,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
                     LAST_MODIFIED_BY, LAST_MODIFIED_DATE);
         }
 
-        try (CloseableHttpResponse response = patchResource(containedBinaryDescriptionURI, sparqlUpdate)) {
+        try (final CloseableHttpResponse response = patchResource(containedBinaryDescriptionURI, sparqlUpdate)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
@@ -357,8 +357,8 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
     private void assertIdentical(final String uri, final String originalRdf) throws IOException {
-        try (CloseableDataset roundtripped = getDataset(new HttpGet(uri))) {
-            try (CloseableDataset original = parseTriples(new ByteArrayInputStream(originalRdf.getBytes()))) {
+        try (final CloseableDataset roundtripped = getDataset(new HttpGet(uri))) {
+            try (final CloseableDataset original = parseTriples(new ByteArrayInputStream(originalRdf.getBytes()))) {
                 final DatasetGraph originalGraph = original.asDatasetGraph();
                 final DatasetGraph roundtrippedGraph = roundtripped.asDatasetGraph();
                 final Iterator<Quad> originalQuadIt = originalGraph.find();
@@ -401,13 +401,13 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
      * @return filtered triples
      */
     private String filterRdf(final String triples, final Property ... predicates) {
-        try (CloseableDataset original = parseTriples(new ByteArrayInputStream(triples.getBytes()))) {
+        try (final CloseableDataset original = parseTriples(new ByteArrayInputStream(triples.getBytes()))) {
             final Model m = original.getDefaultModel();
             final StmtIterator it = m.listStatements();
             while (it.hasNext()) {
                 final Statement stmt = it.nextStatement();
                 boolean keep = false;
-                for (Property p : predicates) {
+                for (final Property p : predicates) {
                     if (stmt.getPredicate().equals(p)) {
                         keep = true;
                         break;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraSearchIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraSearchIT.java
@@ -135,7 +135,7 @@ public class FedoraSearchIT extends AbstractResourceIT {
         final var urlPrefix = serverAddress + id;
         // try all valid prefix formulations
         final var prefixes = new String[]{id, "/" + id, urlPrefix, FEDORA_ID_PREFIX + "/" + id};
-        for (String prefix : prefixes) {
+        for (final String prefix : prefixes) {
             final var condition = FEDORA_ID + "=" + prefix + "*";
             final String searchUrl = getSearchEndpoint() + "condition=" + encode(condition);
             try (final CloseableHttpResponse response = execute(new HttpGet(searchUrl))) {
@@ -334,9 +334,9 @@ public class FedoraSearchIT extends AbstractResourceIT {
             final SearchResult result = objectMapper.readValue(response.getEntity().getContent(), SearchResult.class);
             final var items = result.getItems();
             assertEquals("expected " + count + " items", count, items.size());
-            for (Map<String, Object> item : items) {
+            for (final Map<String, Object> item : items) {
                 assertEquals("expected " + fields.size() + " fields returned", fields.size(), item.size());
-                for (String field : fields) {
+                for (final String field : fields) {
                     assertTrue("Result does not contain expected field: " + field, item.containsKey(field));
                 }
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -204,7 +204,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 "DELETE { <> ldp:membershipResource <" + parentURI + "> ;\n" +
                 "ldp:hasMemberRelation <" + PCDM_HAS_MEMBER + "> ;\n" +
                 "ldp:insertedContentRelation <" + PROXY_FOR.getURI() + "> . } WHERE {}"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
@@ -379,7 +379,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "DELETE { <> ldp:membershipResource <" + parentURI + "> ;\n" +
                 "ldp:hasMemberRelation <" + PCDM_HAS_MEMBER + "> . } WHERE {}"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
@@ -466,7 +466,7 @@ public class LDPContainerIT extends AbstractResourceIT {
         patch.setEntity(new StringEntity(
                 "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "INSERT { <> ldp:hasMemberRelation ldp:member } WHERE {}\n"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
         }
 
@@ -505,7 +505,7 @@ public class LDPContainerIT extends AbstractResourceIT {
         patch.setEntity(new StringEntity(
                 "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "INSERT { <> ldp:membershipResource <" + membershipResc2URI + "> } WHERE {}\n"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
         }
 
@@ -600,7 +600,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "DELETE { <> ldp:hasMemberRelation <" + PCDM_HAS_MEMBER + "> . }" +
                 "INSERT { <> ldp:hasMemberRelation ldp:member } WHERE {}\n"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 
@@ -651,7 +651,7 @@ public class LDPContainerIT extends AbstractResourceIT {
                 "PREFIX ldp: <http://www.w3.org/ns/ldp#>\n" +
                 "DELETE { <> ldp:isMemberOfRelation <" + EX_IS_MEMBER_PROP + "> . }" +
                 "INSERT { <> ldp:isMemberOfRelation ldp:member } WHERE {}\n"));
-        try (CloseableHttpResponse response = execute(patch)) {
+        try (final CloseableHttpResponse response = execute(patch)) {
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
         }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExceptionDebugLogging.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExceptionDebugLogging.java
@@ -31,7 +31,7 @@ public interface ExceptionDebugLogging {
      * @param error Throwable the intercepted error.
      * @param logger Logger the logger to use
      */
-    default void debugException(ExceptionDebugLogging context, Throwable error, Logger logger) {
+    default void debugException(final ExceptionDebugLogging context, final Throwable error, final Logger logger) {
         /*
          * Because the majority case is not debug logging, trade one additional
          * accessor call in a guard clause for multiple in message construction

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/PrometheusMetricsServlet.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/metrics/PrometheusMetricsServlet.java
@@ -42,7 +42,7 @@ public class PrometheusMetricsServlet extends MetricsServlet {
             final var field = MetricsServlet.class.getDeclaredField("registry");
             field.setAccessible(true);
             field.set(this, collector);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (final NoSuchFieldException | IllegalAccessException e) {
             throw new ServletException(e);
         }
 

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/PreferTagTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/PreferTagTest.java
@@ -17,7 +17,7 @@
  */
 package org.fcrepo.http.commons.domain;
 
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +64,7 @@ public class PreferTagTest {
                 true);
 
         doTestHashCode(new PreferTag("handling=lenient; received=\"minimal\""),
-                new PreferTag("return=representation; include=\"" + LDP_NAMESPACE + "PreferMinimalContainer\""),
+                new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + "\""),
                 false);
 
         doTestHashCode(new PreferTag("handling=lenient; received=\"minimal\""),

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
@@ -22,7 +22,9 @@ import org.junit.Test;
 
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
-import static org.fcrepo.kernel.api.RdfLexicon.LDP_NAMESPACE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -49,7 +51,7 @@ public class LdpPreferTagTest {
     @Test
     public void testMinimalContainer() {
         final PreferTag prefer
-                = new PreferTag("return=representation; include=\"" + LDP_NAMESPACE + "PreferMinimalContainer\"");
+                = new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + "\"");
         testObj = new LdpPreferTag(prefer);
 
         assertTrue(testObj.prefersServerManaged());
@@ -62,8 +64,8 @@ public class LdpPreferTagTest {
     @Test
     public void testPreferMembership() {
         final PreferTag prefer
-                = new PreferTag("return=representation; include=\"" + LDP_NAMESPACE + "PreferMinimalContainer "
-                                                                    + LDP_NAMESPACE + "PreferMembership\"");
+                = new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + " "
+                                                                    + PREFER_MEMBERSHIP + "\"");
         testObj = new LdpPreferTag(prefer);
 
         assertTrue(testObj.prefersMembership());
@@ -72,8 +74,8 @@ public class LdpPreferTagTest {
     @Test
     public void testPreferContainment() {
         final PreferTag prefer
-                = new PreferTag("return=representation; include=\"" + LDP_NAMESPACE + "PreferMinimalContainer "
-                                                                    + LDP_NAMESPACE + "PreferContainment\"");
+                = new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + " "
+                                                                    + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
         assertTrue(testObj.prefersContainment());
@@ -82,8 +84,8 @@ public class LdpPreferTagTest {
     @Test
     public void testPreferContainmentAndMembership() {
         final PreferTag prefer
-                = new PreferTag("return=representation; include=\"" + LDP_NAMESPACE + "PreferMembership "
-                                                                    + LDP_NAMESPACE + "PreferContainment\"");
+                = new PreferTag("return=representation; include=\"" + PREFER_MEMBERSHIP + " "
+                                                                    + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
         assertTrue(testObj.prefersMembership());
@@ -93,8 +95,8 @@ public class LdpPreferTagTest {
     @Test
     public void testPreferOmitContainmentAndMembership() {
         final PreferTag prefer
-                = new PreferTag("return=representation; omit=\"" + LDP_NAMESPACE + "PreferMembership "
-                                                                 + LDP_NAMESPACE + "PreferContainment\"");
+                = new PreferTag("return=representation; omit=\"" + PREFER_MEMBERSHIP + " "
+                                                                 + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
         assertFalse(testObj.prefersMembership());

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/RdfStreamProviderTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/responses/RdfStreamProviderTest.java
@@ -87,7 +87,7 @@ public class RdfStreamProviderTest {
         final Map<String, String> namespaces = new HashMap<>();
         try (final RdfStream rdfStream = new DefaultRdfStream(createURI("info:test"), of(t));
                 final RdfNamespacedStream nsStream = new RdfNamespacedStream(rdfStream, namespaces)) {
-            try (ByteArrayOutputStream entityStream = new ByteArrayOutputStream()) {
+            try (final ByteArrayOutputStream entityStream = new ByteArrayOutputStream()) {
                 testProvider.writeTo(nsStream, RdfNamespacedStream.class, null, null,
                         MediaType.valueOf("application/rdf+xml"), null, entityStream);
                 final byte[] result = entityStream.toByteArray();

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/test/util/TestHelpers.java
@@ -109,7 +109,7 @@ public abstract class TestHelpers {
             final Field f = findField(parent.getClass(), name);
             f.setAccessible(true);
             f.set(parent, obj);
-        } catch (IllegalArgumentException | IllegalAccessException | NoSuchFieldException e) {
+        } catch (final IllegalArgumentException | IllegalAccessException | NoSuchFieldException e) {
             throw new RuntimeException(e);
         }
     }

--- a/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
+++ b/fcrepo-integration-rdf/src/test/java/org/fcrepo/integration/rdf/ServerManagedTriplesIT.java
@@ -18,6 +18,7 @@
 package org.fcrepo.integration.rdf;
 
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.PREMIS_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_NAMESPACE;
@@ -92,14 +93,14 @@ public class ServerManagedTriplesIT extends AbstractResourceIT {
         final String refURI = serverAddress + refPid;
         createObject(refPid);
 
-        verifyRejectUriRef(LDP_NAMESPACE + "contains", refURI);
-        verifyRejectUpdateUriRef(LDP_NAMESPACE + "contains", refURI);
+        verifyRejectUriRef(CONTAINS.getURI(), refURI);
+        verifyRejectUpdateUriRef(CONTAINS.getURI(), refURI);
 
         // Verify that ldp:hasMemberRelation referencing an SMT is rejected
         verifyRejectUriRef(HAS_MEMBER_RELATION.getURI(), REPOSITORY_NAMESPACE + NON_EXISTENT_PREDICATE);
         verifyRejectUpdateUriRef(HAS_MEMBER_RELATION.getURI(), REPOSITORY_NAMESPACE + NON_EXISTENT_PREDICATE);
-        verifyRejectUriRef(HAS_MEMBER_RELATION.getURI(), LDP_NAMESPACE + "contains");
-        verifyRejectUpdateUriRef(HAS_MEMBER_RELATION.getURI(), LDP_NAMESPACE + "contains");
+        verifyRejectUriRef(HAS_MEMBER_RELATION.getURI(), CONTAINS.getURI());
+        verifyRejectUpdateUriRef(HAS_MEMBER_RELATION.getURI(), CONTAINS.getURI());
 
         // Verify that types in the ldp namespace are rejected
         verifyRejectRdfType(RESOURCE.getURI());

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -76,8 +76,9 @@ import static javax.jms.Session.AUTO_ACKNOWLEDGE;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
 import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
@@ -99,13 +100,13 @@ abstract class AbstractJmsIT implements MessageListener {
      */
     private static final long TIMEOUT = 20000;
 
-    private String testIngested = "/testMessageFromIngestion-" + randomUUID();
+    private final String testIngested = "/testMessageFromIngestion-" + randomUUID();
 
-    private String testRemoved = "/testMessageFromRemoval-" + randomUUID();
+    private final String testRemoved = "/testMessageFromRemoval-" + randomUUID();
 
-    private String testFile = "/testMessageFromFile-" + randomUUID() + "/file1";
+    private final String testFile = "/testMessageFromFile-" + randomUUID() + "/file1";
 
-    private String testMeta = "/testMessageFromMetadata-" + randomUUID();
+    private final String testMeta = "/testMessageFromMetadata-" + randomUUID();
 
     private static final String USER = "fedoraAdmin";
     private static final String TEST_USER_AGENT = "FedoraClient/1.0";
@@ -210,7 +211,7 @@ abstract class AbstractJmsIT implements MessageListener {
             final String sparql1 = "insert data { <> <http://foo.com/prop> \"foo\" . }";
             updatePropertiesService.updateProperties(tx.getId(), USER, fedoraId, sparql1);
             tx.commit();
-            awaitMessageOrFail(externalId, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Container");
+            awaitMessageOrFail(externalId, RESOURCE_MODIFICATION.getType(), FEDORA_CONTAINER.getURI());
         });
 
         doInTx(tx -> {
@@ -218,7 +219,7 @@ abstract class AbstractJmsIT implements MessageListener {
                     + "insert { <> <http://foo.com/prop> \"bar\" . } where {}";
             updatePropertiesService.updateProperties(tx.getId(), USER, fedoraId, sparql2);
             tx.commit();
-            awaitMessageOrFail(externalId, RESOURCE_MODIFICATION.getType(), REPOSITORY_NAMESPACE + "Resource");
+            awaitMessageOrFail(externalId, RESOURCE_MODIFICATION.getType(), FEDORA_RESOURCE.getURI());
         });
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
@@ -44,12 +44,4 @@ public interface RdfSourceOperationFactory extends ResourceOperationFactory {
      */
     RdfSourceOperationBuilder updateBuilder(FedoraId rescId);
 
-    /**
-     * Get a builder for an operation to perform a sparql update on an RDF source
-     *
-     * @param rescId id of the resource targeted by the operation
-     * @param updateQuery sparql update query
-     * @return new builder
-     */
-    ResourceOperationBuilder sparqlUpdateBuilder(FedoraId rescId, String updateQuery);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
@@ -81,7 +81,7 @@ public class RelaxedPropertiesHelper {
 
     private static String extractSingleStringValue(final Iterable<Statement> statements, final Property predicate) {
         String username = null;
-        for (Statement added : statements) {
+        for (final Statement added : statements) {
             if (added.getPredicate().equals(predicate)) {
                 if (username == null) {
                     username = added.getObject().asLiteral().getString();
@@ -96,7 +96,7 @@ public class RelaxedPropertiesHelper {
     private static Calendar extractSingleCalendarValue(final Iterable<Statement> statements,
                                                        final Property predicate) {
         Calendar cal = null;
-        for (Statement added : statements) {
+        for (final Statement added : statements) {
             if (added.getPredicate().equals(predicate)) {
                 if (cal == null) {
                     cal = RelaxedPropertiesHelper.parseExpectedXsdDateTimeValue(added.getObject());

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
@@ -17,9 +17,9 @@
  */
 package org.fcrepo.kernel.api;
 
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.fcrepo.kernel.api.RdfLexicon.PREMIS_NAMESPACE;
-import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
+import static org.apache.jena.vocabulary.DC_11.title;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -30,16 +30,17 @@ import org.junit.Test;
  * <p>RdfLexiconTest class.</p>
  *
  * @author ajs6f
+ * @author whikloj
  */
 public class RdfLexiconTest {
 
     @Test
     public void repoPredicatesAreManaged() {
-        assertTrue(isManagedPredicate.test(createProperty(PREMIS_NAMESPACE + "hasMessageDigest")));
-        assertTrue(isManagedPredicate.test(createProperty(REPOSITORY_NAMESPACE + "hasParent")));
+        assertTrue(isManagedPredicate.test(HAS_MESSAGE_DIGEST));
+        assertTrue(isManagedPredicate.test(CREATED_BY));
     }
     @Test
     public void otherPredicatesAreNotManaged() {
-        assertFalse(isManagedPredicate.test(createProperty("http://purl.org/dc/elements/1.1/title")));
+        assertFalse(isManagedPredicate.test(title));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImpl.java
@@ -94,7 +94,7 @@ public class EventAccumulatorImpl implements EventAccumulator {
 
                     LOG.debug("Emitting event: {}", event);
                     eventBus.post(event);
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     LOG.error("Failed to emit events: {}", events, e);
                 }
             });
@@ -112,7 +112,7 @@ public class EventAccumulatorImpl implements EventAccumulator {
             return resourceFactory.getResource(fedoraId).getTypes().stream()
                     .map(URI::toString)
                     .collect(Collectors.toSet());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOG.debug("Could not load resource types for {}", fedoraId, e);
             // This can happen if the resource no longer exists
             return Collections.emptySet();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
@@ -21,7 +21,6 @@ import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateRdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationBuilder;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
-import org.fcrepo.kernel.api.operations.ResourceOperationBuilder;
 import org.springframework.stereotype.Component;
 
 
@@ -41,12 +40,6 @@ public class RdfSourceOperationFactoryImpl implements RdfSourceOperationFactory 
     @Override
     public RdfSourceOperationBuilder updateBuilder(final FedoraId rescId) {
         return new UpdateRdfSourceOperationBuilder(rescId);
-    }
-
-    @Override
-    public ResourceOperationBuilder sparqlUpdateBuilder(final FedoraId rescId, final String updateQuery) {
-        // TODO Auto-generated method stub
-        return null;
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -244,7 +244,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             return hdrobjs == null ? emptyList() : hdrobjs.stream()
                     .filter(p -> p.getRel().equalsIgnoreCase("type")).map(Link::getUri)
                     .map(URI::toString).collect(Collectors.toList());
-        } catch ( Exception e ) {
+        } catch (final Exception e ) {
             throw new BadRequestException("Invalid Link header type found",e);
         }
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
@@ -53,7 +53,7 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         try {
             session.persist(operation);
             recordEvent(transaction.getId(), fedoraId, operation);
-        } catch (PersistentStorageException e) {
+        } catch (final PersistentStorageException e) {
             throw new RepositoryRuntimeException(String.format("Failed to create new version of %s",
                     fedoraId.getResourceId()), e);
         }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
@@ -318,7 +318,7 @@ public class EventAccumulatorImplTest {
     private static URI uri(final String uri) {
         try {
             return new URI(uri);
-        } catch (URISyntaxException e) {
+        } catch (final URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -71,7 +71,7 @@ public class RepositoryInitializer {
         try {
             try {
                 session.getHeaders(root, null);
-            } catch (PersistentItemNotFoundException e) {
+            } catch (final PersistentItemNotFoundException e) {
                 LOGGER.info("Repository root ({}) not found. Creating...", root);
                 final RdfSourceOperation operation = this.operationFactory.createBuilder(root,
                         BASIC_CONTAINER.getURI())

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -56,7 +56,7 @@ class DeleteResourcePersister extends AbstractPersister {
             ResourceHeaderUtils.touchModificationHeaders(headers, operation.getUserPrincipal());
 
             objectSession.deleteContentFile(new ResourceHeadersAdapter(headers).asStorageHeaders());
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             throw new PersistentStorageException(
                     String.format("Failed to delete resource content for %s", resourceId), e);
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FcrepoOcflObjectSessionWrapper.java
@@ -200,9 +200,9 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     private <T> T exec(final Callable<T> callable) throws PersistentStorageException {
         try {
             return callable.call();
-        } catch (NotFoundException e) {
+        } catch (final NotFoundException e) {
             throw new PersistentItemNotFoundException(e.getMessage(), e);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new PersistentStorageException(e.getMessage(), e);
         }
     }
@@ -210,9 +210,9 @@ public class FcrepoOcflObjectSessionWrapper implements OcflObjectSession {
     private void exec(final CheckedRunnable runnable) throws PersistentStorageException {
         try {
             runnable.run();
-        } catch (NotFoundException e) {
+        } catch (final NotFoundException e) {
             throw new PersistentItemNotFoundException(e.getMessage(), e);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new PersistentStorageException(e.getMessage(), e);
         }
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -301,7 +301,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
                 session.commit();
                 sessionsToRollback.put(id, session);
                 fedoraOcflIndex.commit(sessionId);
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 this.state = State.COMMIT_FAILED;
                 throw new PersistentStorageException(String.format("Failed to commit object <%s> in session <%s>",
                         id, sessionId), e);
@@ -401,7 +401,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
 
             try {
                 session.rollback();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 rollbackFailures.add(String.format("Failed to rollback object <%s> in session <%s>: %s",
                         id, session.sessionId(), e.getMessage()));
             }
@@ -409,7 +409,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
 
         try {
             fedoraOcflIndex.rollback(sessionId);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             rollbackFailures.add(String.format("Failed to rollback OCFL index updates in transaction <%s>: %s",
                     sessionId, e.getMessage()));
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/PurgeResourcePersister.java
@@ -47,7 +47,7 @@ class PurgeResourcePersister extends AbstractPersister {
 
         try {
             objectSession.deleteResource(resourceId.getResourceId());
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             throw new PersistentStorageException(String.format("Purge resource %s failed", resourceId), e);
         }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -188,7 +188,7 @@ public class DbFedoraToOcflObjectIndexTest {
             final String sessId = UUID.randomUUID().toString();
             index.addMapping(sessId, tempid, ROOT_RESOURCE_ID, OCFL_ID);
             fail();
-        } catch (InvalidResourceIdentifierException e) {
+        } catch (final InvalidResourceIdentifierException e) {
             //the exception is expected
         }
     }

--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
@@ -43,7 +43,7 @@ public class Condition {
         }
 
         public static Operator fromString(final String str) {
-            for (Operator o : Operator.values()) {
+            for (final Operator o : Operator.values()) {
                 if (o.value.equals(str)) {
                     return o;
                 }

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/InstantParser.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/InstantParser.java
@@ -62,7 +62,7 @@ public class InstantParser {
      * @return an instant
      */
     public static Instant parse(final String dateString) {
-        for (DateTimeFormatter formatter : VALID_DATE_FORMATS) {
+        for (final DateTimeFormatter formatter : VALID_DATE_FORMATS) {
             try {
                 final var temporalAccessor = formatter.parse(dateString);
                 return Instant.from(temporalAccessor);

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -23,6 +23,8 @@ import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -367,7 +369,7 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
 
         final HtmlForm form = (HtmlForm)page.getElementById("action_sparql_select");
         final HtmlTextArea q = form.getTextAreaByName("q");
-        q.setText("SELECT ?subject WHERE { ?subject a <" + REPOSITORY_NAMESPACE + "Resource> }");
+        q.setText("SELECT ?subject WHERE { ?subject a <" + FEDORA_RESOURCE + "> }");
         final HtmlButton button = form.getFirstByXPath("button");
         button.click();
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-1940

# What does this Pull Request do?
Removes the redecleration of constants that already exist in the codebase.
Adds `final` keyword where appropriate.
Removes the sparqlUpdateBuilder which was never implemented and is not used.

# How should this be tested?

This has no functional impact.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
