### PR TITLE
FCREPO-3541 - Etags reflect membership and other request preferences

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -663,7 +663,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             date = resource.getLastModifiedDate();
         } else {
             // Use a weak ETag for the LDP-RS
-            final String txId = transaction == null ? null : transaction.getId();
+            final String txId = TransactionUtils.openTxId(transaction);
             etag = new EntityTag(etagService.getRdfResourceEtag(txId, resource, getLdpPreferTag(),
                     headers.getAcceptableMediaTypes()), true);
             date = resource.getLastModifiedDate();
@@ -725,7 +725,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             date = resource.getLastModifiedDate();
         } else {
             // Use a strong ETag for the LDP-RS when validating If-(None)-Match headers
-            final String txId = transaction == null ? null : transaction.getId();
+            final String txId = TransactionUtils.openTxId(transaction);
             etag = new EntityTag(etagService.getRdfResourceEtag(txId, resource, getLdpPreferTag(),
                     headers.getAcceptableMediaTypes()), false);
             date = resource.getLastModifiedDate();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -97,6 +97,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
+import org.fcrepo.http.api.services.EtagService;
 import org.fcrepo.http.api.services.HttpRdfService;
 import org.fcrepo.http.commons.api.rdf.HttpTripleUtil;
 import org.fcrepo.http.commons.domain.MultiPrefer;
@@ -213,6 +214,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
     protected UpdatePropertiesService updatePropertiesService;
 
     @Inject
+    protected EtagService etagService;
+
+    @Inject
     protected HttpRdfService httpRdfService;
 
     @Inject
@@ -277,17 +281,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      */
     private RdfStream getResourceTriples(final int limit, final FedoraResource resource) {
 
-        final PreferTag returnPreference;
-
-        if (prefer != null && prefer.hasReturn()) {
-            returnPreference = prefer.getReturn();
-        } else if (prefer != null && prefer.hasHandling()) {
-            returnPreference = prefer.getHandling();
-        } else {
-            returnPreference = PreferTag.emptyTag();
-        }
-
-        final LdpPreferTag ldpPreferences = new LdpPreferTag(returnPreference);
+        final LdpPreferTag ldpPreferences = getLdpPreferTag();
 
         final List<Stream<Triple>> embedStreams = new ArrayList<>();
 
@@ -314,6 +308,20 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         }
 
         return rdfStream;
+    }
+
+    private LdpPreferTag getLdpPreferTag() {
+        final PreferTag returnPreference;
+
+        if (prefer != null && prefer.hasReturn()) {
+            returnPreference = prefer.getReturn();
+        } else if (prefer != null && prefer.hasHandling()) {
+            returnPreference = prefer.getHandling();
+        } else {
+            returnPreference = PreferTag.emptyTag();
+        }
+
+        return new LdpPreferTag(returnPreference);
     }
 
     /**
@@ -655,7 +663,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             date = resource.getLastModifiedDate();
         } else {
             // Use a weak ETag for the LDP-RS
-            etag = new EntityTag(resource.getEtagValue(), true);
+            final String txId = transaction == null ? null : transaction.getId();
+            etag = new EntityTag(etagService.getRdfResourceEtag(txId, resource, getLdpPreferTag(),
+                    headers.getAcceptableMediaTypes()), true);
             date = resource.getLastModifiedDate();
         }
 
@@ -667,7 +677,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             //State Tokens, while not used for caching per se,  nevertheless belong
             //here since we can conveniently reuse the value of the etag for
             //our state token
-            servletResponse.addHeader("X-State-Token", etag.getValue());
+            servletResponse.addHeader("X-State-Token", resource.getStateToken());
         }
 
         if (date != null) {
@@ -715,7 +725,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             date = resource.getLastModifiedDate();
         } else {
             // Use a strong ETag for the LDP-RS when validating If-(None)-Match headers
-            etag = new EntityTag(resource.getEtagValue());
+            final String txId = transaction == null ? null : transaction.getId();
+            etag = new EntityTag(etagService.getRdfResourceEtag(txId, resource, getLdpPreferTag(),
+                    headers.getAcceptableMediaTypes()), false);
             date = resource.getLastModifiedDate();
         }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.api.services;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
+
+import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
+import org.fcrepo.kernel.api.services.MembershipService;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Service for computing etags for request responses
+ *
+ * @author bbpennel
+ */
+@Component
+public class EtagService {
+    private static final Logger LOGGER = getLogger(EtagService.class);
+
+    @Inject
+    private ContainmentIndex containmentIndex;
+
+    @Inject
+    private MembershipService membershipService;
+
+    /**
+     * Produces etag for a request for an RDF resource. It is based on factors related to the
+     * current state of the resource, as well as request options which change the
+     * representation of the reosurce.
+     *
+     * @param txId transaction id
+     * @param resource resource
+     * @param prefers LDP preference headers for the request
+     * @param acceptableMediaTypes collection of acceptable media types for the response
+     * @return etag for the request
+     */
+    public String getRdfResourceEtag(final String txId, final FedoraResource resource,
+            final LdpTriplePreferences prefers, final Collection<MediaType> acceptableMediaTypes) {
+        // Start etag based on the current state of the fedora resource, using the state token
+        final StringBuilder etag = new StringBuilder(resource.getStateToken());
+
+        // Factor in the requested mimetype(s)
+        final String mimetype = acceptableMediaTypes.stream()
+                .map(MediaType::toString)
+                .sorted()
+                .collect(Collectors.joining(";"));
+        addComponent(etag, mimetype);
+
+        // Factor in preferences which change which triples are included in the response
+        etag.append('|');
+        if (prefers.prefersContainment()) {
+            etag.append(containmentIndex.containmentLastUpdated(txId, resource.getFedoraId()));
+        }
+        etag.append('|');
+        if (prefers.prefersMembership()) {
+            etag.append(membershipService.getLastUpdatedTimestamp(txId, resource.getFedoraId()));
+        }
+        addComponent(etag, prefers.prefersEmbed());
+        addComponent(etag, prefers.preferNoUserRdf());
+        addComponent(etag, prefers.prefersReferences());
+        addComponent(etag, prefers.prefersServerManaged());
+
+        // Compute a digest of all these components to use as the etag
+        final String etagMd5 = DigestUtils.md5Hex(etag.toString()).toUpperCase();
+        LOGGER.debug("Produced etag {} for {} from {}", etagMd5, resource.getId(), etag);
+
+        return etagMd5;
+    }
+
+    private void addComponent(final StringBuilder etag, final Object component) {
+        etag.append('|').append(component);
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -52,7 +52,7 @@ public class EtagService {
     /**
      * Produces etag for a request for an RDF resource. It is based on factors related to the
      * current state of the resource, as well as request options which change the
-     * representation of the reosurce.
+     * representation of the resource.
      *
      * @param txId transaction id
      * @param resource resource

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -75,11 +75,17 @@ public class EtagService {
         // Factor in preferences which change which triples are included in the response
         etag.append('|');
         if (prefers.prefersContainment()) {
-            etag.append(containmentIndex.containmentLastUpdated(txId, resource.getFedoraId()));
+            final var lastUpdated = containmentIndex.containmentLastUpdated(txId, resource.getFedoraId());
+            if (lastUpdated != null) {
+                etag.append(lastUpdated);
+            }
         }
         etag.append('|');
         if (prefers.prefersMembership()) {
-            etag.append(membershipService.getLastUpdatedTimestamp(txId, resource.getFedoraId()));
+            final var lastUpdated = membershipService.getLastUpdatedTimestamp(txId, resource.getFedoraId());
+            if (lastUpdated != null) {
+                etag.append(lastUpdated);
+            }
         }
         addComponent(etag, prefers.prefersEmbed());
         addComponent(etag, prefers.preferNoUserRdf());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -24,6 +24,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
+
+import org.fcrepo.http.api.services.EtagService;
 import org.fcrepo.http.api.services.HttpRdfService;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.domain.MultiPrefer;
@@ -140,6 +142,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -244,6 +247,9 @@ public class FedoraLdpTest {
     @Mock
     private ResourceTripleService resourceTripleService;
 
+    @Mock
+    private EtagService etagService;
+
     private final List<URI> typeList = new ArrayList<>();
 
     private static final Logger log = getLogger(FedoraLdpTest.class);
@@ -276,6 +282,7 @@ public class FedoraLdpTest {
         setField(testObj, "replacePropertiesService", replacePropertiesService);
         setField(testObj, "updatePropertiesService", updatePropertiesService);
         setField(testObj, "resourceHelper", resourceHelper);
+        setField(testObj, "etagService", etagService);
 
         when(rdfNamespaceRegistry.getNamespaces()).thenReturn(new HashMap<>());
 
@@ -320,6 +327,8 @@ public class FedoraLdpTest {
             return null;
         }).when(preferTag).addResponseHeaders(mockResponse);
 
+        when(etagService.getRdfResourceEtag(nullable(String.class), any(FedoraResource.class),
+                nullable(LdpTriplePreferences.class), any())).thenReturn("etagval");
     }
 
     private FedoraResource setResource(final Class<? extends FedoraResource> klass) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -57,6 +57,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.DatatypeConverter;
@@ -380,6 +381,39 @@ public abstract class AbstractResourceIT {
             EntityUtils.consume(response.getEntity());
             return response.getFirstHeader(CONTENT_TYPE).getValue();
         }
+    }
+
+    /**
+     * Get the etag of the given URI, as returned from a HEAD request
+     *
+     * @param uri uri of the resource
+     * @return etag
+     * @throws IOException
+     */
+    protected String getEtag(final String uri) throws IOException {
+        return getEtag(new HttpHead(uri));
+    }
+
+    /**
+     * Get the etag returned when executing the provided method
+     * @param method method to execute
+     * @return etag
+     * @throws IOException
+     */
+    protected String getEtag(final HttpUriRequest method) throws IOException {
+        try (final CloseableHttpResponse response = execute(method)) {
+            return getEtag(response);
+        }
+    }
+
+    /**
+     * Get the etag header value present in the provided response
+     * @param response response
+     * @return etag header value or null
+     */
+    protected String getEtag(final HttpResponse response) {
+        final var etag = response.getFirstHeader(HttpHeaders.ETAG);
+        return etag == null ? null : etag.getValue();
     }
 
     protected static Collection<String> getLinkHeaders(final HttpResponse response) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -17,7 +17,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -58,7 +57,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -290,7 +288,7 @@ public class LDPContainerIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Needs updated eTags - FCREPO-3541")
+    @Ignore("Needs updated eTags - FCREPO-3410")
     public void testETagOnDeletedLdpIndirectContainerChild() throws Exception {
         final String id = getRandomUniqueId();
         final String members = id + "/members";
@@ -315,21 +313,12 @@ public class LDPContainerIT extends AbstractResourceIT {
         createChild.setEntity(new StringEntity(childRDF));
         assertEquals("Child container not created!", CREATED.getStatusCode(), getStatus(createChild));
 
-        final HttpGet get = new HttpGet(serverAddress + id);
-        final String etag1;
-        try (final CloseableHttpResponse response = execute(get)) {
-            etag1 = response.getFirstHeader("ETag").getValue();
-            IOUtils.toString(response.getEntity().getContent(), UTF_8);
-        }
+        final String etag1 = getEtag(serverAddress + id);
 
         assertEquals("Child resource not deleted!", NO_CONTENT.getStatusCode(),
                 getStatus(new HttpDelete(serverAddress + child)));
 
-        final String etag2;
-        try (final CloseableHttpResponse response = execute(get)) {
-            etag2 = response.getFirstHeader("ETag").getValue();
-            IOUtils.toString(response.getEntity().getContent(), UTF_8);
-        }
+        final String etag2 = getEtag(serverAddress + id);
 
         assertNotEquals("ETag didn't change!", etag1, etag2);
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.kernel.api.services;
 
+import java.time.Instant;
+
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 
@@ -67,6 +69,14 @@ public interface MembershipService {
      * @param containerId ID of the container
      */
     void populateMembershipHistory(final String txId, final FedoraId containerId);
+
+    /**
+     * Get the timestamp of the most recent member added or removed, or null if none.
+     * @param txId transaction id or null if none
+     * @param fedoraId the resource id
+     * @return the timestamp or null
+     */
+    Instant getLastUpdatedTimestamp(final String txId, final FedoraId fedoraId);
 
     /**
      * Commit any pending membership changes.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -419,6 +419,11 @@ public class MembershipServiceImpl implements MembershipService {
         }
     }
 
+    @Override
+    public Instant getLastUpdatedTimestamp(final String txId, final FedoraId fedoraId) {
+        return indexManager.getLastUpdated(txId, fedoraId);
+    }
+
     /**
      * @param indexManager the indexManager to set
      */

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -104,5 +104,4 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
 
         return streams.stream().reduce(empty(), Stream::concat);
     }
-
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -104,4 +104,5 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
 
         return streams.stream().reduce(empty(), Stream::concat);
     }
+
 }

--- a/fcrepo-kernel-impl/src/main/resources/sql/default-membership.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/default-membership.sql
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS membership (
     object_id varchar(503) NOT NULL,
     source_id varchar(503) NOT NULL,
     start_time timestamp,
-    end_time timestamp
+    end_time timestamp,
+    last_updated timestamp
 );
 
 -- Create an index to speed searches for a resource.
@@ -25,6 +26,10 @@ CREATE INDEX IF NOT EXISTS membership_idx1b
 CREATE INDEX IF NOT EXISTS membership_idx2
     ON membership (source_id);
 
+-- Create an index to speed retrieval of last_updated times
+CREATE INDEX IF NOT EXISTS membership_idx3
+    ON membership (subject_id, last_updated);
+
 -- Holds operations to add or delete records from the REFERENCE table.
 CREATE TABLE IF NOT EXISTS membership_tx_operations (
     subject_id varchar(503) NOT NULL,
@@ -33,6 +38,7 @@ CREATE TABLE IF NOT EXISTS membership_tx_operations (
     source_id varchar(503) NOT NULL,
     start_time timestamp,
     end_time timestamp,
+    last_updated timestamp,
     tx_id varchar(36) NOT NULL,
     operation varchar(10) NOT NULL,
     force_flag varchar(10)
@@ -48,3 +54,10 @@ CREATE INDEX IF NOT EXISTS membership_tx_operations_idx1a
 -- Create an index to speed finding records related to a transaction.
 CREATE INDEX IF NOT EXISTS membership_tx_operations_idx2
     ON membership_tx_operations (tx_id);
+
+CREATE INDEX IF NOT EXISTS membership_tx_operations_idx3
+    ON membership_tx_operations (source_id);
+
+-- Create an index to speed retrieval of last_updated times
+CREATE INDEX IF NOT EXISTS membership_tx_operations_idx3
+    ON membership_tx_operations (subject_id, last_updated);

--- a/fcrepo-kernel-impl/src/main/resources/sql/mariadb-membership.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mariadb-membership.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS membership (
     object_id varchar(503) NOT NULL,
     source_id varchar(503) NOT NULL,
     start_time datetime,
-    end_time datetime
+    end_time datetime,
+    last_updated datetime
 );
 
 -- Create an index to speed searches for a resource.
@@ -24,6 +25,10 @@ CREATE INDEX IF NOT EXISTS membership_idx1b
 CREATE INDEX IF NOT EXISTS membership_idx2
     ON membership (source_id);
 
+-- Create an index to speed retrieval of last_updated times
+CREATE INDEX IF NOT EXISTS membership_idx3
+    ON membership (subject_id, last_updated);
+
 -- Holds operations to add or delete records from the REFERENCE table.
 CREATE TABLE IF NOT EXISTS membership_tx_operations (
     subject_id varchar(503) NOT NULL,
@@ -32,6 +37,7 @@ CREATE TABLE IF NOT EXISTS membership_tx_operations (
     source_id varchar(503) NOT NULL,
     start_time datetime,
     end_time datetime,
+    last_updated datetime,
     tx_id varchar(36) NOT NULL,
     operation varchar(10) NOT NULL,
     force_flag varchar(10)
@@ -50,3 +56,7 @@ CREATE INDEX IF NOT EXISTS membership_tx_operations_idx2
 
 CREATE INDEX IF NOT EXISTS membership_tx_operations_idx3
     ON membership_tx_operations (source_id);
+
+-- Create an index to speed retrieval of last_updated times
+CREATE INDEX IF NOT EXISTS membership_tx_operations_idx4
+    ON membership_tx_operations (subject_id, last_updated);

--- a/fcrepo-kernel-impl/src/main/resources/sql/mysql-membership.sql
+++ b/fcrepo-kernel-impl/src/main/resources/sql/mysql-membership.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS membership (
     object_id varchar(503) NOT NULL,
     source_id varchar(503) NOT NULL,
     start_time datetime,
-    end_time datetime
+    end_time datetime,
+    last_updated datetime
 );
 
 -- Create an index to speed searches for a resource.
@@ -54,6 +55,14 @@ SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 
+-- Create an index to speed retrieval of last_updated times
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'membership' AND index_name = 'membership_idx5' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX membership_idx5 ON membership (subject_id, last_updated)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
 -- Holds operations to add or delete records from the REFERENCE table.
 CREATE TABLE IF NOT EXISTS membership_tx_operations (
     subject_id varchar(503) NOT NULL,
@@ -62,6 +71,7 @@ CREATE TABLE IF NOT EXISTS membership_tx_operations (
     source_id varchar(503) NOT NULL,
     start_time datetime,
     end_time datetime,
+    last_updated datetime,
     tx_id varchar(36) NOT NULL,
     operation varchar(10) NOT NULL,
     force_flag varchar(10)
@@ -101,5 +111,13 @@ SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
     WHERE table_name = 'membership_tx_operations' AND index_name = 'membership_tx_operations_idx4' AND table_schema = database());
 SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
     'CREATE INDEX membership_tx_operations_idx4 ON membership_tx_operations (end_time)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index to speed retrieval of last_updated times
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'membership_tx_operations' AND index_name = 'membership_tx_operations_idx5' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX membership_tx_operations_idx5 ON membership_tx_operations (subject_id, last_updated)');
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3541

# What does this Pull Request do?
* Determines last updated timestamp of membership for a resource
* Etags and state tokens now diverge for RDF sources, as etags now reflect
    * State token
    * Requested mimetype
    * Prefer headers that affect the included triples
    * Last updated from containment index
    * Last updated from membership index
* Adds a service for calculating etags
* Removes inclusion of containment last updated from state token calculation, as it is happening at request time now


# How should this be tested?

You can see a few other examples of DirectContainer operations that could be used for testing in:
https://github.com/fcrepo/fcrepo/pull/1781

```
# Create the membership resource
curl -XPUT http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin

# Create a DirectContainer using hasMember relation
echo "
<http://localhost:8080/rest/dc_hm> <http://www.w3.org/ns/ldp#membershipResource> <http://localhost:8080/rest/mem_resc1> .
<http://localhost:8080/rest/dc_hm> <http://www.w3.org/ns/ldp#hasMemberRelation> <http://example.com/hasMember> .
" | curl -XPUT http://localhost:8080/rest/dc_hm -ufedoraAdmin:fedoraAdmin -H'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H"Content-Type: application/n-triples" --data-binary "@-"

# Etag for GET and HEAD requests should be the same

curl -I http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin

    ETag: W/"E1F2B178018FD97465BC14AD84826960"
  
curl http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin -v

    < ETag: W/"E1F2B178018FD97465BC14AD84826960"

# Check etag without membership, should be the same at this point
curl http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin -v -H 'Prefer: return=representation; omit="http://www.w3.org/ns/ldp#PreferMembership"'

    < ETag: W/"E1F2B178018FD97465BC14AD84826960"


# Now add a member
curl -XPUT http://localhost:8080/rest/dc_hm/memb1 -ufedoraAdmin:fedoraAdmin

# Etag in HEAD and GET should have changed from before, but match each other
curl -I http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin

    ETag: W/"8C2E7DFF1429384C8D97E0F35A02E49A"
    
curl http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin -v

    < ETag: W/"8C2E7DFF1429384C8D97E0F35A02E49A"

# ETag without membership should match from before membership added
curl http://localhost:8080/rest/mem_resc1 -ufedoraAdmin:fedoraAdmin -v -H 'Prefer: return=representation; omit="http://www.w3.org/ns/ldp#PreferMembership"'

    < ETag: W/"E1F2B178018FD97465BC14AD84826960"
    


# Verify that excluding containment impacts etag
curl -XPUT http://localhost:8080/rest/parent_resc -ufedoraAdmin:fedoraAdmin

# Etag of resc before children
curl -I http://localhost:8080/rest/parent_resc -ufedoraAdmin:fedoraAdmin

    ETag: W/"A3CFA72A1C75348BC44B463F7F98BE86"

# Add child
curl -XPUT http://localhost:8080/rest/parent_resc/child_resc -ufedoraAdmin:fedoraAdmin

# Etag of parent should have changed
curl -I http://localhost:8080/rest/parent_resc -ufedoraAdmin:fedoraAdmin

    ETag: W/"B3CC7929EA643EC9BA83E5C32F2ECDE7"

# Excluding containment should match etag before children
curl http://localhost:8080/rest/parent_resc -ufedoraAdmin:fedoraAdmin -v -H 'Prefer: return=representation; omit="http://www.w3.org/ns/ldp#PreferContainment"'

    < ETag: W/"A3CFA72A1C75348BC44B463F7F98BE86"
```
