### PR TITLE
fixed MySQL transaction problems and improved commit robustness

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -291,7 +291,7 @@ public class TransactionsIT extends AbstractResourceIT {
     }
 
     @Test
-    public void rollbackFailsWhenAutoVersioningNotUsed() throws IOException {
+    public void rollbackSucceedsWhenAutoVersioningNotUsedAndFailureInDbCommit() throws IOException {
         objectSessionFactory.setDefaultCommitType(CommitType.UNVERSIONED);
 
         final String txLocation1 = createTransaction();
@@ -321,10 +321,10 @@ public class TransactionsIT extends AbstractResourceIT {
         assertEquals("Rolled back transaction should be gone",
                 GONE.getStatusCode(), getStatus(new HttpGet(txLocation2)));
 
-        // bin1 was not rolled back because it has an active mutable head
-        assertBinaryContent("test 1 -- updated!", bin1, null);
+        // bin1 was not changed
+        assertBinaryContent("test 1", bin1, null);
 
-        // bin2 was rolled back because it does not have a mutable head
+        // bin2 was rolled back
         assertEquals("Expected to not find our object after rollback",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(serverAddress + bin2)));
         assertObjectDoesNotExistOnDisk(FedoraId.create(bin2));

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -17,38 +17,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
-import org.fcrepo.common.lang.CheckedRunnable;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.kernel.api.ContainmentIndex;
-import org.fcrepo.kernel.api.identifiers.FedoraId;
-import org.fcrepo.storage.ocfl.CommitType;
-import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.springframework.test.context.TestExecutionListeners;
-
-import javax.ws.rs.core.Response.Status;
-import java.io.IOException;
-import java.time.format.DateTimeParseException;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static java.lang.Math.min;
 import static java.lang.Thread.sleep;
 import static javax.ws.rs.core.HttpHeaders.CACHE_CONTROL;
@@ -81,6 +49,43 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.fcrepo.common.lang.CheckedRunnable;
+import org.fcrepo.config.OcflPropsConfig;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.storage.ocfl.CommitType;
+import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.test.context.TestExecutionListeners;
+
 /**
  * <p>TransactionsIT class.</p>
  *
@@ -99,11 +104,13 @@ public class TransactionsIT extends AbstractResourceIT {
 
     private DefaultOcflObjectSessionFactory objectSessionFactory;
     private ContainmentIndex containmentIndex;
+    private OcflPropsConfig ocflConfig;
 
     @Before
     public void setup() {
         objectSessionFactory = getBean(DefaultOcflObjectSessionFactory.class);
         containmentIndex = getBean("containmentIndex", ContainmentIndex.class);
+        ocflConfig = getBean(OcflPropsConfig.class);
     }
 
     @After
@@ -328,6 +335,100 @@ public class TransactionsIT extends AbstractResourceIT {
         assertEquals("Expected to not find our object after rollback",
                 NOT_FOUND.getStatusCode(), getStatus(new HttpGet(serverAddress + bin2)));
         assertObjectDoesNotExistOnDisk(FedoraId.create(bin2));
+    }
+
+    @Test
+    public void rollbackFailsWhenAutoVersioningNotUsedAndFailureInOcflCommit() throws IOException {
+        objectSessionFactory.setDefaultCommitType(CommitType.UNVERSIONED);
+
+        final String txLocation1 = createTransaction();
+
+        // need prefix so they're ordered deterministically
+        final var bin1 = "1" + UUID.randomUUID().toString();
+        final var bin2 = "2" + UUID.randomUUID().toString();
+        final var bin3 = "3" + UUID.randomUUID().toString();
+
+        putBinary(bin1, txLocation1, "test 1");
+        putBinary(bin3, txLocation1, "test 3");
+
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation1)));
+
+        assertBinaryContent("test 1", bin1, null);
+        assertBinaryContent("test 3", bin3, null);
+
+        final String txLocation2 = createTransaction();
+
+        putBinary(bin1, txLocation2, "test 1 -- updated!");
+        putBinary(bin2, txLocation2, "test 2 -- I'm new!");
+        putBinary(bin3, txLocation2, "test 3 -- updated!");
+
+        assertBinaryContent("test 1 -- updated!", bin1, txLocation2);
+        assertBinaryContent("test 2 -- I'm new!", bin2, txLocation2);
+
+        corruptStagedBinary(bin3);
+
+        // Commit transaction -- should fail
+        assertEquals(CONFLICT.getStatusCode(), getStatus(new HttpPut(txLocation2)));
+
+        assertEquals("Rolled back transaction should be gone",
+                GONE.getStatusCode(), getStatus(new HttpGet(txLocation2)));
+
+        // bin1 was not rolled back
+        assertBinaryContent("test 1 -- updated!", bin1, null);
+
+        // bin2 was rolled back
+        assertEquals("Expected to not find our object after rollback",
+                NOT_FOUND.getStatusCode(), getStatus(new HttpGet(serverAddress + bin2)));
+        assertObjectDoesNotExistOnDisk(FedoraId.create(bin2));
+
+        // bin1 was not committed
+        assertBinaryContent("test 3", bin3, null);
+    }
+
+    @Test
+    public void rollbackSucceedsWhenAutoVersioningUsedAndFailureInOcflCommit() throws IOException {
+        final String txLocation1 = createTransaction();
+
+        // need prefix so they're ordered deterministically
+        final var bin1 = "1" + UUID.randomUUID().toString();
+        final var bin2 = "2" + UUID.randomUUID().toString();
+        final var bin3 = "3" + UUID.randomUUID().toString();
+
+        putBinary(bin1, txLocation1, "test 1");
+        putBinary(bin3, txLocation1, "test 3");
+
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpPut(txLocation1)));
+
+        assertBinaryContent("test 1", bin1, null);
+        assertBinaryContent("test 3", bin3, null);
+
+        final String txLocation2 = createTransaction();
+
+        putBinary(bin1, txLocation2, "test 1 -- updated!");
+        putBinary(bin2, txLocation2, "test 2 -- I'm new!");
+        putBinary(bin3, txLocation2, "test 3 -- updated!");
+
+        assertBinaryContent("test 1 -- updated!", bin1, txLocation2);
+        assertBinaryContent("test 2 -- I'm new!", bin2, txLocation2);
+
+        corruptStagedBinary(bin3);
+
+        // Commit transaction -- should fail
+        assertEquals(CONFLICT.getStatusCode(), getStatus(new HttpPut(txLocation2)));
+
+        assertEquals("Rolled back transaction should be gone",
+                GONE.getStatusCode(), getStatus(new HttpGet(txLocation2)));
+
+        // bin1 was rolled back
+        assertBinaryContent("test 1", bin1, null);
+
+        // bin2 was rolled back
+        assertEquals("Expected to not find our object after rollback",
+                NOT_FOUND.getStatusCode(), getStatus(new HttpGet(serverAddress + bin2)));
+        assertObjectDoesNotExistOnDisk(FedoraId.create(bin2));
+
+        // bin1 was not committed
+        assertBinaryContent("test 3", bin3, null);
     }
 
     @Test
@@ -948,6 +1049,22 @@ public class TransactionsIT extends AbstractResourceIT {
         final var txId = UUID.randomUUID().toString();
         containmentIndex.addContainedBy(txId, FedoraId.getRepositoryRootId(), FedoraId.create(resourceId));
         containmentIndex.commitTransaction(txId);
+    }
+
+    private void corruptStagedBinary(final String resourceId) {
+        final var lastPart = resourceId.contains("/") ?
+                StringUtils.substringAfterLast(resourceId, "/") : resourceId;
+        final var stagingRoot = ocflConfig.getFedoraOcflStaging();
+        try {
+            final var binary = Files.find(stagingRoot, 10, (file, attrs) -> {
+                return attrs.isRegularFile() &&
+                        file.getFileName().toString().equals(lastPart);
+            }).findFirst().get();
+
+            Files.writeString(binary, "corrupted!");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/TransactionProvider.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/session/TransactionProvider.java
@@ -74,14 +74,14 @@ public class TransactionProvider implements Factory<Transaction> {
         if (!transaction.isShortLived()) {
             transaction.refresh();
         }
-        LOGGER.trace("Providing new transaction {}", transaction);
+        LOGGER.trace("Providing new transaction {}", transaction.getId());
         return transaction;
     }
 
     @Override
     public void dispose(final Transaction transaction) {
         if (transaction.isShortLived()) {
-            LOGGER.trace("Disposing transaction {}", transaction);
+            LOGGER.trace("Disposing transaction {}", transaction.getId());
             transaction.expire();
         }
     }

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -72,6 +72,10 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
+    </dependency>
 
     <!-- test gear -->
     <dependency>

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -58,7 +58,7 @@ public class TransactionImpl implements Transaction {
     private static final RetryPolicy<Object> DB_RETRY = new RetryPolicy<>()
             .handleIf(e -> {
                 return e instanceof DeadlockLoserDataAccessException
-                        || e.getCause() != null && e.getCause() instanceof DeadlockLoserDataAccessException;
+                        || (e.getCause() != null && e.getCause() instanceof DeadlockLoserDataAccessException);
             })
             .withBackoff(50, 1000, ChronoUnit.MILLIS, 1.5)
             .withJitter(0.1)

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -112,7 +112,11 @@ public class TransactionImpl implements Transaction {
                     this.getReferenceService().commitTransaction(id);
                     this.getMembershipService().commitTransaction(id);
                     this.getPersistentSession().prepare();
-                    // storage session must be committed last because mutable head changes cannot be rolled back
+                    // The storage session must be committed last because mutable head changes cannot be rolled back.
+                    // The db transaction will remain open until all changes have been written to OCFL. If the changes
+                    // are large, or are going to S3, this could take some time. In which case, it is possible the
+                    // db's connection timeout may need to be adjusted so that the connection is not closed while
+                    // waiting for the OCFL changes to be committed.
                     this.getPersistentSession().commit();
                 });
             });

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSession.java
@@ -99,7 +99,14 @@ public interface PersistentStorageSession {
             throws PersistentStorageException;
 
     /**
-     * Commits any changes in the current sesssion to persistent storage.
+     * Does anything that's necessary to prepare the session to be committed, for example committing database
+     * changes. This method MUST be called before commit(). If prepare() fails, then the session should be rolled back.
+     * @throws PersistentStorageException if an error is encountered
+     */
+    void prepare() throws PersistentStorageException;
+
+    /**
+     * Commits any changes in the current session to persistent storage.
      * @throws PersistentStorageException Error during commit.
      */
     void commit() throws PersistentStorageException;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -92,6 +92,7 @@ public class RepositoryInitializer {
                     final var versionOperation = this.versionResourceOperationFactory.createBuilder(root).build();
                     session.persist(versionOperation);
                 }
+                session.prepare();
                 session.commit();
 
                 LOGGER.info("Successfully created repository root ({}).", root);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -111,7 +111,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
             " (" + FEDORA_ID_COLUMN + ", " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + ", " +
             TRANSACTION_ID_COLUMN + ", " + OPERATION_COLUMN + ")" +
             " VALUES (:fedoraId, :fedoraRootId, :ocflId, :transactionId, :operation) ON DUPLICATE KEY UPDATE " +
-            FEDORA_ROOT_ID_COLUMN + " = VALUES(" + FEDORA_ID_COLUMN + "), " + OCFL_ID_COLUMN + " = VALUES(" +
+            FEDORA_ROOT_ID_COLUMN + " = VALUES(" + FEDORA_ROOT_ID_COLUMN + "), " + OCFL_ID_COLUMN + " = VALUES(" +
             OCFL_ID_COLUMN + "), " + OPERATION_COLUMN + " = VALUES(" + OPERATION_COLUMN + ")";
 
     private static final String UPSERT_MAPPING_TX_H2 = "MERGE INTO " + TRANSACTION_OPERATIONS_TABLE +
@@ -143,7 +143,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
             FEDORA_ID_COLUMN + ", " + FEDORA_ROOT_ID_COLUMN + ", " + OCFL_ID_COLUMN + " FROM " +
             TRANSACTION_OPERATIONS_TABLE + " WHERE " + OPERATION_COLUMN + " = 'add' AND " + TRANSACTION_ID_COLUMN +
             " = :transactionId ON DUPLICATE KEY UPDATE " +
-            FEDORA_ROOT_ID_COLUMN + " = VALUES(" + FEDORA_ID_COLUMN + "), " + OCFL_ID_COLUMN + " = VALUES(" +
+            FEDORA_ROOT_ID_COLUMN + " = VALUES(" + FEDORA_ROOT_ID_COLUMN + "), " + OCFL_ID_COLUMN + " = VALUES(" +
             OCFL_ID_COLUMN + ")";
 
     private static final String COMMIT_ADD_MAPPING_H2 = "MERGE INTO " + MAPPING_TABLE +
@@ -293,6 +293,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
     @Transactional
     @Override
     public void commit(@Nonnull final String sessionId) {
+        LOGGER.debug("Committing FedoraToOcfl index changes from transaction {}", sessionId);
         final Map<String, String> map = Map.of("transactionId", sessionId);
         try {
             jdbcTemplate.update(COMMIT_DELETE_RECORDS, map);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionMetrics.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionMetrics.java
@@ -18,8 +18,10 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.List;
+
 import org.fcrepo.common.metrics.MetricsHelper;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -28,9 +30,8 @@ import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
-import java.io.InputStream;
-import java.time.Instant;
-import java.util.List;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 
 /**
  * PersistentStorageSession wrapper for collecting metrics
@@ -46,6 +47,7 @@ public class OcflPersistentStorageSessionMetrics implements PersistentStorageSes
     private static final Timer getTriplesTimer = Metrics.timer(METRIC_NAME, OPERATION, "getTriples");
     private static final Timer listVersionsTimer = Metrics.timer(METRIC_NAME, OPERATION, "listVersions");
     private static final Timer getContentTimer = Metrics.timer(METRIC_NAME, OPERATION, "getContent");
+    private static final Timer prepareTimer = Metrics.timer(METRIC_NAME, OPERATION, "prepare");
     private static final Timer commitTimer = Metrics.timer(METRIC_NAME, OPERATION, "commit");
     private static final Timer rollbackTimer = Metrics.timer(METRIC_NAME, OPERATION, "rollback");
 
@@ -98,17 +100,18 @@ public class OcflPersistentStorageSessionMetrics implements PersistentStorageSes
     }
 
     @Override
+    public void prepare() throws PersistentStorageException {
+        prepareTimer.record(delegate::prepare);
+    }
+
+    @Override
     public void commit() throws PersistentStorageException {
-        commitTimer.record(() -> {
-            delegate.commit();
-        });
+        commitTimer.record(delegate::commit);
     }
 
     @Override
     public void rollback() throws PersistentStorageException {
-        rollbackTimer.record(() -> {
-            delegate.rollback();
-        });
+        rollbackTimer.record(delegate::rollback);
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -109,7 +109,7 @@ public class NonRdfSourcesPersistenceIT {
                 .build();
 
         storageSession.persist(op);
-
+        storageSession.prepare();
         storageSession.commit();
 
         final var readSession = sessionManager.getReadOnlySession();
@@ -135,7 +135,7 @@ public class NonRdfSourcesPersistenceIT {
                 .build();
 
         storageSession.persist(op);
-
+        storageSession.prepare();
         storageSession.commit();
 
         final var readSession = sessionManager.getReadOnlySession();
@@ -215,7 +215,7 @@ public class NonRdfSourcesPersistenceIT {
                 .build();
 
         storageSession.persist(updateOp);
-
+        storageSession.prepare();
         storageSession.commit();
 
         final var readSession = sessionManager.getReadOnlySession();
@@ -242,6 +242,7 @@ public class NonRdfSourcesPersistenceIT {
             .build();
 
         storageSession.persist(op);
+        storageSession.prepare();
         storageSession.commit();
 
         final var updateOp = nonRdfSourceOpFactory.updateInternalBinaryBuilder(
@@ -283,7 +284,7 @@ public class NonRdfSourcesPersistenceIT {
                 .build();
 
         storageSession.persist(op);
-
+        storageSession.prepare();
         storageSession.commit();
 
         final var readSession = sessionManager.getReadOnlySession();
@@ -317,13 +318,14 @@ public class NonRdfSourcesPersistenceIT {
                 .build();
 
         storageSession.persist(op);
-
+        storageSession.prepare();
         storageSession.commit();
 
         final var deleteOp = deleteResourceOpFactory.deleteBuilder(rescId).build();
 
         final var deleteSession = startWriteSession();
         deleteSession.persist(deleteOp);
+        deleteSession.prepare();
         deleteSession.commit();
 
         final var readSession = sessionManager.getReadOnlySession();
@@ -360,6 +362,7 @@ public class NonRdfSourcesPersistenceIT {
         Files.write(stagedFile, "oops".getBytes(), StandardOpenOption.APPEND);
 
         try {
+            storageSession.prepare();
             storageSession.commit();
             fail("Expected commit to fail to due fixity failure");
         } catch (final PersistentStorageException e) {

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -248,6 +248,7 @@ public class OcflPersistentStorageSessionTest {
         final var originalModifiedDate = headers.getLastModifiedDate();
         assertNotNull("Headers must contain modified date", originalModifiedDate);
 
+        session.prepare();
         //commit to OCFL
         session.commit();
 
@@ -294,7 +295,7 @@ public class OcflPersistentStorageSessionTest {
 
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
-
+        session.prepare();
         //commit to OCFL
         session.commit();
 
@@ -314,7 +315,7 @@ public class OcflPersistentStorageSessionTest {
 
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
-
+        session.prepare();
         //commit to OCFL
         session.commit();
 
@@ -334,7 +335,7 @@ public class OcflPersistentStorageSessionTest {
 
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
-
+        session.prepare();
         //commit to OCFL
         session.commit();
 
@@ -354,7 +355,7 @@ public class OcflPersistentStorageSessionTest {
 
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
-
+        session.prepare();
         //commit to OCFL
         session.commit();
 
@@ -362,6 +363,39 @@ public class OcflPersistentStorageSessionTest {
         try {
             session.commit();
             fail("second session.commit(...) invocation should have failed.");
+        } catch (final PersistentStorageException ex) {
+            //expected failure
+        }
+    }
+
+    @Test
+    public void commitFailsIfNotPrepared() throws Exception {
+        mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+        mockResourceOperation(rdfSourceOperation, RESOURCE_ID);
+
+        //perform the create rdf operation
+        session.persist(rdfSourceOperation);
+
+        try {
+            session.commit();
+            fail("commit should have failed because prepare() was not called");
+        } catch (final PersistentStorageException ex) {
+            //expected failure
+        }
+    }
+
+    @Test
+    public void prepareFailsIfAlreadyPrepared() throws Exception {
+        mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
+        mockResourceOperation(rdfSourceOperation, RESOURCE_ID);
+
+        //perform the create rdf operation
+        session.persist(rdfSourceOperation);
+        session.prepare();
+
+        try {
+            session.prepare();
+            fail("prepare should have failed because prepare() was already called");
         } catch (final PersistentStorageException ex) {
             //expected failure
         }
@@ -420,6 +454,7 @@ public class OcflPersistentStorageSessionTest {
 
         //get triples should now fail because the session is effectively closed.
         try {
+            session1.prepare();
             session1.commit();
             fail("session1.commit(...) invocation should fail.");
         } catch (final PersistentStorageException ex) {
@@ -453,6 +488,7 @@ public class OcflPersistentStorageSessionTest {
         final CountDownLatch latch = new CountDownLatch(1);
         new Thread(() -> {
             try {
+                session1.prepare();
                 session1.commit();
             } catch (final PersistentStorageException e) {
                 fail("The commit() should not fail.");
@@ -486,6 +522,7 @@ public class OcflPersistentStorageSessionTest {
         //persist the operation
         try {
             session1.persist(rdfSourceOperation);
+            session1.prepare();
             session1.commit();
         } catch (final PersistentStorageException e) {
             fail("Operation should not fail.");
@@ -527,6 +564,7 @@ public class OcflPersistentStorageSessionTest {
         }
 
         try {
+            session1.prepare();
             session1.commit();
             fail("Operation should fail.");
         } catch (final PersistentStorageException e) {
@@ -558,7 +596,7 @@ public class OcflPersistentStorageSessionTest {
 
         //perform the create rdf operation
         session.persist(rdfSourceOperation);
-
+        session.prepare();
         //commit to new version
         session.commit();
 
@@ -594,6 +632,7 @@ public class OcflPersistentStorageSessionTest {
 
         mockResourceOperation(createArchivalGroupOperation, RESOURCE_ID);
         session.persist(createArchivalGroupOperation);
+        session.prepare();
         session.commit();
 
         final var childId = RESOURCE_ID.resolve("child");
@@ -610,6 +649,7 @@ public class OcflPersistentStorageSessionTest {
                 .thenReturn(RESOURCE_ID);
 
         session2.persist(rdfSourceOperation);
+        session2.prepare();
         session2.commit();
 
         final var session3 = createSession(index, objectSessionFactory);
@@ -631,7 +671,7 @@ public class OcflPersistentStorageSessionTest {
 
         // perform the create non-rdf source operation
         session.persist(binOperation);
-
+        session.prepare();
         // commit to OCFL
         session.commit();
 
@@ -651,7 +691,7 @@ public class OcflPersistentStorageSessionTest {
 
         // perform the create non-rdf source operation
         session.persist(binOperation);
-
+        session.prepare();
         // commit to OCFL
         session.commit();
 
@@ -672,6 +712,7 @@ public class OcflPersistentStorageSessionTest {
         final var binOperation = mockNonRdfSourceOperation(BINARY_CONTENT, USER_PRINCIPAL, RESOURCE_ID);
         // perform the create non-rdf source operation
         session.persist(binOperation);
+        session.prepare();
         // commit to OCFL
         session.commit();
 
@@ -712,6 +753,7 @@ public class OcflPersistentStorageSessionTest {
         final DefaultRdfStream userStream = new DefaultRdfStream(resourceUri, userTriples);
         mockResourceOperation(rdfSourceOperation, userStream, USER_PRINCIPAL, RESOURCE_ID);
         session.persist(rdfSourceOperation);
+        session.prepare();
         session.commit();
 
         // read-only read resource

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexManagerTest.java
@@ -53,6 +53,7 @@ public class ReindexManagerTest extends AbstractReindexerTest {
         createResource(session, resource1, true);
         createChildResourceNonRdf(session, resource1, resource2);
 
+        session.prepare();
         session.commit();
 
         assertHasOcflId("resource1", resource1);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexServiceTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexServiceTest.java
@@ -93,6 +93,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
         createResource(session, parentId, true);
         createChildResourceRdf(session, parentId, childId);
 
+        session.prepare();
         session.commit();
 
         assertHasOcflId(parentIdPart, parentId);
@@ -129,6 +130,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
         createResource(session, resource1, true);
         createChildResourceNonRdf(session, resource1, resource2);
 
+        session.prepare();
         session.commit();
 
         assertHasOcflId("resource1", resource1);
@@ -162,6 +164,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
         createResource(session, resource1, false);
         createChildResourceNonRdf(session, resource1, resource2);
 
+        session.prepare();
         session.commit();
 
         assertHasOcflId("resource1", resource1);
@@ -194,6 +197,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
         createResource(session, resource1, true);
         createChildResourceNonRdf(session, resource1, resource2);
 
+        session.prepare();
         session.commit();
 
         assertHasOcflId("resource1", resource1);
@@ -203,6 +207,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
 
         deleteResource(session2, resource2);
 
+        session2.prepare();
         session2.commit();
 
         ocflIndex.reset();
@@ -243,6 +248,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
 
         when(containerResult.getItems()).thenReturn(result);
 
+        session.prepare();
         session.commit();
 
         ocflIndex.reset();

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <commons-lang.version>3.11</commons-lang.version>
     <narayana-jta.version>5.9.0.Final</narayana-jta.version>
     <jetty.version>9.4.34.v20201102</jetty.version>
+    <failsafe.version>2.4.0</failsafe.version>
     <guava.version>30.0-jre</guava.version>
     <h2database.version>1.4.195</h2database.version>
     <hk2.version>2.6.1</hk2.version>
@@ -334,6 +335,11 @@
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
         <version>${caffeine.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jodah</groupId>
+        <artifactId>failsafe</artifactId>
+        <version>${failsafe.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3581 and https://jira.lyrasis.org/browse/FCREPO-3543

# What does this Pull Request do?

* MySQL can fail if a competing transaction updates the same record. The only solution is to retry. This PR adds retries to the transaction commit.
* Reorders the commit operations so that all of the db changes are committed before the ocfl changes

# How should this be tested?

Everything should still work and MySQL should not fail due to a race condition. I ran the test that exposed the problem, `FedoraLdpIT.testConcurrentPutsWithPairtrees()`, 20+ times with this PR and it did not fail.

# Interested parties
@fcrepo/committers
