### PR TITLE
Encode internal URIs in stored RDF documents.

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -138,7 +138,7 @@ public class FedoraAcl extends ContentExposingResource {
                     requestContentType == null ?
                             RDFMediaType.TURTLE_TYPE : valueOf(getSimpleContentType(requestContentType));
             if (isRdfContentType(contentType.toString())) {
-                final Model model = httpRdfService.bodyToInternalModel(aclId.getFullId(),
+                final Model model = httpRdfService.bodyToInternalModel(aclId,
                         requestBodyStream, contentType, identifierConverter(), hasLenientPreferHeader());
                 if (exists) {
                     replacePropertiesService.perform(transaction(), getUserPrincipal(), aclId, model);
@@ -208,7 +208,7 @@ public class FedoraAcl extends ContentExposingResource {
             evaluateRequestPreconditions(request, servletResponse, aclResource, transaction());
 
             LOGGER.info("PATCH for '{}'", externalPath);
-            final String newRequest = httpRdfService.patchRequestToInternalString(aclResource.getFedoraId().getFullId(),
+            final String newRequest = httpRdfService.patchRequestToInternalString(aclResource.getFedoraId(),
                     requestBody, identifierConverter());
             LOGGER.debug("PATCH request translated to '{}'", newRequest);
             patchResourcewithSparql(aclResource, newRequest);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -461,7 +461,7 @@ public class FedoraLdp extends ContentExposingResource {
                 }
             } else {
                 final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;
-                final Model model = httpRdfService.bodyToInternalModel(fedoraId.getFullId(), requestBodyStream,
+                final Model model = httpRdfService.bodyToInternalModel(fedoraId, requestBodyStream,
                         contentType, identifierConverter(), hasLenientPreferHeader());
 
                 if (resourceExists) {
@@ -523,7 +523,7 @@ public class FedoraLdp extends ContentExposingResource {
             evaluateRequestPreconditions(request, servletResponse, resource(), transaction);
 
             LOGGER.info("PATCH for '{}'", externalPath);
-            final String newRequest = httpRdfService.patchRequestToInternalString(resource().getFedoraId().getFullId(),
+            final String newRequest = httpRdfService.patchRequestToInternalString(resource().getFedoraId(),
                     requestBody, identifierConverter());
             LOGGER.debug("PATCH request translated to '{}'", newRequest);
             patchResourcewithSparql(resource(), newRequest);
@@ -627,7 +627,7 @@ public class FedoraLdp extends ContentExposingResource {
                         extContent);
             } else {
                 final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;
-                final Model model = httpRdfService.bodyToInternalModel(newFedoraId.getFullId(), requestBodyStream,
+                final Model model = httpRdfService.bodyToInternalModel(newFedoraId, requestBodyStream,
                         contentType, identifierConverter(), hasLenientPreferHeader());
                 createResourceService.perform(transaction,
                         getUserPrincipal(),

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3446,16 +3446,28 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-@Ignore
     public void testUpdateObjectWithSpaces() throws IOException {
         final String id = getRandomUniqueId() + " 2";
+        final String expectedUri = serverAddress + id.replace(" ", "%20");
         try (final CloseableHttpResponse createResponse = createObject(id)) {
             final String subjectURI = getLocation(createResponse);
+            assertEquals(expectedUri, subjectURI);
             final HttpPatch updateObjectGraphMethod = new HttpPatch(subjectURI);
             updateObjectGraphMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
             updateObjectGraphMethod.setEntity(new StringEntity(
                     "INSERT { <> <http://purl.org/dc/elements/1.1/title> \"test\" } WHERE {}"));
             assertEquals(NO_CONTENT.getStatusCode(), getStatus(updateObjectGraphMethod));
+        }
+        final HttpGet httpGet = new HttpGet(expectedUri);
+        try (final var dataset = getDataset(httpGet)) {
+            final var graph  = dataset.asDatasetGraph();
+            // Ensure the graph has an encoded URI too.
+            assertTrue(graph.contains(
+                    ANY,
+                    createURI(expectedUri),
+                    ANY,
+                    ANY
+            ));
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -3446,9 +3446,10 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testUpdateObjectWithSpaces() throws IOException {
+    public void testUpdateObjectWithSpacesPost() throws IOException {
         final String id = getRandomUniqueId() + " 2";
         final String expectedUri = serverAddress + id.replace(" ", "%20");
+        final String notExpectedUri = expectedUri.replace("%", "%25");
         try (final CloseableHttpResponse createResponse = createObject(id)) {
             final String subjectURI = getLocation(createResponse);
             assertEquals(expectedUri, subjectURI);
@@ -3465,6 +3466,47 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(graph.contains(
                     ANY,
                     createURI(expectedUri),
+                    ANY,
+                    ANY
+            ));
+            // Ensure it does not have a double encoded URI.
+            assertFalse(graph.contains(
+                    ANY,
+                    createURI(notExpectedUri),
+                    ANY,
+                    ANY
+            ));
+        }
+    }
+
+    @Test
+    public void testUpdateObjectWithSpacesPut() throws IOException {
+        final String id = getRandomUniqueId() + "%202";
+        final String expectedUri = serverAddress + id;
+        final String notExpectedUri = expectedUri.replace("%", "%25");
+        try (final CloseableHttpResponse createResponse = execute(putObjMethod(id))) {
+            final String subjectURI = getLocation(createResponse);
+            assertEquals(expectedUri, subjectURI);
+            final HttpPatch updateObjectGraphMethod = new HttpPatch(subjectURI);
+            updateObjectGraphMethod.addHeader(CONTENT_TYPE, "application/sparql-update");
+            updateObjectGraphMethod.setEntity(new StringEntity(
+                    "INSERT { <> <http://purl.org/dc/elements/1.1/title> \"test\" } WHERE {}"));
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(updateObjectGraphMethod));
+        }
+        final HttpGet httpGet = new HttpGet(expectedUri);
+        try (final var dataset = getDataset(httpGet)) {
+            final var graph  = dataset.asDatasetGraph();
+            // Ensure the graph has an encoded URI too.
+            assertTrue(graph.contains(
+                    ANY,
+                    createURI(expectedUri),
+                    ANY,
+                    ANY
+            ));
+            // Ensure it does not have a double encoded URI.
+            assertFalse(graph.contains(
+                    ANY,
+                    createURI(notExpectedUri),
                     ANY,
                     ANY
             ));

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -62,17 +62,6 @@ public class HttpIdentifierConverter {
     }
 
     /**
-     * TODO: This constructor should be removed!
-     * ..it is only used so that Spring can create this class... since it is unclear where the `UriBuilder` will come
-     * ..from when this class is expected to be injected into `ContentExposingResource.java`
-     */
-    public HttpIdentifierConverter() {
-        // nothing :(
-        this.uriBuilder = null;
-        this.uriTemplate = null;
-    }
-
-    /**
      * Convert an external URI to an internal ID.
      *
      * @param httpUri the external URI.
@@ -116,15 +105,7 @@ public class HttpIdentifierConverter {
             // If it starts with our prefix, strip the prefix and any leading slashes and use it as the path
             // part of the URI.
             final String path = fedoraId.substring(FEDORA_ID_PREFIX.length()).replaceFirst("\\/", "");
-            final UriBuilder uri = uriBuilder();
-            if (path.contains("#")) {
-                final String[] split = path.split("#", 2);
-                uri.resolveTemplate("path", split[0], false);
-                uri.fragment(split[1]);
-            } else {
-                uri.resolveTemplate("path", path, false);
-            }
-            return uri.build().toString();
+            return buildUri(path);
         }
         throw new IllegalArgumentException("Cannot translate IDs without our prefix");
     }
@@ -167,19 +148,7 @@ public class HttpIdentifierConverter {
             realPath = path;
         }
 
-        final UriBuilder uri = uriBuilder();
-
-        if (realPath.contains("#")) {
-
-            final String[] split = realPath.split("#", 2);
-
-            uri.resolveTemplate("path", split[0], false);
-            uri.fragment(split[1]);
-        } else {
-            uri.resolveTemplate("path", realPath, false);
-
-        }
-        return uri.build().toString();
+        return buildUri(realPath);
     }
 
     /**
@@ -188,7 +157,24 @@ public class HttpIdentifierConverter {
      * @return the FedoraId.
      */
     public FedoraId pathToInternalId(final String externalPath) {
-        return FedoraId.create(toInternalId(toDomain(externalPath)));
+        return FedoraId.create(externalPath);
+    }
+
+    /**
+     * Utility to build a URL.
+     * @param path the path from the internal Id.
+     * @return an external URI.
+     */
+    private String buildUri(final String path) {
+        final UriBuilder uri = uriBuilder();
+        if (path.contains("#")) {
+            final String[] split = path.split("#", 2);
+            uri.resolveTemplateFromEncoded("path", split[0]);
+            uri.fragment(split[1]);
+        } else {
+            uri.resolveTemplateFromEncoded("path", path);
+        }
+        return uri.build().toString();
     }
 
     /**

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -58,7 +58,7 @@ public class HttpIdentifierConverterTest {
     @Test(expected = IllegalArgumentException.class)
     public void testBlankUri() {
         final String testUri = "";
-        final String fedoraId = converter.toInternalId(testUri);
+        converter.toInternalId(testUri);
     }
 
     /**

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
@@ -439,6 +439,53 @@ public class FedoraIdTest {
         assertAsAcl("original/child#sad", "original/child/" + FCR_ACL);
     }
 
+    @Test
+    public void testEncodedId() {
+        // Slashes are not encoded.
+        final String normal = "/object/child";
+        final var normalId = FedoraId.create(normal);
+        assertEquals(FEDORA_ID_PREFIX + normal, normalId.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + normal, normalId.getFullId());
+        // Colons are not encoded.
+        final String withColon = "/object/test:prefix";
+        final var withColonId = FedoraId.create(withColon);
+        assertEquals(FEDORA_ID_PREFIX + withColon, withColonId.getEncodedFullId());
+        assertEquals( FEDORA_ID_PREFIX + withColon, withColonId.getFullId());
+        // Hashes are not encoded.
+        final String withHash = "/object/with#hash";
+        final var withHashId = FedoraId.create(withHash);
+        assertEquals(FEDORA_ID_PREFIX + withHash, withHashId.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + withHash, withHashId.getFullId());
+        // Query string characters (? & =) are not encoded.
+        final String withQueryString = "/object/with?query=parameters&for=uris";
+        final var withQueryStringId = FedoraId.create(withQueryString);
+        assertEquals(FEDORA_ID_PREFIX + withQueryString, withQueryStringId.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + withQueryString, withQueryStringId.getFullId());
+        // Plus and minus (hyphens) signs are not encoded
+        final String plus_sign = "/object/one+two/three-four";
+        final var plus_signId = FedoraId.create(plus_sign);
+        assertEquals(FEDORA_ID_PREFIX + plus_sign, plus_signId.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + plus_sign, plus_signId.getFullId());
+        // Remaining URI sub-deliminators are not encoded
+        final String sub_delims = "/object/with!/some$weird/possibly'unstable/group(ing)/all*/comma,comma/and;this";
+        final var sub_delimsId = FedoraId.create(sub_delims);
+        assertEquals(FEDORA_ID_PREFIX + sub_delims, sub_delimsId.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + sub_delims, sub_delimsId.getFullId());
+
+        // Spaces ARE encoded.
+        final String with_space = "/object/has a space";
+        final var with_space_id = FedoraId.create(with_space);
+        assertEquals(FEDORA_ID_PREFIX + "/object/has%20a%20space", with_space_id.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + with_space, with_space_id.getFullId());
+
+        // Encoded spaces are double encoded
+        final String with_encoded_space = "/object/has%20a%20space";
+        final var with_encoded_space_id = FedoraId.create(with_encoded_space);
+        assertEquals(FEDORA_ID_PREFIX + "/object/has%2520a%2520space", with_encoded_space_id.getEncodedFullId());
+        assertEquals(FEDORA_ID_PREFIX + with_encoded_space, with_encoded_space_id.getFullId());
+
+    }
+
     private void assertAsMemento(final String original, final String expected) {
         final var id = FedoraId.create(original);
         assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3539

# What does this Pull Request do?
* Adds a new `getEncodedFullId()` method to the `FedoraId` class to ensure when clients use spaces in their IDs they don't mess up the RDF.  
* It stops encoding the path as it is translated from internal to external URIs.
* Removes the `bodyToInternalStream()` method as it was only referenced by its own test.

# How should this be tested?

Create objects with complex and strange URIs both as POST and PUT and ensure that the resulting graph looks correct.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
