### PR TITLE
Removes the "Vary-Post: Memento-Datetime" heaader from the LDPCv response

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -513,7 +513,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             options = "GET,HEAD,OPTIONS";
         } else if (resource instanceof TimeMap) {
             options = "POST,HEAD,GET,OPTIONS";
-            servletResponse.addHeader("Vary-Post", MEMENTO_DATETIME_HEADER);
             addAcceptPostHeader();
         } else if (resource instanceof Binary) {
             options = "DELETE,HEAD,GET,PUT,OPTIONS";

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.micrometer.core.annotation.Timed;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.LinkFormatStream;
+import org.fcrepo.kernel.api.exception.CannotCreateMementoException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -126,7 +127,8 @@ public class FedoraVersioning extends ContentExposingResource {
         }
 
         if (headers.getHeaderString(MEMENTO_DATETIME_HEADER) != null) {
-            throw new BadRequestException("date-time header is no longer supported on versioning.");
+            throw new CannotCreateMementoException(MEMENTO_DATETIME_HEADER +
+                    " header is no longer supported on versioning.");
         }
 
         final var transaction = transaction();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -18,6 +18,7 @@
 package org.fcrepo.integration.http.api;
 
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.util.Arrays.asList;
 import static java.util.Arrays.sort;
 import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
@@ -33,6 +34,7 @@ import static javax.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
@@ -81,7 +83,6 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -147,7 +148,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
 
     private static final Resource TEST_TYPE_RESOURCE = createResource("http://example.com/custom_type");
 
-    private final List<String> rdfTypes = new ArrayList<>(Arrays.asList(POSSIBLE_RDF_RESPONSE_VARIANTS_STRING));
+    private final List<String> rdfTypes = new ArrayList<>(asList(POSSIBLE_RDF_RESPONSE_VARIANTS_STRING));
 
     private String subjectUri;
     private String id;
@@ -308,6 +309,21 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             assertMementoEqualsOriginal(mementoUri);
         }
     }
+
+    @Test
+    public void testCreateVersionWithAcceptDatetime() throws Exception {
+        final String mementoDateTime =
+                MEMENTO_RFC_1123_FORMATTER.format(ISO_INSTANT.parse("2017-06-10T11:41:00Z", Instant::from));
+        createVersionedContainer(id);
+        final var post = postObjMethod(id + "/fcr:versions");
+        post.addHeader(MEMENTO_DATETIME_HEADER, mementoDateTime);
+        try (final CloseableHttpResponse response = execute(post)) {
+            assertEquals("Operation should return " + SC_BAD_REQUEST + " status", SC_BAD_REQUEST,
+                    response.getStatusLine().getStatusCode());
+            assertConstrainedByPresent(response);
+        }
+    }
+
 
     @Test
     public void testCreateVersionFromResourceWithHashURI() throws Exception {
@@ -726,7 +742,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
             // verify headers in link format.
             verifyTimeMapHeaders(response, uri);
             final var responseBody = EntityUtils.toString(response.getEntity());
-            final List<String> bodyList = Arrays.asList(responseBody.split("," + System.lineSeparator()));
+            final List<String> bodyList = asList(responseBody.split("," + System.lineSeparator()));
             //the links from the body are not
 
             Link selfLink = null;

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateMementoExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/CannotCreateMementoExceptionMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import org.fcrepo.kernel.api.exception.CannotCreateMementoException;
+import org.slf4j.Logger;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.Provider;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * A mapper for memento creation exceptions
+ *
+ * @author dbernstein
+ */
+@Provider
+public class CannotCreateMementoExceptionMapper extends ConstraintExceptionMapper<CannotCreateMementoException>
+        implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(CannotCreateMementoExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Context
+    private ServletContext context;
+
+    @Override
+    public Response toResponse(final CannotCreateMementoException e) {
+        debugException(this, e, LOGGER);
+        final Link link = buildConstraintLink(e, context, uriInfo);
+        final String msg = e.getMessage();
+        return status(BAD_REQUEST).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/CannotCreateMementoException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/CannotCreateMementoException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * An exception class for invalid memento creation attempts.
+ *
+ * @author dbernstein
+ */
+public class CannotCreateMementoException extends ConstraintViolationException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default constructor
+     *
+     * @param msg the message
+     */
+    public CannotCreateMementoException(final String msg) {
+        super(msg);
+    }
+
+}

--- a/fcrepo-webapp/src/main/webapp/static/constraints/CannotCreateMementoException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/CannotCreateMementoException.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
+
+<rdf:RDF
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="static/constraints/CannotCreateMementoException">
+        <rdfs:label xml:lang="en">Cannot Create Memento</rdfs:label>
+        <rdfs:comment xml:lang="en">Fedora is unable to create the requested memento. Fedora does
+        not support creating a memento with a Memento-Datetime header.
+        </rdfs:comment>
+    </owl:Ontology>
+</rdf:RDF>


### PR DESCRIPTION
…onse in order to align with the API test suite.

**Removes the "Vary-Post: Memento-Datetime" heaader from the LDPCv response**
* * *

**JIRA Ticket**:  https://jira.lyrasis.org/browse/FCREPO-3480

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Since we no longer support POST's to LDPCv with Memento-Datetime, the Vary-Post header should be removed on LDPCv.  In this way, the test suite can discern that the feature is not supported.

# How should this be tested?
Create a resource and verify that the when you curl the time map (http://localhost:8080/rest/resource/fcr:versions no longer contains the "Vary-Post: Memento-Datetime" header.
A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
