### PR TITLE
add resource locking

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -842,7 +842,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected void patchResourcewithSparql(final FedoraResource resource,
             final String requestBody) {
-        updatePropertiesService.updateProperties(transaction().getId(),
+        updatePropertiesService.updateProperties(transaction(),
                                                  getUserPrincipal(),
                                                  resource.getFedoraId(),
                                                  requestBody);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraTombstones.java
@@ -38,8 +38,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.noContent;
 import static javax.ws.rs.core.HttpHeaders.ALLOW;
+import static javax.ws.rs.core.Response.noContent;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -86,11 +86,15 @@ public class FedoraTombstones extends ContentExposingResource {
             // If the resource is not deleted there is no tombstone.
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        final Tombstone tombstone = (Tombstone) resource;
-        LOGGER.info("Delete tombstone: {}", resource.getFedoraId());
-        purgeResourceService.perform(transaction(), tombstone.getDeletedObject(), getUserPrincipal());
-        transaction().commitIfShortLived();
-        return noContent().build();
+        try {
+            final Tombstone tombstone = (Tombstone) resource;
+            LOGGER.info("Delete tombstone: {}", resource.getFedoraId());
+            purgeResourceService.perform(transaction(), tombstone.getDeletedObject(), getUserPrincipal());
+            transaction().commitIfShortLived();
+            return noContent().build();
+        } finally {
+            transaction().releaseResourceLocksIfShortLived();
+        }
     }
 
     /*

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -157,6 +157,8 @@ public class FedoraVersioning extends ContentExposingResource {
         } catch (final Exception e) {
             checkForInsufficientStorageException(e, e);
             return null; // not reachable
+        } finally {
+            transaction.releaseResourceLocksIfShortLived();
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -984,7 +984,7 @@ public class FedoraLdpTest {
 
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(createResourceService).perform(
-                eq(mockTransaction.getId()),
+                eq(mockTransaction),
                 anyString(),
                 eq(pathId),
                 isNull(),
@@ -1017,7 +1017,7 @@ public class FedoraLdpTest {
                 toInputStream("_:a <info:x> _:c .", UTF_8), null, null, null, null);
 
         assertEquals(NO_CONTENT.getStatusCode(), actual.getStatus());
-        verify(replacePropertiesService).perform(eq(mockTransaction.getId()), anyString(), eq(pathId),
+        verify(replacePropertiesService).perform(eq(mockTransaction), anyString(), eq(pathId),
                 any(Model.class));
     }
 
@@ -1056,7 +1056,7 @@ public class FedoraLdpTest {
                 .thenReturn(mockNonRdfSourceDescription);
         testObj.updateSparql(toInputStream("INSERT DATA { <> <http://some/predicate> \"xyz\" }", UTF_8));
         verify(updatePropertiesService).updateProperties(
-                eq(mockTransaction.getId()),
+                eq(mockTransaction),
                 anyString(),
                 eq(binaryDescId),
                 contains("<http://some/predicate> \"xyz\"")
@@ -1123,7 +1123,7 @@ public class FedoraLdpTest {
                 toInputStream("_:a <info:b> _:c .", UTF_8), null, null);
         assertEquals(CREATED.getStatusCode(), actual.getStatus());
         verify(createResourceService).perform(
-                eq(mockTransaction.getId()),
+                eq(mockTransaction),
                 anyString(),
                 eq(finalId),
                any(),
@@ -1142,7 +1142,7 @@ public class FedoraLdpTest {
                 nonRDFSourceLink, null);
             assertEquals(CREATED.getStatusCode(), actual.getStatus());
             verify(createResourceService).perform(
-                    eq(mockTransaction.getId()),
+                    eq(mockTransaction),
                     any(),
                     eq(finalId),
                     eq(APPLICATION_OCTET_STREAM),
@@ -1164,7 +1164,7 @@ public class FedoraLdpTest {
         try (final InputStream content = toInputStream("x", UTF_8)) {
             final RuntimeException ex = new RuntimeException(new IOException("root exception", new IOException(
                     FedoraLdp.INSUFFICIENT_SPACE_IDENTIFYING_MESSAGE)));
-            doThrow(ex).when(createResourceService).perform(anyString(), anyString(), eq(finalId), anyString(),
+            doThrow(ex).when(createResourceService).perform(any(), anyString(), eq(finalId), anyString(),
                     anyString(), any(Long.class), anyList(), isNull(), any(InputStream.class), isNull());
 
             testObj.createObject(null, APPLICATION_OCTET_STREAM_TYPE, "b", content, nonRDFSourceLink, null);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -17,91 +17,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterators;
-import nu.validator.htmlparser.sax.HtmlParser;
-import nu.validator.saxtree.TreeBuilder;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.FileEntity;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.apache.http.util.EntityUtils;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.vocabulary.DC_11;
-import org.apache.jena.vocabulary.RDF;
-import org.fcrepo.http.commons.domain.RDFMediaType;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.glassfish.jersey.media.multipart.ContentDisposition;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.springframework.test.context.TestExecutionListeners;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Variant;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.io.Writer;
-import java.net.URI;
-import java.text.ParseException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.Random;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.TimeUnit;
-
 import static java.lang.Thread.sleep;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.ZoneId.of;
@@ -208,6 +123,89 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.URI;
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.Variant;
+
+import org.fcrepo.http.commons.domain.RDFMediaType;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.DC_11;
+import org.apache.jena.vocabulary.RDF;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.springframework.test.context.TestExecutionListeners;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
+
+import nu.validator.htmlparser.sax.HtmlParser;
+import nu.validator.saxtree.TreeBuilder;
+
 /**
  * @author cabeer
  * @author ajs6f
@@ -268,18 +266,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final DateTimeFormatter tripleFormat =
       DateTimeFormatter.ISO_INSTANT.withZone(of("GMT"));
-
-    private static ExecutorService executor;
-
-    @BeforeClass
-    public static void beforeClass() {
-        executor = Executors.newCachedThreadPool();
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        executor.shutdown();
-    }
 
     @Test
     public void testHeadRepositoryGraph() throws IOException {
@@ -4357,18 +4343,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
             binaryEtag = response.getFirstHeader("ETag").getValue();
         }
 
-        final PutThread[] threads = new PutThread[] {
-                new PutThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 1")),
-                new PutThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 2")),
-                new PutThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 3")),
-                new PutThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 4"))  };
+        final RequestThread[] threads = new RequestThread[] {
+                new RequestThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 1")),
+                new RequestThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 2")),
+                new RequestThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 3")),
+                new RequestThread(putBinaryObjMethodIfMatch(path, binaryEtag, "thread 4"))  };
 
-        for (final PutThread t : threads) {
+        for (final RequestThread t : threads) {
             t.start();
         }
 
-        final List<PutThread> successfulThreads = new ArrayList<>();
-        for (final PutThread t : threads) {
+        final List<RequestThread> successfulThreads = new ArrayList<>();
+        for (final RequestThread t : threads) {
             t.join(1000);
             assertFalse("Thread " + t.getId() + " could not perform its operation in time!", t.isAlive());
             final int status = t.response.getStatusLine().getStatusCode();
@@ -4381,22 +4367,22 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals("Only one PUT request should have been successful!", 1, successfulThreads.size());
     }
 
-    private class PutThread extends Thread {
+    private static class RequestThread extends Thread {
 
-        private final HttpPut put;
+        private final HttpUriRequest request;
 
         private HttpResponse response;
 
-        public PutThread(final HttpPut put) {
-            this.put = put;
+        public RequestThread(final HttpUriRequest request) {
+            this.request = request;
         }
 
         @Override
         public void run() {
             try {
-                response = execute(put);
+                response = execute(request);
             } catch (final IOException e) {
-                LOGGER.error("Thread " + Thread.currentThread().getId() + ", failed to PUT resource!", e);
+                LOGGER.error("Thread " + Thread.currentThread().getId() + ", failed to request!", e);
             }
 
         }
@@ -4415,26 +4401,27 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String path = getRandomUniqueId();
         executeAndClose(putObjMethod(path));
 
-        final var phaser = new Phaser(3);
-        final var futures = new ArrayList<Future<Integer>>();
+        final RequestThread[] threads = new RequestThread[] {
+                new RequestThread(patchWithSparql(path,
+                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'one' . }")),
+                new RequestThread(patchWithSparql(path,
+                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }")),
+                new RequestThread(patchWithSparql(path,
+                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'three' . }")),
+                new RequestThread(patchWithSparql(path,
+                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'four' . }"))
+        };
 
-        futures.add(executor.submit(() -> {
-            phaser.arriveAndAwaitAdvance();
-            return patchWithSparql(path,
-                    "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'one' . }");
-        }));
-        futures.add(executor.submit(() -> {
-            phaser.arriveAndAwaitAdvance();
-            return patchWithSparql(path,
-                    "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }");
-        }));
-
-        phaser.arriveAndAwaitAdvance();
+        for (final RequestThread t : threads) {
+            t.start();
+        }
 
         var successCount = 0;
-
-        for (final var future : futures) {
-            if (future.get().equals(204)) {
+        for (final RequestThread t : threads) {
+            t.join(1000);
+            assertFalse("Thread " + t.getId() + " could not perform its operation in time!", t.isAlive());
+            final int status = t.response.getStatusLine().getStatusCode();
+            if (status == 204) {
                 successCount++;
             }
         }
@@ -4442,16 +4429,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals("Exactly one patch should have succeeded", 1, successCount);
     }
 
-    private int patchWithSparql(final String path, final String sparqlUpdate) {
+    private HttpPatch patchWithSparql(final String path, final String sparqlUpdate) {
         try {
             final HttpPatch patch = new HttpPatch(serverAddress + path);
             patch.addHeader(CONTENT_TYPE, "application/sparql-update");
             patch.setEntity(new StringEntity(sparqlUpdate));
-            final CloseableHttpResponse r = client.execute(patch);
-            final int code = r.getStatusLine().getStatusCode();
-            r.close();
-            return code;
-        } catch (final IOException e) {
+            return patch;
+        } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4396,47 +4396,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testConcurrentPatchesOnlyOneShouldSucceed() throws Exception {
-        // create a resource
-        final String path = getRandomUniqueId();
-        executeAndClose(putObjMethod(path));
-
-        final RequestThread[] threads = new RequestThread[] {
-                new RequestThread(patchWithSparql(path,
-                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'one' . }")),
-                new RequestThread(patchWithSparql(path,
-                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }"))
-        };
-
-        for (final RequestThread t : threads) {
-            t.start();
-        }
-
-        var successCount = 0;
-        for (final RequestThread t : threads) {
-            t.join(1000);
-            assertFalse("Thread " + t.getId() + " could not perform its operation in time!", t.isAlive());
-            final int status = t.response.getStatusLine().getStatusCode();
-            if (status == 204) {
-                successCount++;
-            }
-        }
-
-        assertEquals("Exactly one patch should have succeeded", 1, successCount);
-    }
-
-    private HttpPatch patchWithSparql(final String path, final String sparqlUpdate) {
-        try {
-            final HttpPatch patch = new HttpPatch(serverAddress + path);
-            patch.addHeader(CONTENT_TYPE, "application/sparql-update");
-            patch.setEntity(new StringEntity(sparqlUpdate));
-            return patch;
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
     public void testBinaryLastModified() throws Exception {
         final String objid = getRandomUniqueId();
         final String objURI = serverAddress + objid;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4405,11 +4405,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
                 new RequestThread(patchWithSparql(path,
                         "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'one' . }")),
                 new RequestThread(patchWithSparql(path,
-                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }")),
-                new RequestThread(patchWithSparql(path,
-                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'three' . }")),
-                new RequestThread(patchWithSparql(path,
-                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'four' . }"))
+                        "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }"))
         };
 
         for (final RequestThread t : threads) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4415,7 +4415,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String path = getRandomUniqueId();
         executeAndClose(putObjMethod(path));
 
-        final var phaser = new Phaser(5);
+        final var phaser = new Phaser(4);
         final var futures = new ArrayList<Future<Integer>>();
 
         futures.add(executor.submit(() -> {
@@ -4432,11 +4432,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
             phaser.arriveAndAwaitAdvance();
             return patchWithSparql(path,
                     "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'three' . }");
-        }));
-        futures.add(executor.submit(() -> {
-            phaser.arriveAndAwaitAdvance();
-            return patchWithSparql(path,
-                    "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'four' . }");
         }));
 
         phaser.arriveAndAwaitAdvance();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4415,7 +4415,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final String path = getRandomUniqueId();
         executeAndClose(putObjMethod(path));
 
-        final var phaser = new Phaser(4);
+        final var phaser = new Phaser(3);
         final var futures = new ArrayList<Future<Integer>>();
 
         futures.add(executor.submit(() -> {
@@ -4427,11 +4427,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
             phaser.arriveAndAwaitAdvance();
             return patchWithSparql(path,
                     "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'two' . }");
-        }));
-        futures.add(executor.submit(() -> {
-            phaser.arriveAndAwaitAdvance();
-            return patchWithSparql(path,
-                    "PREFIX dc: <http://purl.org/dc/elements/1.1/>\nINSERT DATA { <> dc:identifier 'three' . }");
         }));
 
         phaser.arriveAndAwaitAdvance();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
+import org.slf4j.Logger;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author pwinckles
+ */
+@Provider
+public class ConcurrentUpdateExceptionMapper implements
+        ExceptionMapper<ConcurrentUpdateException>, ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(ConcurrentUpdateExceptionMapper.class);
+
+    @Override
+    public Response toResponse(final ConcurrentUpdateException e) {
+        debugException(this, e, LOGGER);
+        return status(Response.Status.CONFLICT).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
@@ -17,6 +17,9 @@
  */
 package org.fcrepo.kernel.api;
 
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
 import java.time.Duration;
 import java.time.Instant;
 
@@ -76,12 +79,13 @@ public interface Transaction {
     /**
      * Expire a transaction
      */
-    public void expire();
+    void expire();
 
     /**
      * Has the transaction expired?
+     * @return true if expired
      */
-    public boolean hasExpired();
+    boolean hasExpired();
 
     /**
     * Update the expiry by the provided amount
@@ -100,6 +104,21 @@ public interface Transaction {
      * Refresh the transaction to extend its expiration window.
      */
     void refresh();
+
+    /**
+     * Acquires a lock on the specified resource for this transaction.
+     *
+     * @param resourceId the resource to lock
+     * @throws ConcurrentUpdateException if the lock cannot be acquired
+     */
+    void lockResource(final FedoraId resourceId);
+
+    /**
+     * Releases any resource locks held by the transaction if the session is short-lived. This method should always be
+     * called after handling a request, regardless of the outcome, so that any held locks are released immediately
+     * without having to wait for the short-lived transaction to expire.
+     */
+    void releaseResourceLocksIfShortLived();
 
     /**
      * Sets the baseUri on the transaction

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * This exception indicates that a resource could not be modified because it is currently being modified by another
+ * transaction.
+ *
+ * @author pwinckles
+ */
+public class ConcurrentUpdateException extends RepositoryRuntimeException {
+
+    /**
+     * Constructor
+     *
+     * @param msg message
+     */
+    public ConcurrentUpdateException(final String msg) {
+        super(msg);
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/lock/ResourceLockManager.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/lock/ResourceLockManager.java
@@ -15,31 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.fcrepo.kernel.api.services;
 
-import org.apache.jena.rdf.model.Model;
-import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.exception.MalformedRdfException;
+package org.fcrepo.kernel.api.lock;
+
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 /**
- * @author peichman
- * @since 6.0.0
+ * Responsible for managing write locks on Fedora resources
+ *
+ * @author pwinckles
  */
-public interface ReplacePropertiesService {
+public interface ResourceLockManager {
 
     /**
-     * Replace the properties of this object with the properties from the given
-     * model
+     * Acquires a lock on the resource, associating it to the txId. If the lock is held by a different transaction,
+     * an exception is thrown. If the lock is already held by the same transaction, then it returns successfully.
      *
-     * @param tx the Transaction
-     * @param userPrincipal the user performing the service
-     * @param fedoraId the internal Id of the fedora resource to update
-     * @param inputModel the model built from the body of the request
-     * @throws MalformedRdfException if malformed rdf exception occurred
+     * @param txId the transaction id to associate the lock to
+     * @param resourceId the resource to lock
+     * @throws ConcurrentUpdateException when lock cannot be acquired
      */
-    void perform(Transaction tx,
-                 String userPrincipal,
-                 FedoraId fedoraId,
-                 Model inputModel) throws MalformedRdfException;
+    void acquire(final String txId, final FedoraId resourceId);
+
+    /**
+     * Releases all of the locks held by the transaction
+     *
+     * @param txId the transaction id
+     */
+    void releaseAll(final String txId);
+
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/ResourceHeaders.java
@@ -45,6 +45,14 @@ public interface ResourceHeaders {
     FedoraId getParent();
 
     /**
+     * Get the identifier of the archival group resource that contains this resource, or null if the resource is not
+     * an archival part resource
+     *
+     * @return identifier of the containing archival group resource or null
+     */
+    FedoraId getArchivalGroupId();
+
+    /**
      * Get the State Token value for the resource.
      *
      * @return state-token value
@@ -136,7 +144,7 @@ public interface ResourceHeaders {
 
     /**
      * Determine whether a resource is the object root
-     * @return
+     * @return true if the resource is at the root of a persistence object
      */
     boolean isObjectRoot();
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateResourceOperation.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/CreateResourceOperation.java
@@ -49,7 +49,7 @@ public interface CreateResourceOperation extends ResourceOperation {
 
     /**
      * A flag indicating whether or the new resource should be created as an archival group.
-     * @return
+     * @return true if archival group
      */
-    public boolean isArchivalGroup();
+    boolean isArchivalGroup();
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/CreateResourceService.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.api.services;
 
 import org.apache.jena.rdf.model.Model;
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
 
@@ -36,7 +37,7 @@ public interface CreateResourceService {
     /**
      * Create a new NonRdfSource resource.
      *
-     * @param txId The transaction ID for the request.
+     * @param tx The transaction for the request.
      * @param userPrincipal the principal of the user performing the service
      * @param fedoraId The internal identifier of the resource.
      * @param contentType The content-type header or null if none.
@@ -47,20 +48,20 @@ public interface CreateResourceService {
      * @param requestBody The request body or null if none.
      * @param externalContent The external content handler or null if none.
      */
-    void perform(String txId, String userPrincipal, FedoraId fedoraId,
-            String contentType, String filename, long contentSize, List<String> linkHeaders,
-            Collection<URI> digest, InputStream requestBody, ExternalContent externalContent);
+    void perform(Transaction tx, String userPrincipal, FedoraId fedoraId,
+                 String contentType, String filename, long contentSize, List<String> linkHeaders,
+                 Collection<URI> digest, InputStream requestBody, ExternalContent externalContent);
 
     /**
      * Create a new RdfSource resource.
      *
-     * @param txId The transaction ID for the request.
+     * @param tx The transaction for the request.
      * @param userPrincipal the principal of the user performing the service
      * @param fedoraId The internal identifier of the resource
      * @param linkHeaders The original LINK headers or null if none.
      * @param model The request body RDF as a Model
      */
-    void perform(String txId, String userPrincipal, FedoraId fedoraId,
+    void perform(Transaction tx, String userPrincipal, FedoraId fedoraId,
             List<String> linkHeaders, Model model);
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReplaceBinariesService.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
 
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ExternalContent;
 
@@ -34,7 +35,7 @@ public interface ReplaceBinariesService {
     /**
      * Replace an existing binary.
      *
-     * @param txId The transaction ID for the request.
+     * @param tx The transaction for the request.
      * @param userPrincipal the user performing the service
      * @param fedoraId The internal identifier of the parent.
      * @param filename The filename of the binary.
@@ -44,7 +45,7 @@ public interface ReplaceBinariesService {
      * @param contentBody The request body or null if none.
      * @param externalContent The external content handler or null if none.
      */
-    void perform(String txId,
+    void perform(Transaction tx,
                  String userPrincipal,
                  FedoraId fedoraId,
                  String filename,

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/UpdatePropertiesService.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -30,14 +31,14 @@ public interface UpdatePropertiesService {
    * Update the provided properties with a SPARQL Update query. The updated
    * properties may be serialized to the persistence layer.
    *
-   * @param txId the Transaction Id
+   * @param tx the Transaction
    * @param userPrincipal the user performing the service
    * @param fedoraId the internal Id of the fedora resource to update
    * @param sparqlUpdateStatement sparql update statement
    * @throws MalformedRdfException if malformed rdf exception occurred
    * @throws AccessDeniedException if access denied in updating properties
    */
-  void updateProperties(final String txId,
+  void updateProperties(final Transaction tx,
                         final String userPrincipal,
                         final FedoraId fedoraId,
                         final String sparqlUpdateStatement) throws MalformedRdfException, AccessDeniedException;

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -68,6 +68,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
 
     <!-- test gear -->
     <dependency>

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -22,6 +22,7 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
+import org.fcrepo.kernel.api.lock.ResourceLockManager;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.services.MembershipService;
 import org.fcrepo.kernel.api.services.ReferenceService;
@@ -73,6 +74,9 @@ public class TransactionManagerImpl implements TransactionManager {
 
     @Inject
     private MembershipService membershipService;
+
+    @Inject
+    private ResourceLockManager resourceLockManager;
 
     private TransactionTemplate transactionTemplate;
 
@@ -178,4 +182,9 @@ public class TransactionManagerImpl implements TransactionManager {
     protected TransactionTemplate getTransactionTemplate() {
         return transactionTemplate;
     }
+
+    protected ResourceLockManager getResourceLockManager() {
+        return resourceLockManager;
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManager.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManager.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.lock;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.Sets;
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.lock.ResourceLockManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * In memory resource lock manager
+ *
+ * @author pwinckles
+ */
+@Component
+public class InMemoryResourceLockManager implements ResourceLockManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InMemoryResourceLockManager.class);
+
+    private final Map<String, Set<String>> transactionLocks;
+    private final Set<String> lockedResources;
+    private final Map<String, Object> internalResourceLocks;
+
+    public InMemoryResourceLockManager() {
+        transactionLocks = new ConcurrentHashMap<>();
+        lockedResources = Sets.newConcurrentHashSet();
+        internalResourceLocks = Caffeine.newBuilder()
+                .expireAfterAccess(10, TimeUnit.MINUTES)
+                .<String, Object>build()
+                .asMap();
+    }
+
+    @Override
+    public void acquire(final String txId, final FedoraId resourceId) {
+        final var resourceIdStr = resourceId.getResourceId();
+
+        if (transactionHoldsLock(txId, resourceIdStr)) {
+            return;
+        }
+
+        synchronized (acquireInternalLock(resourceIdStr)) {
+            if (transactionHoldsLock(txId, resourceIdStr)) {
+                return;
+            }
+
+            if (lockedResources.contains(resourceIdStr)) {
+                throw new ConcurrentUpdateException(
+                        String.format("Cannot update %s because it is being updated by another transaction.",
+                                resourceIdStr));
+            }
+
+            LOG.debug("Transaction {} acquiring lock on {}", txId, resourceIdStr);
+
+            lockedResources.add(resourceIdStr);
+            transactionLocks.computeIfAbsent(txId, key -> Sets.newConcurrentHashSet())
+                    .add(resourceIdStr);
+        }
+    }
+
+    @Override
+    public void releaseAll(final String txId) {
+        final var locks = transactionLocks.remove(txId);
+        if (locks != null) {
+            locks.forEach(resourceId -> {
+                LOG.debug("Transaction {} releasing lock on {}", txId, resourceId);
+                synchronized (acquireInternalLock(resourceId)) {
+                    lockedResources.remove(resourceId);
+                    internalResourceLocks.remove(resourceId);
+                }
+            });
+        }
+    }
+
+    private Object acquireInternalLock(final String resourceId) {
+        return internalResourceLocks.computeIfAbsent(resourceId, key -> new Object());
+    }
+
+    private boolean transactionHoldsLock(final String txId, final String resourceId) {
+        final var locks = transactionLocks.get(txId);
+        return locks != null && locks.contains(resourceId);
+    }
+
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImpl.java
@@ -59,6 +59,10 @@ public class DeleteResourceServiceImpl extends AbstractDeleteResourceService imp
         final ResourceOperation deleteOp = deleteResourceFactory.deleteBuilder(fedoraId)
                 .userPrincipal(userPrincipal)
                 .build();
+
+        lockArchivalGroupResource(tx, pSession, fedoraId);
+        tx.lockResource(fedoraId);
+
         pSession.persist(deleteOp);
         membershipService.resourceDeleted(tx.getId(), fedoraId);
         containmentIndex.removeResource(tx.getId(), fedoraId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImpl.java
@@ -58,6 +58,10 @@ public class PurgeResourceServiceImpl extends AbstractDeleteResourceService impl
         final ResourceOperation purgeOp = deleteResourceFactory.purgeBuilder(resourceId)
                 .userPrincipal(userPrincipal)
                 .build();
+
+        lockArchivalGroupResource(tx, pSession, resourceId);
+        tx.lockResource(resourceId);
+
         pSession.persist(purgeOp);
         containmentIndex.purgeResource(tx.getId(), resourceId);
         recordEvent(tx.getId(), resourceId, purgeOp);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/VersionServiceImpl.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.services;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -49,6 +50,16 @@ public class VersionServiceImpl extends AbstractService implements VersionServic
         final var operation = versionOperationFactory.createBuilder(fedoraId)
                 .userPrincipal(userPrincipal)
                 .build();
+
+        lockArchivalGroupResource(transaction, session, fedoraId);
+        final var headers = session.getHeaders(fedoraId, null);
+        if (RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI.equals(headers.getInteractionModel())) {
+            transaction.lockResource(fedoraId.asBaseId());
+        }
+        if (RdfLexicon.NON_RDF_SOURCE.toString().equals(headers.getInteractionModel())) {
+            transaction.lockResource(fedoraId.asDescription());
+        }
+        transaction.lockResource(fedoraId);
 
         try {
             session.persist(operation);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/WebacAclServiceImpl.java
@@ -82,6 +82,10 @@ public class WebacAclServiceImpl extends AbstractService implements WebacAclServ
                 .relaxedProperties(model)
                 .userPrincipal(userPrincipal)
                 .build();
+
+        lockArchivalGroupResourceFromParent(transaction, pSession, fedoraId.asBaseId());
+        transaction.lockResource(fedoraId);
+
         try {
             pSession.persist(createOp);
             recordEvent(transaction.getId(), fedoraId, createOp);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManagerTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManagerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.lock;
+
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.lock.ResourceLockManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author pwinckles
+ */
+public class InMemoryResourceLockManagerTest {
+
+    private ResourceLockManager lockManager;
+
+    private static ExecutorService executor;
+
+    private String txId1;
+    private String txId2;
+    private FedoraId resourceId;
+
+    @BeforeClass
+    public static void beforeClass() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        executor.shutdown();
+    }
+
+    @Before
+    public void setup() {
+        lockManager = new InMemoryResourceLockManager();
+        txId1 = UUID.randomUUID().toString();
+        txId2 = UUID.randomUUID().toString();
+        resourceId = randomResourceId();
+    }
+
+    @Test
+    public void shouldLockResourceWhenNotAlreadyLocked() {
+        lockManager.acquire(txId1, resourceId);
+    }
+
+    @Test
+    public void sameTxShouldBeAbleToReacquireLockItAlreadyHolds() {
+        lockManager.acquire(txId1, resourceId);
+        lockManager.acquire(txId1, resourceId);
+    }
+
+    @Test
+    public void shouldFailToAcquireLockWhenHeldByAnotherTx() {
+        lockManager.acquire(txId1, resourceId);
+        assertLockException(() -> {
+            lockManager.acquire(txId2, resourceId);
+        });
+    }
+
+    @Test
+    public void shouldAcquireLockAfterReleasedByAnotherTx() {
+        lockManager.acquire(txId1, resourceId);
+        lockManager.releaseAll(txId1);
+        lockManager.acquire(txId2, resourceId);
+    }
+
+    @Test
+    public void concurrentRequestsFromSameTxShouldBothSucceedWhenLockAvailable()
+            throws ExecutionException, InterruptedException {
+        final var phaser = new Phaser(3);
+
+        final var future1 = executor.submit(() -> {
+            phaser.arriveAndAwaitAdvance();
+            lockManager.acquire(txId1, resourceId);
+            return true;
+        });
+        final var future2 = executor.submit(() -> {
+            phaser.arriveAndAwaitAdvance();
+            lockManager.acquire(txId1, resourceId);
+            return true;
+        });
+
+        phaser.arriveAndAwaitAdvance();
+
+        assertTrue(future1.get());
+        assertTrue(future2.get());
+    }
+
+    @Test
+    public void concurrentRequestsFromDifferentTxesOnlyOneShouldSucceed()
+            throws ExecutionException, InterruptedException {
+        final var phaser = new Phaser(3);
+
+        final var future1 = executor.submit(() -> {
+            phaser.arriveAndAwaitAdvance();
+            try {
+                lockManager.acquire(txId1, resourceId);
+                return true;
+            } catch (ConcurrentUpdateException e) {
+                return false;
+            }
+        });
+        final var future2 = executor.submit(() -> {
+            phaser.arriveAndAwaitAdvance();
+            try {
+                lockManager.acquire(txId2, resourceId);
+                return true;
+            } catch (ConcurrentUpdateException e) {
+                return false;
+            }
+        });
+
+        phaser.arriveAndAwaitAdvance();
+
+        if (future1.get()) {
+            assertFalse("Only one tx should have acquired a lock", future2.get());
+        } else {
+            assertTrue("Only one tx should have acquired a lock", future2.get());
+        }
+    }
+
+    @Test
+    public void releasingAlreadyReleasedLocksShouldDoNothing() {
+        lockManager.acquire(txId1, resourceId);
+        lockManager.releaseAll(txId1);
+        lockManager.releaseAll(txId1);
+        lockManager.acquire(txId2, resourceId);
+    }
+
+    private void assertLockException(final Runnable runnable) {
+        try {
+            runnable.run();
+            fail("acquire should have thrown an exception");
+        } catch (ConcurrentUpdateException e) {
+            // expected exception
+        }
+    }
+
+    private FedoraId randomResourceId() {
+        return FedoraId.create(UUID.randomUUID().toString());
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -25,6 +25,7 @@ import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
 import org.fcrepo.kernel.api.services.MembershipService;
@@ -107,6 +108,15 @@ public class DeleteResourceServiceImplTest {
     @Mock
     private MembershipService membershipService;
 
+    @Mock
+    private ResourceHeaders resourceHeaders;
+    @Mock
+    private ResourceHeaders childHeaders;
+    @Mock
+    private ResourceHeaders descHeaders;
+    @Mock
+    private ResourceHeaders aclHeaders;
+
     @Captor
     private ArgumentCaptor<DeleteResourceOperation> operationCaptor;
 
@@ -132,6 +142,11 @@ public class DeleteResourceServiceImplTest {
         setField(service, "referenceService", referenceService);
         setField(service, "membershipService", membershipService);
         when(container.getFedoraId()).thenReturn(RESOURCE_ID);
+
+        when(pSession.getHeaders(RESOURCE_ID, null)).thenReturn(resourceHeaders);
+        when(pSession.getHeaders(CHILD_RESOURCE_ID, null)).thenReturn(childHeaders);
+        when(pSession.getHeaders(RESOURCE_DESCRIPTION_ID, null)).thenReturn(descHeaders);
+        when(pSession.getHeaders(RESOURCE_ACL_ID, null)).thenReturn(aclHeaders);
     }
 
     @After
@@ -174,6 +189,9 @@ public class DeleteResourceServiceImplTest {
         assertEquals(RESOURCE_ID, operations.get(1).getResourceId());
 
         assertEquals(0, containmentIndex.getContains(tx.getId(), RESOURCE_ID).count());
+
+        verify(tx).lockResource(RESOURCE_ID);
+        verify(tx).lockResource(CHILD_RESOURCE_ID);
     }
 
     private void verifyResourceOperation(final FedoraId fedoraID,
@@ -216,5 +234,10 @@ public class DeleteResourceServiceImplTest {
         assertEquals(RESOURCE_DESCRIPTION_ID, operations.get(0).getResourceId());
         assertEquals(RESOURCE_ACL_ID, operations.get(1).getResourceId());
         assertEquals(RESOURCE_ID, operations.get(2).getResourceId());
+
+        verify(tx).lockResource(RESOURCE_ID);
+        verify(tx).lockResource(RESOURCE_DESCRIPTION_ID);
+        verify(tx).lockResource(RESOURCE_ACL_ID);
     }
+
 }

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeadersImpl.java
@@ -35,6 +35,8 @@ public class ResourceHeadersImpl implements ResourceHeaders {
 
     private FedoraId parent;
 
+    private FedoraId archivalGroupId;
+
     private String stateToken;
 
     private String interactionModel;
@@ -89,6 +91,18 @@ public class ResourceHeadersImpl implements ResourceHeaders {
      */
     public void setParent(final FedoraId parent) {
         this.parent = parent;
+    }
+
+    @Override
+    public FedoraId getArchivalGroupId() {
+        return archivalGroupId;
+    }
+
+    /**
+     * @param archivalGroupId the archivalGroupId to set
+     */
+    public void setArchivalGroupId(final FedoraId archivalGroupId) {
+        this.archivalGroupId = archivalGroupId;
     }
 
     @Override
@@ -295,6 +309,31 @@ public class ResourceHeadersImpl implements ResourceHeaders {
      */
     public void setContentPath(final String contentPath) {
         this.contentPath = contentPath;
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceHeadersImpl{" +
+                "id=" + id +
+                ", parent=" + parent +
+                ", archivalGroupId=" + archivalGroupId +
+                ", stateToken='" + stateToken + '\'' +
+                ", interactionModel='" + interactionModel + '\'' +
+                ", mimeType='" + mimeType + '\'' +
+                ", filename='" + filename + '\'' +
+                ", contentSize=" + contentSize +
+                ", digests=" + digests +
+                ", externalUrl='" + externalUrl + '\'' +
+                ", externalHandling='" + externalHandling + '\'' +
+                ", createdDate=" + createdDate +
+                ", createdBy='" + createdBy + '\'' +
+                ", lastModifiedDate=" + lastModifiedDate +
+                ", lastModifiedBy='" + lastModifiedBy + '\'' +
+                ", archivalGroup=" + archivalGroup +
+                ", objectRoot=" + objectRoot +
+                ", deleted=" + deleted +
+                ", contentPath='" + contentPath + '\'' +
+                '}';
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -61,11 +61,13 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
      * @param operation The operation to perform the persistence routine on
      * @param objectSession The ocfl object session
      * @param rootIdentifier The fedora object root identifier associated with the resource to be persisted.
+     * @param isArchivalPart indicates if the resource is an AG part resource, ignored on update
      * @throws PersistentStorageException thrown if writing fails
      */
     protected void persistNonRDFSource(final ResourceOperation operation,
                                        final OcflObjectSession objectSession,
-                                       final FedoraId rootIdentifier)
+                                       final FedoraId rootIdentifier,
+                                       final boolean isArchivalPart)
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
 
@@ -74,8 +76,10 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
         final var nonRdfSourceOperation = (NonRdfSourceOperation) operation;
 
         final var headers = new ResourceHeadersAdapter(
-                createHeaders(objectSession, nonRdfSourceOperation,
-                resourceId.equals(rootIdentifier)));
+                createHeaders(objectSession,
+                        nonRdfSourceOperation,
+                        resourceId.equals(rootIdentifier),
+                        isArchivalPart ? rootIdentifier : null));
 
         if (forExternalBinary(nonRdfSourceOperation)) {
             objectSession.writeResource(headers.asStorageHeaders(), null);
@@ -105,13 +109,15 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
      * @param objSession the object session
      * @param op the operation being persisted
      * @param objectRoot flag indicating whether or not headerPath represents the object root resource
+     * @param archivalGroupId for AG parts, the id of the containg AG, otherwise null
      * @return populated resource headers
      */
     private ResourceHeadersImpl createHeaders(final OcflObjectSession objSession,
                                               final NonRdfSourceOperation op,
-                                              final boolean objectRoot) throws PersistentStorageException {
+                                              final boolean objectRoot,
+                                              final FedoraId archivalGroupId) throws PersistentStorageException {
 
-        final var headers = createCommonHeaders(objSession, op, objectRoot);
+        final var headers = createCommonHeaders(objSession, op, objectRoot, archivalGroupId);
 
         ResourceHeaderUtils.populateBinaryHeaders(headers,
                 op.getMimeType(),

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractPersister.java
@@ -87,18 +87,6 @@ abstract class AbstractPersister implements Persister {
         }
     }
 
-    /**
-     * Resolves the fedora root object identifier associated with the operation's resource identifier.
-     * @param fedoraId The fedoraId of the resource the being acted on
-     * @param session The OCFL persistent storage session.
-     * @return The fedora root object identifier associated with the resource described by the operation.
-     */
-    protected FedoraId resolveRootObjectId(final FedoraId fedoraId,
-                                       final OcflPersistentStorageSession session) {
-        final var archivalGroupId = findArchivalGroupInAncestry(fedoraId, session);
-        return archivalGroupId.orElseGet(fedoraId::asBaseId);
-    }
-
     protected Optional<FedoraId> findArchivalGroupInAncestry(final FedoraId fedoraId,
                                                              final OcflPersistentStorageSession session) {
             if (fedoraId.isRepositoryRoot()) {
@@ -142,7 +130,9 @@ abstract class AbstractPersister implements Persister {
 
     protected ResourceHeadersImpl createCommonHeaders(final OcflObjectSession session,
                                                       final ResourceOperation operation,
-                                                      final boolean isResourceRoot) throws PersistentStorageException {
+                                                      final boolean isResourceRoot,
+                                                      final FedoraId archivalGroupId)
+            throws PersistentStorageException {
         final var now = Instant.now();
 
         final ResourceHeadersImpl headers;
@@ -155,6 +145,7 @@ abstract class AbstractPersister implements Persister {
             ResourceHeaderUtils.touchCreationHeaders(headers, createOperation.getUserPrincipal(), now);
             headers.setArchivalGroup(createOperation.isArchivalGroup());
             headers.setObjectRoot(isResourceRoot);
+            headers.setArchivalGroupId(archivalGroupId);
         } else {
             headers = new ResourceHeadersAdapter(session.readHeaders(operation.getResourceId().getResourceId()))
                     .asKernelHeaders();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractRdfSourcePersister.java
@@ -61,17 +61,22 @@ abstract class AbstractRdfSourcePersister extends AbstractPersister {
      * @param objectSession The object session.
      * @param operation The operation
      * @param rootId The fedora root object identifier tha maps to the OCFL object root.
+     * @param isArchivalPart indicates if the resource is an AG part resource, ignored on update
      * @throws PersistentStorageException
      */
     protected void persistRDF(final OcflObjectSession objectSession,
                               final ResourceOperation operation,
-                              final FedoraId rootId) throws PersistentStorageException {
+                              final FedoraId rootId,
+                              final boolean isArchivalPart) throws PersistentStorageException {
 
         final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
         log.debug("persisting RDFSource ({}) to OCFL", operation.getResourceId());
 
-        final var headers = createHeaders(objectSession, rdfSourceOp,
-                operation.getResourceId().equals(rootId));
+        final var headers = createHeaders(
+                objectSession,
+                rdfSourceOp,
+                operation.getResourceId().equals(rootId),
+                isArchivalPart ? rootId : null);
 
         writeRdf(objectSession, headers, rdfSourceOp.getTriples());
     }
@@ -83,12 +88,14 @@ abstract class AbstractRdfSourcePersister extends AbstractPersister {
      * @param objSession the object session
      * @param operation the operation being persisted
      * @param objectRoot indicates this is the object root
+     * @param archivalGroupId for AG parts, the id of the containg AG, otherwise null
      * @return populated resource headers
      */
     private ResourceHeadersImpl createHeaders(final OcflObjectSession objSession,
                                           final RdfSourceOperation operation,
-                                          final boolean objectRoot) throws PersistentStorageException {
-        final var headers = createCommonHeaders(objSession, operation, objectRoot);
+                                          final boolean objectRoot,
+                                          final FedoraId archivalGroupId) throws PersistentStorageException {
+        final var headers = createCommonHeaders(objSession, operation, objectRoot, archivalGroupId);
         overrideRelaxedProperties(headers, operation);
         return headers;
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateNonRdfSourcePersister.java
@@ -49,10 +49,13 @@ class CreateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
             throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
         log.debug("persisting {} to {}", resourceId, session);
-        final var rootObjectId = resolveRootObjectId(resourceId, session);
+
+        final var archivalGroupId = findArchivalGroupInAncestry(resourceId, session);
+        final var rootObjectId = archivalGroupId.orElseGet(resourceId::asBaseId);
         final String ocflId = mapToOcflId(session.getId(), rootObjectId);
         final OcflObjectSession ocflObjectSession = session.findOrCreateSession(ocflId);
-        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.asBaseId());
+
+        persistNonRDFSource(operation, ocflObjectSession, rootObjectId.asBaseId(), archivalGroupId.isPresent());
         ocflIndex.addMapping(session.getId(), resourceId.asResourceId(), rootObjectId.asBaseId(), ocflId);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
@@ -158,6 +158,19 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
     }
 
     @Override
+    public FedoraId getArchivalGroupId() {
+        return kernelHeaders.getArchivalGroupId();
+    }
+
+    /**
+     * @param archivalGroupId the archivalGroupId to set
+     */
+    public void setArchivalGroupId(final FedoraId archivalGroupId) {
+        kernelHeaders.setArchivalGroupId(archivalGroupId);
+        storageHeaders.withArchivalGroupId(idToString(archivalGroupId));
+    }
+
+    @Override
     public String getStateToken() {
         return kernelHeaders.getStateToken();
     }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ResourceHeadersAdapter.java
@@ -60,6 +60,9 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
         if (storageHeaders.getParent() != null) {
             kernelHeaders.setParent(FedoraId.create(storageHeaders.getParent()));
         }
+        if (storageHeaders.getArchivalGroupId() != null) {
+            kernelHeaders.setArchivalGroupId(FedoraId.create(storageHeaders.getArchivalGroupId()));
+        }
         kernelHeaders.setArchivalGroup(storageHeaders.isArchivalGroup());
         kernelHeaders.setContentPath(storageHeaders.getContentPath());
         kernelHeaders.setContentSize(storageHeaders.getContentSize());
@@ -91,6 +94,9 @@ public class ResourceHeadersAdapter implements ResourceHeaders {
         }
         if (kernelHeaders.getParent() != null) {
             storageHeaders.withParent(kernelHeaders.getParent().getFullId());
+        }
+        if (kernelHeaders.getArchivalGroupId() != null) {
+            storageHeaders.withArchivalGroupId(kernelHeaders.getArchivalGroupId().getFullId());
         }
         storageHeaders.withArchivalGroup(kernelHeaders.isArchivalGroup());
         storageHeaders.withContentPath(kernelHeaders.getContentPath());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
@@ -64,6 +64,6 @@ class UpdateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
             }
         }
 
-        persistNonRDFSource(operation, objSession, rootIdentifier);
+        persistNonRDFSource(operation, objSession, rootIdentifier, false);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfSourcePersister.java
@@ -54,6 +54,6 @@ class UpdateRdfSourcePersister extends AbstractRdfSourcePersister {
         final var fedoraOcflMapping = getMapping(session.getId(), resourceId);
         final var ocflId = fedoraOcflMapping.getOcflObjectId();
         final OcflObjectSession objSession = session.findOrCreateSession(ocflId);
-        persistRDF(objSession, operation, fedoraOcflMapping.getRootObjectIdentifier());
+        persistRDF(objSession, operation, fedoraOcflMapping.getRootObjectIdentifier(), false);
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3123

**This PR requires https://github.com/fcrepo/fcrepo-storage-ocfl/pull/25 to work**

# What does this Pull Request do?

Adds resource locking so that a resource cannot be concurrently modified in different transaction.

In this implementation,

* A transaction holds a lock on a resource for the duration of the transaction
* The same transaction may modify a resource that it holds a lock on multiple times
* AGs are locked when any of their children are modified
* Binaries are locked when their description is modified
* Binary descriptions are locked when their binary is modified

# How should this be tested?

1. Create a resource
2. Start a transaction
3. Modify the resource in a transaction, but do not commit
4. Attempt to modify the same resource outside of the transaction. This should fail with a `409`.

# Interested parties
@fcrepo/committers
