### PR TITLE
upgraded to ocfl-java 0.2

### DIFF
--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -97,12 +97,12 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
-      <version>4.1.46.Final</version>
+      <version>4.1.53.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-      <version>4.1.46.Final</version>
+      <version>4.1.53.Final</version>
     </dependency>
     <dependency>
       <groupId>org.reactivestreams</groupId>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -26,7 +26,7 @@ import edu.wisc.library.ocfl.api.OcflConfig;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.aws.OcflS3Client;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.constraint.ContentPathConstraints;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.cloud.CloudOcflStorage;
@@ -149,7 +149,7 @@ public class OcflPersistentStorageUtils {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         final var builder = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .ocflConfig(new OcflConfig().setDefaultDigestAlgorithm(ocflDigestAlg))
                 .logicalPathMapper(logicalPathMapper)
                 .workDir(ocflWorkDir);

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <jsonld.version>0.13.2</jsonld.version>
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.5.5</micrometer.version>
-    <ocfl-java.version>0.1.0</ocfl-java.version>
+    <ocfl-java.version>0.2.0</ocfl-java.version>
     <prometheus.version>0.8.1</prometheus.version>
     <shiro.version>1.7.0</shiro.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
**Jira:** https://jira.lyrasis.org/browse/FCREPO-3590

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/27**

Upgrades ocfl-java to the latest version.

A key difference in this version is that the storage layout extension definition is moved into the `extensions` directory. While the layout extension we're using has not been merged yet, it is unlikely that it'll need to be updated again.

This change does mean that the layout config in the storage root will no longer be read. Existing repositories with the storage layout in the old location are still usable, but `ocfl-java` will **not** write the storage layout to the new location for an existing repository. You either need to recreate the repository or write it manually.

To manually create it, write the following to `ocfl-root/extensions/0004-hashed-n-tuple-storage-layout/config.json`:

```json
{
  "digestAlgorithm" : "sha256",
  "tupleSize" : 3,
  "numberOfTuples" : 3,
  "shortObjectRoot" : false,
  "extensionName" : "0004-hashed-n-tuple-storage-layout"
}
```

