### PR TITLE
enfoce id constraints

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -66,6 +66,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -101,6 +102,7 @@ import org.fcrepo.kernel.api.exception.CannotCreateResourceException;
 import org.fcrepo.kernel.api.exception.GhostNodeException;
 import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
@@ -153,6 +155,18 @@ public class FedoraLdp extends ContentExposingResource {
 
     @Inject
     protected ReplaceBinariesService replaceBinariesService;
+
+    private static final Set<String> FORBIDDEN_ID_PART_STRINGS = Set.of(
+            "fcr-root",
+            ".fcrepo",
+            "fcr-container.nt"
+    );
+    private static final Set<String> FORBIDDEN_ID_PART_SUFFIXES = Set.of(
+            "~fcr-desc",
+            "~fcr-acl",
+            "~fcr-desc.nt",
+            "~fcr-acl.nt"
+    );
 
     /**
      * Default JAX-RS entry point
@@ -385,7 +399,6 @@ public class FedoraLdp extends ContentExposingResource {
 
         try {
             final List<String> links = unpackLinks(rawLinks);
-
             if (externalPath.contains("/" + FedoraTypes.FCR_VERSIONS)) {
                 handleRequestDisallowedOnMemento();
 
@@ -398,6 +411,7 @@ public class FedoraLdp extends ContentExposingResource {
             final String interactionModel = checkInteractionModel(links);
 
             final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
+            validateFedoraId(fedoraId);
             final boolean resourceExists = doesResourceExist(transaction, fedoraId, true);
 
             if (resourceExists) {
@@ -599,6 +613,7 @@ public class FedoraLdp extends ContentExposingResource {
 
             final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
             final FedoraId newFedoraId = mintNewPid(fedoraId, slug);
+            validateFedoraId(newFedoraId);
             final var providedContentType = getSimpleContentType(requestContentType);
 
             LOGGER.info("POST to create resource with ID: {}, slug: {}", newFedoraId.getFullIdPath(), slug);
@@ -699,6 +714,32 @@ public class FedoraLdp extends ContentExposingResource {
         final Collection<URI> checksumResults = fixityService.getFixity(binary, preferredDigests);
         return checksumResults.stream().map(uri -> uri.toString().replaceFirst("urn:", "")
                 .replaceFirst(":", "=").replaceFirst("sha1=", "sha=")).collect(Collectors.joining(","));
+    }
+
+    /**
+     * Ensures that the Fedora ID does not violate any naming restrictions that are in place prevent collisions on disk.
+     * These restrictions are based on the following naming conventions:
+     *      https://wiki.lyrasis.org/display/FF/Design+-+Fedora+OCFL+Object+Structure
+     *
+     * All ids should be validated on resource creation
+     *
+     * @param fedoraId the id to validate
+     */
+    private void validateFedoraId(final FedoraId fedoraId) {
+        final var baseId = fedoraId.getBaseId();
+        final var finalPart = StringUtils.substringAfterLast(baseId, "/");
+
+        if (FORBIDDEN_ID_PART_STRINGS.contains(finalPart)) {
+            throw new InvalidResourceIdentifierException(
+                    String.format("Invalid resource ID. IDs may not contain the string '%s'.", finalPart));
+        }
+
+        FORBIDDEN_ID_PART_SUFFIXES.forEach(suffix -> {
+            if (finalPart.endsWith(suffix) && !finalPart.equals(suffix)) {
+                throw new InvalidResourceIdentifierException(
+                        String.format("Invalid resource ID. IDs may not end with '%s'.", suffix));
+            }
+        });
     }
 
     private static void ensureArchivalGroupHeaderNotPresentForBinaries(final List<String> links) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -5108,4 +5108,45 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
         }
     }
+
+    @Test
+    public void testIdConstraints() throws IOException {
+        assertIdStringConstraint(".fcrepo");
+        assertIdStringConstraint("fcr-root");
+        assertIdStringConstraint("fcr-container.nt");
+
+        assertIdSuffixConstraint("~fcr-desc");
+        assertIdSuffixConstraint("~fcr-acl");
+        assertIdSuffixConstraint("~fcr-desc.nt");
+        assertIdSuffixConstraint("~fcr-acl.nt");
+    }
+
+    private void assertIdStringConstraint(final String id) throws IOException {
+        assertInvalidId(id);
+        assertValidId(id + "-suffix");
+        assertValidId("prefix-" + id);
+    }
+
+    private void assertIdSuffixConstraint(final String suffix) throws IOException {
+        assertInvalidId("prefix" + suffix);
+        assertValidId(suffix);
+        assertValidId(suffix + "-suffix");
+    }
+
+    private void assertInvalidId(final String id) throws IOException {
+        final HttpPost postMethod = postObjMethod();
+        postMethod.setHeader("Slug", id);
+        try (final CloseableHttpResponse response = execute(postMethod)) {
+            assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
+        }
+    }
+
+    private void assertValidId(final String id) throws IOException {
+        final HttpPost postMethod = postObjMethod();
+        postMethod.setHeader("Slug", id);
+        try (final CloseableHttpResponse response = execute(postMethod)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+        }
+    }
+
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidResourceIdentifierExceptionMapper.java
@@ -44,12 +44,12 @@ public class InvalidResourceIdentifierExceptionMapper implements
 
     @Override
     public Response toResponse(final InvalidResourceIdentifierException e) {
-        LOGGER.warn("Invalid resource identifier", e);
+        debugException(this, e, LOGGER);
         return status(BAD_REQUEST).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 
     public Response toResponse(final String msg, final InvalidResourceIdentifierException e) {
-        LOGGER.warn("Invalid resource identifier", e);
+        debugException(this, e, LOGGER);
         return status(BAD_REQUEST).entity(msg).type(TEXT_PLAIN_WITH_CHARSET).build();
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3537

# What does this Pull Request do?

Enforces id constraints for strings that are problematic based on the storage layout: https://wiki.lyrasis.org/display/FF/Design+-+Fedora+OCFL+Object+Structure

# How should this be tested?

See the example queries in the jira: https://jira.lyrasis.org/browse/FCREPO-3537

# Interested parties
@fcrepo/committers
