### PR TITLE
Downgrades the maven-failsafe-plugin to 3.0.0. 

### DIFF
--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -42,7 +42,7 @@
     <dependency.plugin.version>3.1.1</dependency.plugin.version>
     <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <doxia-markdown.plugin.version>1.8</doxia-markdown.plugin.version>
-    <failsafe.plugin.version>3.0.0-M4</failsafe.plugin.version>
+    <failsafe.plugin.version>3.0.0-M3</failsafe.plugin.version>
     <fcrepo-build-tools.version>6.0.0-SNAPSHOT</fcrepo-build-tools.version>
     <github-site.plugin.version>0.12</github-site.plugin.version>
     <gpg.plugin.version>1.6</gpg.plugin.version>


### PR DESCRIPTION
** Gets integration tests running again.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3600


* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Downgrades the maven-failsafe-plugin to 3.0.0. 
This change fixes the problem of integration tests not running.  It is not clear why.


# How should this be tested?
Run the build (mvn clean install) 
Verify that the number of integration tests run in all modules with integration tests is greater than zero.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
