### PR TITLE
Alter preferTags to use enum (Minimal container triples)

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -48,7 +48,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice.INCLUDE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -775,7 +774,7 @@ public class WebACFilter extends RequestContextFilter {
         final MultiPrefer multiPrefer = new MultiPrefer(preferTagSet);
         if (multiPrefer.hasReturn()) {
             final LdpPreferTag ldpPreferences = new LdpPreferTag(multiPrefer.getReturn());
-            return ldpPreferences.prefersEmbed().equals(INCLUDE);
+            return ldpPreferences.displayEmbed();
         }
         return false;
     }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -48,6 +48,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice.INCLUDE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -774,7 +775,7 @@ public class WebACFilter extends RequestContextFilter {
         final MultiPrefer multiPrefer = new MultiPrefer(preferTagSet);
         if (multiPrefer.hasReturn()) {
             final LdpPreferTag ldpPreferences = new LdpPreferTag(multiPrefer.getReturn());
-            return ldpPreferences.prefersEmbed();
+            return ldpPreferences.prefersEmbed().equals(INCLUDE);
         }
         return false;
     }

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -204,6 +204,11 @@
       <version>1.4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- This dependency is for compile-time: it keeps this module independent 
       of any given choice of JAX-RS implementation. It must be _after_ the test 
       gear. Otherwise it will get loaded during test phase, but because this is 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -128,6 +128,7 @@ import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 import org.fcrepo.kernel.api.services.CreateResourceService;
 import org.fcrepo.kernel.api.services.DeleteResourceService;
@@ -289,7 +290,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 transaction(), resource, ldpPreferences, limit));
 
         // Embed the children of this object
-        if (ldpPreferences.prefersEmbed()) {
+        if (ldpPreferences.prefersEmbed().equals(preferChoice.INCLUDE)) {
             final var containedResources = resourceFactory.getChildren(
                     TransactionUtils.openTxId(transaction()),
                     resource.getFedoraId());
@@ -302,7 +303,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 embedStreams.stream().reduce(empty(), Stream::concat)
         );
 
-        if (httpTripleUtil != null && ldpPreferences.prefersServerManaged()) {
+        if (httpTripleUtil != null &&
+                !ldpPreferences.prefersServerManaged().equals(preferChoice.EXCLUDE)) {
             // Adds fixity service triple to all resources and transaction triple to repo root.
             return httpTripleUtil.addHttpComponentModelsForResourceToStream(rdfStream, resource, uriInfo);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -128,7 +128,6 @@ import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.kernel.api.models.WebacAcl;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
-import org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 import org.fcrepo.kernel.api.services.CreateResourceService;
 import org.fcrepo.kernel.api.services.DeleteResourceService;
@@ -290,7 +289,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 transaction(), resource, ldpPreferences, limit));
 
         // Embed the children of this object
-        if (ldpPreferences.prefersEmbed().equals(preferChoice.INCLUDE)) {
+        if (ldpPreferences.displayEmbed()) {
             final var containedResources = resourceFactory.getChildren(
                     TransactionUtils.openTxId(transaction()),
                     resource.getFedoraId());
@@ -303,8 +302,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 embedStreams.stream().reduce(empty(), Stream::concat)
         );
 
-        if (httpTripleUtil != null &&
-                !ldpPreferences.prefersServerManaged().equals(preferChoice.EXCLUDE)) {
+        if (httpTripleUtil != null && ldpPreferences.displayServerManaged()) {
             // Adds fixity service triple to all resources and transaction triple to repo root.
             return httpTripleUtil.addHttpComponentModelsForResourceToStream(rdfStream, resource, uriInfo);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -74,23 +74,23 @@ public class EtagService {
 
         // Factor in preferences which change which triples are included in the response
         etag.append('|');
-        if (!prefers.prefersContainment().equals(LdpTriplePreferences.preferChoice.EXCLUDE)) {
+        if (prefers.displayContainment()) {
             final var lastUpdated = containmentIndex.containmentLastUpdated(txId, resource.getFedoraId());
             if (lastUpdated != null) {
                 etag.append(lastUpdated);
             }
         }
         etag.append('|');
-        if (!prefers.prefersMembership().equals(LdpTriplePreferences.preferChoice.EXCLUDE)) {
+        if (prefers.displayMembership()) {
             final var lastUpdated = membershipService.getLastUpdatedTimestamp(txId, resource.getFedoraId());
             if (lastUpdated != null) {
                 etag.append(lastUpdated);
             }
         }
-        addComponent(etag, prefers.prefersEmbed());
-        addComponent(etag, prefers.preferMinimal());
-        addComponent(etag, prefers.prefersReferences());
-        addComponent(etag, prefers.prefersServerManaged());
+        addComponent(etag, prefers.displayEmbed());
+        addComponent(etag, prefers.displayUserRdf());
+        addComponent(etag, prefers.displayReferences());
+        addComponent(etag, prefers.displayServerManaged());
 
         // Compute a digest of all these components to use as the etag
         final String etagMd5 = DigestUtils.md5Hex(etag.toString()).toUpperCase();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -74,21 +74,21 @@ public class EtagService {
 
         // Factor in preferences which change which triples are included in the response
         etag.append('|');
-        if (prefers.prefersContainment()) {
+        if (!prefers.prefersContainment().equals(LdpTriplePreferences.preferChoice.EXCLUDE)) {
             final var lastUpdated = containmentIndex.containmentLastUpdated(txId, resource.getFedoraId());
             if (lastUpdated != null) {
                 etag.append(lastUpdated);
             }
         }
         etag.append('|');
-        if (prefers.prefersMembership()) {
+        if (!prefers.prefersMembership().equals(LdpTriplePreferences.preferChoice.EXCLUDE)) {
             final var lastUpdated = membershipService.getLastUpdatedTimestamp(txId, resource.getFedoraId());
             if (lastUpdated != null) {
                 etag.append(lastUpdated);
             }
         }
         addComponent(etag, prefers.prefersEmbed());
-        addComponent(etag, prefers.preferNoUserRdf());
+        addComponent(etag, prefers.preferMinimal());
         addComponent(etag, prefers.prefersReferences());
         addComponent(etag, prefers.prefersServerManaged());
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -45,6 +45,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
@@ -94,6 +95,7 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.vocabulary.DC_11.title;
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.fcrepo.http.commons.test.util.TestHelpers.parseTriples;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
@@ -101,6 +103,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.CONSTRAINED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.EXTERNAL_CONTENT;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
@@ -126,9 +129,12 @@ public abstract class AbstractResourceIT {
 
     protected static final String NON_RDF_SOURCE_LINK_HEADER = "<" + NON_RDF_SOURCE.getURI() + ">;rel=\"type\"";
     protected static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">;rel=\"type\"";
+    protected static final String DIRECT_CONTAINER_LINK_HEADER = "<" + DIRECT_CONTAINER.getURI() + ">; rel=\"type\"";
 
     private static final String OMIT_SERVER_PREFER_HEADER = "return=representation; omit=\"" + PREFER_SERVER_MANAGED +
             "\"";
+
+    protected static final Node DCTITLE = title.asNode();
 
     @Inject
     private ContainerWrapper containerWrapper;
@@ -390,7 +396,7 @@ public abstract class AbstractResourceIT {
      *
      * @param uri uri of the resource
      * @return etag
-     * @throws IOException
+     * @throws IOException if the uri is invalid
      */
     protected String getEtag(final String uri) throws IOException {
         return getEtag(new HttpHead(uri));
@@ -400,7 +406,7 @@ public abstract class AbstractResourceIT {
      * Get the etag returned when executing the provided method
      * @param method method to execute
      * @return etag
-     * @throws IOException
+     * @throws IOException in case of a problem or the connection was aborted
      */
     protected String getEtag(final HttpUriRequest method) throws IOException {
         try (final CloseableHttpResponse response = execute(method)) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/LDPContainerIT.java
@@ -25,6 +25,10 @@ import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.awaitility.Awaitility.await;
 import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_LINK_FORMAT;
 import static org.fcrepo.http.commons.session.TransactionConstants.ATOMIC_ID_HEADER;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
@@ -36,9 +40,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.MEMBER_SUBJECT;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -56,6 +57,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response.Status;
 
+import org.fcrepo.kernel.api.RdfLexicon;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -72,7 +75,6 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
-import org.fcrepo.kernel.api.RdfLexicon;
 import org.junit.Test;
 import org.springframework.test.context.TestExecutionListeners;
 
@@ -699,8 +701,12 @@ public class LDPContainerIT extends AbstractResourceIT {
 
         final var member2Mementos = listMementoIds(member2Id);
         assertEquals(2, member2Mementos.size());
-        assertMementoIsMemberOf(member2Mementos.get(0), EX_IS_MEMBER_PROP, membershipRescId);
-        assertMementoIsMemberOf(member2Mementos.get(1), RdfLexicon.LDP_MEMBER, membershipRescId);
+        await().atMost(2, TimeUnit.SECONDS).until(() -> {
+            assertMementoIsMemberOf(member2Mementos.get(0), EX_IS_MEMBER_PROP, membershipRescId);
+            assertMementoIsMemberOf(member2Mementos.get(1), RdfLexicon.LDP_MEMBER, membershipRescId);
+            return true;
+        });
+
         assertIsMemberOf(member2Id, RdfLexicon.LDP_MEMBER, membershipRescId);
 
         final var member3Mementos = listMementoIds(member3Id);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
@@ -1,0 +1,704 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.http.api;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.jena.graph.Node.ANY;
+import static org.apache.jena.graph.NodeFactory.createLiteral;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.vocabulary.DC_11.title;
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.DIRECT_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
+import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.LDP_MEMBER;
+import static org.fcrepo.kernel.api.RdfLexicon.MEMBERSHIP_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.DC_11;
+import org.junit.Test;
+import org.springframework.test.context.TestExecutionListeners;
+
+/**
+ * Integration tests for various Prefer headers
+ * @author whikloj
+ * @since 6.0.0
+ */
+@TestExecutionListeners(
+        listeners = { TestIsolationExecutionListener.class },
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public class PrefersLdpIT extends AbstractResourceIT {
+
+    private String mainResource;
+
+    private Quad userRdfTriple;
+
+    private Quad systemManagedPropertyTriple;
+
+    private Quad membershipTriple;
+
+    private Quad inboundReferenceTriple;
+
+    private Quad containmentTriple;
+
+    private Quad embededTriple;
+
+    /**
+     * Execute a request, test for a CREATED response code and return the location.
+     * @param request the request.
+     * @return the location URI.
+     * @throws Exception on problems with request.
+     */
+    private String createAndGetLocation(final HttpUriRequest request) throws Exception {
+        try (final var response = execute(request)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            return getLocation(response);
+        }
+    }
+
+    /**
+     * Generate a quad.
+     * @param subject the subject
+     * @param predicate the predicate
+     * @param object the object
+     * @return the quad
+     */
+    private Quad generateQuad(final String subject, final String predicate, final Node object) {
+        return generateQuad(createURI(subject), predicate, object);
+    }
+
+    /**
+     * Generate a quad.
+     * @param subject the subject
+     * @param predicate the predicate
+     * @param object the object
+     * @return the quad
+     */
+    private Quad generateQuad(final Node subject, final String predicate, final String object) {
+        final Node objectNode = (object == null ? ANY : createURI(object));
+        return generateQuad(subject, predicate, objectNode);
+    }
+
+    /**
+     * Generate a quad.
+     * @param subject the subject
+     * @param predicate the predicate
+     * @param object the object
+     * @return the quad
+     */
+    private Quad generateQuad(final Node subject, final String predicate, final Node object) {
+        return Quad.create(ANY, subject, createURI(predicate), object);
+    }
+
+    /**
+     * Create a Prefer header
+     * @param includes String of include URIs or null if none
+     * @param omits String of omit URIs or null if none
+     * @return The Prefer header.
+     */
+    private String preferLink(final String includes, final String omits) {
+        if (includes != null || omits != null) {
+            String link = "return=representation; ";
+            if (includes != null) {
+                link += "include=\"" + includes + "\"";
+            }
+            if (includes != null && omits != null) {
+                link += "; ";
+            }
+            if (omits != null) {
+                link += "omit=\"" + omits + "\"";
+            }
+            return link;
+        }
+        return "";
+    }
+
+    /**
+     * Generate a common set of triples for the Prefer header tests.
+     * @throws Exception problems with a http request.
+     */
+    private void generateResources() throws Exception {
+        // Make the main resource to check with a user triple.
+        final var postMain = postObjMethod();
+        final String body = "<> <" + DC_11.title + "> \"The object's title\" .";
+        postMain.setHeader(CONTENT_TYPE, "text/turtle");
+        postMain.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+        mainResource = createAndGetLocation(postMain);
+        final Node mainNode = createURI(mainResource);
+        userRdfTriple = generateQuad(mainNode, DC_11.title.getURI(), createLiteral("The object's title"));
+        systemManagedPropertyTriple = generateQuad(mainNode, CREATED_DATE.getURI(), ANY);
+        // Make a DirectContainer pointing at the main resource.
+        final var postDC = postObjMethod();
+        postDC.setHeader("Link", "<" + DIRECT_CONTAINER + ">; rel=\"type\"");
+        final String pcdmHasMember = "http://pcdm.org/models#hasMember";
+        final String dcBody =
+                "@prefix ldp: <http://www.w3.org/ns/ldp#> . <> " +
+                        "ldp:membershipResource <" + mainResource + "> ; ldp:hasMemberRelation " +
+                        "<" + pcdmHasMember + "> .";
+        postDC.setHeader(CONTENT_TYPE, "text/turtle");
+        postDC.setEntity(new StringEntity(dcBody, StandardCharsets.UTF_8));
+        final String directResource = createAndGetLocation(postDC);
+        // Make a member of the DC.
+        final var postDCchild = new HttpPost(directResource);
+        final String directResourceReference = createAndGetLocation(postDCchild);
+        membershipTriple = generateQuad(mainNode, pcdmHasMember, directResourceReference);
+        // Make a contained resource.
+        final var postChild = new HttpPost(mainResource);
+        final String childBody = "<> <" + DC_11.title + "> \"The child's title\" .";
+        postChild.setHeader(CONTENT_TYPE, "text/turtle");
+        postChild.setEntity(new StringEntity(childBody, StandardCharsets.UTF_8));
+        final String containedResource = createAndGetLocation(postChild);
+        containmentTriple = generateQuad(mainNode, CONTAINS.getURI(), containedResource);
+        embededTriple = generateQuad(containedResource, DC_11.title.getURI(), createLiteral("The child's title"));
+        // Make an inbound reference.
+        final var otherRef = postObjMethod();
+        final String refBody = "<> <http://example.org/related> <" + mainResource + "> .";
+        otherRef.setHeader(CONTENT_TYPE, "text/turtle");
+        otherRef.setEntity(new StringEntity(refBody, StandardCharsets.UTF_8));
+        final String otherReference = createAndGetLocation(otherRef);
+        inboundReferenceTriple = generateQuad(otherReference, "http://example.org/related", mainNode);
+    }
+
+    @Test
+    public void testNormalTriples() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeMinimal() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(PREFER_MINIMAL_CONTAINER.getURI(), null));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertFalse(graph.contains(containmentTriple));
+            assertFalse(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferOmitMinimal() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(null, PREFER_MINIMAL_CONTAINER.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertFalse(graph.contains(userRdfTriple));
+            assertFalse(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeMinimalAndSystem() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                PREFER_MINIMAL_CONTAINER.getURI() + " " + PREFER_SERVER_MANAGED.getURI(),
+                null));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertFalse(graph.contains(containmentTriple));
+            assertFalse(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferOmitSystem() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                null,
+                PREFER_SERVER_MANAGED.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertFalse(graph.contains(systemManagedPropertyTriple));
+            // Containment is consider system managed.
+            assertFalse(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferOmitSystemIncludeContainment() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                PREFER_CONTAINMENT.getURI(),
+                PREFER_SERVER_MANAGED.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertFalse(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeMinimalOmitSystem() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                PREFER_MINIMAL_CONTAINER.getURI(),
+                PREFER_SERVER_MANAGED.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertFalse(graph.contains(systemManagedPropertyTriple));
+            assertFalse(graph.contains(containmentTriple));
+            assertFalse(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferExcludeMembership() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                null,
+                PREFER_MEMBERSHIP.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertFalse(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeInbound() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                INBOUND_REFERENCES.getURI(),
+                null));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertTrue(graph.contains(inboundReferenceTriple));
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeEmbed() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                EMBED_CONTAINED.getURI(),
+                null));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertTrue(graph.contains(userRdfTriple));
+            assertTrue(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(inboundReferenceTriple));
+            assertTrue(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testPreferIncludeEmbedInbound_OmitMinimal() throws Exception {
+        generateResources();
+        final var getReq = new HttpGet(mainResource);
+        getReq.setHeader("Prefer", preferLink(
+                EMBED_CONTAINED.getURI() + " " + INBOUND_REFERENCES.getURI(),
+                PREFER_MINIMAL_CONTAINER.getURI()));
+        try (final var dataset = getDataset(getReq)) {
+            final var graph = dataset.asDatasetGraph();
+            assertFalse(graph.contains(userRdfTriple));
+            assertFalse(graph.contains(systemManagedPropertyTriple));
+            assertTrue(graph.contains(containmentTriple));
+            assertTrue(graph.contains(membershipTriple));
+            assertTrue(graph.contains(inboundReferenceTriple));
+            // Omitting minimal removes user rdf, this also happens to the embedded resources.
+            assertFalse(graph.contains(embededTriple));
+        }
+    }
+
+    @Test
+    public void testGetObjectGraphMinimal() throws IOException {
+        final String uri;
+        final HttpPost httpPost = postObjMethod();
+        httpPost.setHeader("Link", BASIC_CONTAINER_LINK_HEADER);
+        httpPost.setHeader(CONTENT_TYPE, "text/turtle");
+        httpPost.setEntity(new StringEntity("<> <" + DCTITLE.getURI() + "> \"The title\" ."));
+        try (final CloseableHttpResponse response = execute(httpPost)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            uri = getLocation(response);
+        }
+        final Node resource = createURI(uri);
+        // Create a contained child.
+        final HttpPut httpPut = new HttpPut(uri + "/a");
+        assertEquals(CREATED.getStatusCode(), getStatus(httpPut));
+
+        // Now test with include preference
+        final HttpGet httpGet = new HttpGet(uri);
+        final String preferHeader2 = preferLink(PREFER_MINIMAL_CONTAINER.toString(), null);
+        httpGet.setHeader("Prefer", preferHeader2);
+        try (final CloseableHttpResponse response = execute(httpGet);
+             final CloseableDataset dataset = getDataset(response)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertFalse("Didn't expect members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched",
+                    preferenceApplied.contains(preferHeader2));
+            assertTrue("Missing a user RDF triple", graph.contains(ANY, resource, DCTITLE, ANY));
+        }
+        // Now try with Omit minimal
+        final HttpGet getOmit = new HttpGet(uri);
+        final String preferOmitHeader = preferLink(null, PREFER_MINIMAL_CONTAINER.toString());
+        getOmit.addHeader("Prefer", preferOmitHeader);
+        try (final CloseableHttpResponse response = execute(getOmit);
+             final CloseableDataset dataset = getDataset(response)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue("Expected members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't matched",
+                    preferenceApplied.contains(preferOmitHeader));
+            assertFalse("Should not return user RDF triples", graph.contains(ANY, resource, DCTITLE, ANY));
+        }
+    }
+
+    @Test
+    public void testGetObjectOmitMembership() throws IOException {
+        final String id = getRandomUniqueId();
+        final Node resource = createURI(serverAddress + id);
+        createObjectAndClose(id, BASIC_CONTAINER_LINK_HEADER);
+        final String initialEtag = getEtag(serverAddress + id);
+        createObjectAndClose(id + "/a");
+        final String withChildEtag = getEtag(serverAddress + id);
+        assertNotEquals(initialEtag, withChildEtag);
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer", preferLink(null, PREFER_CONTAINMENT + " " + PREFER_MEMBERSHIP));
+        final String omitEtag = getEtag(getObjMethod);
+        assertEquals(initialEtag, omitEtag);
+        assertNotEquals(withChildEtag, omitEtag);
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected no members", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetObjectOmitContainment() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String initialEtag = getEtag(serverAddress + id);
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final String withMemberEtag = getEtag(serverAddress + id);
+        assertNotEquals(initialEtag, withMemberEtag);
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer", preferLink(null, PREFER_CONTAINMENT.toString()));
+        final String omitEtag = getEtag(getObjMethod);
+        assertNotEquals("Should not match initial because of membership", initialEtag, omitEtag);
+        assertNotEquals(withMemberEtag, omitEtag);
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed", graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing contained", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetObjectOmitServerManaged() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final String withMemberEtag = getEtag(serverAddress + id);
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer", preferLink(null, PREFER_SERVER_MANAGED.toString()));
+        assertNotEquals("Etag should not match with SMTs excluded", withMemberEtag, getEtag(getObjMethod));
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, BASIC_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetObjectIncludeContainmentAndOmitServerManaged() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String location = serverAddress + id;
+        final String updateString = "<> <" + MEMBERSHIP_RESOURCE.getURI() +
+                "> <" + location + "> ; <" + HAS_MEMBER_RELATION + "> <" + LDP_MEMBER + "> .";
+        final HttpPut put = putObjMethod(id + "/a", "text/turtle", updateString);
+        put.setHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
+        assertEquals(CREATED.getStatusCode(), getStatus(put));
+        assertTrue(getLinkHeaders(getObjMethod(id + "/a")).contains(DIRECT_CONTAINER_LINK_HEADER));
+        createObject(id + "/a/1");
+
+        final String withMemberEtag = getEtag(serverAddress + id);
+
+        final HttpGet getObjMethod = getObjMethod(id);
+        getObjMethod.addHeader("Prefer", preferLink(PREFER_CONTAINMENT.toString(), PREFER_SERVER_MANAGED.toString()));
+        assertNotEquals("Etag should not match with SMTs excluded", withMemberEtag, getEtag(getObjMethod));
+        try (final CloseableDataset dataset = getDataset(getObjMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(serverAddress + id);
+            assertTrue("Didn't find ldp containment", graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetLDPRmOmitServerManaged() throws Exception {
+        final String versionedResourceURI = createAndGetLocation(postObjMethod());
+        final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));
+        final String mementoEtag = getEtag(mementoResourceURI);
+
+        final HttpGet mementoGetMethod = new HttpGet(mementoResourceURI);
+        mementoGetMethod.addHeader("Prefer", preferLink(null, PREFER_SERVER_MANAGED.toString()));
+        assertNotEquals(mementoEtag, getEtag(mementoGetMethod));
+        try (final CloseableDataset dataset = getDataset(mementoGetMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(versionedResourceURI);
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertFalse("Expected nothing server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testGetLDPRmWithoutOmitServerManager() throws Exception {
+        final String versionedResourceURI = createAndGetLocation(postObjMethod());
+        final String mementoResourceURI = getLocation(new HttpPost(versionedResourceURI + "/fcr:versions"));
+
+        final HttpGet mementoGetMethod = new HttpGet(mementoResourceURI);
+        try (final CloseableDataset dataset = getDataset(mementoGetMethod)) {
+            final DatasetGraph graph = dataset.asDatasetGraph();
+            final Node resource = createURI(versionedResourceURI);
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, RDF_SOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_CONTAINER.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, ANY, FEDORA_RESOURCE.asNode()).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, CREATED_DATE.asNode(), ANY).hasNext());
+            assertTrue("Expected server managed",
+                    graph.find(ANY, resource, LAST_MODIFIED_DATE.asNode(), ANY).hasNext());
+        }
+    }
+
+    @Test
+    public void testEmbeddedContainedResources() throws IOException {
+        final String id = getRandomUniqueId();
+        final String binaryId = "binary0";
+        final String preferEmbed = preferLink(EMBED_CONTAINED.toString(), null);
+
+        assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
+        assertEquals(CREATED.getStatusCode(), getStatus(putDSMethod(id, binaryId, "some test content")));
+
+        final HttpPatch httpPatch = patchObjMethod(id + "/" + binaryId + "/fcr:metadata");
+        httpPatch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        httpPatch.setEntity(new StringEntity(
+                "INSERT { <> <http://purl.org/dc/elements/1.1/title> 'this is a title' } WHERE {}"));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(httpPatch));
+
+        final String withoutEmbedEtag = getEtag(serverAddress + id);
+
+        final HttpGet httpGet = getObjMethod(id);
+        httpGet.setHeader("Prefer", preferEmbed);
+        assertNotEquals(withoutEmbedEtag, getEtag(httpGet));
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't match", preferenceApplied.contains(preferEmbed));
+
+            final DatasetGraph graphStore = getDataset(response).asDatasetGraph();
+            assertTrue("Property on child binary should be found!" + graphStore, graphStore.contains(ANY,
+                    createURI(serverAddress + id + "/" + binaryId),
+                    title.asNode(), createLiteral("this is a title")));
+        }
+    }
+
+    @Test
+    public void testEmbeddedContainedResourcesNotToDeep() throws IOException {
+        final String id = getRandomUniqueId();
+        final String level1 = id + "/" + getRandomUniqueId();
+        final String level2 = level1 + "/" + getRandomUniqueId();
+        final String preferEmbed = preferLink(EMBED_CONTAINED.toString(), null);
+
+        assertEquals(CREATED.getStatusCode(), getStatus(putObjMethod(id)));
+
+        final HttpPut putLevel1 = putObjMethod(level1);
+        putLevel1.addHeader(CONTENT_TYPE, "text/turtle");
+        putLevel1.setEntity(new StringEntity("<> <" + title + "> \"First level\"", UTF_8));
+        assertEquals(CREATED.getStatusCode(), getStatus(putLevel1));
+
+        final HttpPut putLevel2 = putObjMethod(level2);
+        putLevel2.addHeader(CONTENT_TYPE, "text/turtle");
+        putLevel2.setEntity(new StringEntity("<> <" + title + "> \"Second level\"", UTF_8));
+        assertEquals(CREATED.getStatusCode(), getStatus(putLevel2));
+
+        final HttpGet httpGet = getObjMethod(id);
+        httpGet.setHeader("Prefer", preferEmbed);
+        try (final CloseableHttpResponse response = execute(httpGet)) {
+            final Collection<String> preferenceApplied = getHeader(response, "Preference-Applied");
+            assertTrue("Preference-Applied header doesn't match", preferenceApplied.contains(preferEmbed));
+
+            final DatasetGraph graphStore = getDataset(response).asDatasetGraph();
+            assertTrue("Property on child binary should be found!" + graphStore, graphStore.contains(ANY,
+                    createURI(serverAddress + level1),
+                    title.asNode(), createLiteral("First level")));
+            assertFalse("Property from embedded resource's own child should not be found.",
+                    graphStore.contains(ANY,
+                            createURI(serverAddress + level2),
+                            title.asNode(), createLiteral("Second level")
+                    )
+            );
+        }
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
@@ -288,7 +288,8 @@ public class PrefersLdpIT extends AbstractResourceIT {
             assertFalse(graph.contains(systemManagedPropertyTriple));
             // Containment is consider system managed.
             assertFalse(graph.contains(containmentTriple));
-            assertTrue(graph.contains(membershipTriple));
+            // Membership is considered system managed.
+            assertFalse(graph.contains(membershipTriple));
             assertFalse(graph.contains(inboundReferenceTriple));
             assertFalse(graph.contains(embededTriple));
         }
@@ -306,7 +307,7 @@ public class PrefersLdpIT extends AbstractResourceIT {
             assertTrue(graph.contains(userRdfTriple));
             assertFalse(graph.contains(systemManagedPropertyTriple));
             assertTrue(graph.contains(containmentTriple));
-            assertTrue(graph.contains(membershipTriple));
+            assertFalse(graph.contains(membershipTriple));
             assertFalse(graph.contains(inboundReferenceTriple));
             assertFalse(graph.contains(embededTriple));
         }
@@ -537,7 +538,8 @@ public class PrefersLdpIT extends AbstractResourceIT {
         try (final CloseableDataset dataset = getDataset(getObjMethod)) {
             final DatasetGraph graph = dataset.asDatasetGraph();
             final Node resource = createURI(serverAddress + id);
-            assertTrue("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
+            // Membership is now consider system managed and so is removed with the rest.
+            assertFalse("Didn't find member resources", graph.find(ANY, resource, LDP_MEMBER.asNode(), ANY).hasNext());
             assertFalse("Expected nothing server managed",
                     graph.find(ANY, resource, CONTAINS.asNode(), ANY).hasNext());
             assertFalse("Expected nothing server managed",

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -25,6 +25,8 @@ import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
+import static org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice.EXCLUDE;
+import static org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice.INCLUDE;
 
 import java.util.List;
 import java.util.Optional;
@@ -99,32 +101,58 @@ public class LdpPreferTag extends PreferTag implements LdpTriplePreferences {
     }
 
     @Override
-    public preferChoice preferMinimal() {
-        return minimal;
+    public boolean displayUserRdf() {
+        // Displayed by default unless we asked to exclude minimal container.
+        return !minimal.equals(EXCLUDE);
     }
 
     @Override
-    public preferChoice prefersMembership() {
-        return membership;
+    public boolean displayMembership() {
+        // Displayed by default unless we specifically asked for it or didn't specifically ask for a minimal container
+        // AND ( we didn't exclude either managed properties or membership ).
+        return membership.equals(INCLUDE) || notIncludeMinimal() && (
+                        notExcludeManaged() && !membership.equals(EXCLUDE)
+        );
     }
 
     @Override
-    public preferChoice prefersContainment() {
-        return containment;
+    public boolean displayContainment() {
+        // Displayed by default unless we specifically asked for it or didn't specifically ask for a minimal container
+        // AND ( we didn't exclude either managed properties or containment ).
+        return containment.equals(INCLUDE) || notIncludeMinimal() && (
+                        notExcludeManaged() && !containment.equals(EXCLUDE)
+        );
     }
 
     @Override
-    public preferChoice prefersReferences() {
-        return references;
+    public boolean displayReferences() {
+        // If we did ask for references. (Not shown by default).
+        return references.equals(INCLUDE);
     }
 
     @Override
-    public preferChoice prefersEmbed() {
-        return embed;
+    public boolean displayEmbed() {
+        // If we did ask for embedded resources. (Not shown by default).
+        return embed.equals(preferChoice.INCLUDE);
     }
 
     @Override
-    public preferChoice prefersServerManaged() {
-        return managedProperties;
+    public boolean displayServerManaged() {
+        // Displayed by default, unless excluded minimal container or managed properties.
+        return !minimal.equals(EXCLUDE) && notExcludeManaged();
+    }
+
+    /**
+     * @return whether we did not explicitly ask for a minimal container.
+     */
+    private boolean notIncludeMinimal() {
+        return !minimal.equals(INCLUDE);
+    }
+
+    /**
+     * @return whether we did not explicitly exclude managed properties.
+     */
+    private boolean notExcludeManaged() {
+        return !managedProperties.equals(EXCLUDE);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTag.java
@@ -133,7 +133,7 @@ public class LdpPreferTag extends PreferTag implements LdpTriplePreferences {
     @Override
     public boolean displayEmbed() {
         // If we did ask for embedded resources. (Not shown by default).
-        return embed.equals(preferChoice.INCLUDE);
+        return embed.equals(INCLUDE);
     }
 
     @Override

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
@@ -22,10 +22,10 @@ import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.fcrepo.http.commons.domain.PreferTag;
-import org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice;
 
 import org.junit.Test;
 
@@ -37,17 +37,30 @@ public class LdpPreferTagTest {
     private LdpPreferTag testObj;
 
     @Test
+    public void testDefaultDecisions() {
+        final PreferTag prefer = PreferTag.emptyTag();
+        testObj = new LdpPreferTag(prefer);
+
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertTrue(testObj.displayContainment());
+        assertTrue(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
+    }
+
+    @Test
     public void testMinimalContainer() {
         final PreferTag prefer
                 = new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
-        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertFalse(testObj.displayContainment());
+        assertFalse(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
@@ -57,12 +70,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_MEMBERSHIP + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertFalse(testObj.displayContainment());
+        assertTrue(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
@@ -72,12 +85,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersContainment());
-        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertTrue(testObj.displayContainment());
+        assertFalse(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
@@ -87,12 +100,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersContainment());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertTrue(testObj.displayContainment());
+        assertTrue(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
@@ -102,12 +115,12 @@ public class LdpPreferTagTest {
                                                                  + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.EXCLUDE, testObj.prefersContainment());
-        assertEquals(preferChoice.EXCLUDE, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertFalse(testObj.displayContainment());
+        assertFalse(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
@@ -116,33 +129,23 @@ public class LdpPreferTagTest {
                 = new PreferTag("return=representation; include=\"" + INBOUND_REFERENCES + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersReferences());
-        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
-        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
-    }
-
-    @Test
-    public void testEmbedDefault() {
-        testObj = new LdpPreferTag(PreferTag.emptyTag());
-        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
-        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
-        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertTrue(testObj.displayReferences());
+        assertTrue(testObj.displayContainment());
+        assertTrue(testObj.displayMembership());
+        assertFalse(testObj.displayEmbed());
     }
 
     @Test
     public void testEmbedContained() {
         testObj = new LdpPreferTag(new PreferTag("return=representation; include=\"" + EMBED_CONTAINED + "\""));
-        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
-        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
-        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
-        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
-        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
-        assertEquals(preferChoice.INCLUDE, testObj.prefersEmbed());
+
+        assertTrue(testObj.displayUserRdf());
+        assertTrue(testObj.displayServerManaged());
+        assertFalse(testObj.displayReferences());
+        assertTrue(testObj.displayContainment());
+        assertTrue(testObj.displayMembership());
+        assertTrue(testObj.displayEmbed());
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/ldp/LdpPreferTagTest.java
@@ -17,16 +17,17 @@
  */
 package org.fcrepo.http.commons.domain.ldp;
 
-import org.fcrepo.http.commons.domain.PreferTag;
-import org.junit.Test;
-
 import static org.fcrepo.kernel.api.RdfLexicon.EMBED_CONTAINED;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_CONTAINMENT;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MEMBERSHIP;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_MINIMAL_CONTAINER;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.fcrepo.http.commons.domain.PreferTag;
+import org.fcrepo.kernel.api.rdf.LdpTriplePreferences.preferChoice;
+
+import org.junit.Test;
 
 /**
  * @author cabeer
@@ -35,30 +36,18 @@ public class LdpPreferTagTest {
 
     private LdpPreferTag testObj;
 
-
-    @Test
-    public void testMinimalHandling() {
-        testObj = new LdpPreferTag(new PreferTag("handling=lenient; received=\"minimal\""));
-
-        assertFalse(testObj.prefersServerManaged());
-        assertFalse(testObj.prefersContainment());
-        assertFalse(testObj.prefersMembership());
-        assertFalse(testObj.prefersEmbed());
-        assertFalse(testObj.prefersReferences());
-
-    }
-
     @Test
     public void testMinimalContainer() {
         final PreferTag prefer
                 = new PreferTag("return=representation; include=\"" + PREFER_MINIMAL_CONTAINER + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertTrue(testObj.prefersServerManaged());
-        assertFalse(testObj.prefersReferences());
-        assertFalse(testObj.prefersContainment());
-        assertFalse(testObj.prefersMembership());
-        assertFalse(testObj.prefersEmbed());
+        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
@@ -68,7 +57,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_MEMBERSHIP + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertTrue(testObj.prefersMembership());
+        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
@@ -78,7 +72,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertTrue(testObj.prefersContainment());
+        assertEquals(preferChoice.INCLUDE, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
@@ -88,8 +87,12 @@ public class LdpPreferTagTest {
                                                                     + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertTrue(testObj.prefersMembership());
-        assertTrue(testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersContainment());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
@@ -99,8 +102,12 @@ public class LdpPreferTagTest {
                                                                  + PREFER_CONTAINMENT + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertFalse(testObj.prefersMembership());
-        assertFalse(testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.EXCLUDE, testObj.prefersContainment());
+        assertEquals(preferChoice.EXCLUDE, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
@@ -109,18 +116,33 @@ public class LdpPreferTagTest {
                 = new PreferTag("return=representation; include=\"" + INBOUND_REFERENCES + "\"");
         testObj = new LdpPreferTag(prefer);
 
-        assertTrue(testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
     public void testEmbedDefault() {
         testObj = new LdpPreferTag(PreferTag.emptyTag());
-        assertFalse(testObj.prefersEmbed());
+        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
+        assertEquals(preferChoice.SILENT, testObj.prefersEmbed());
     }
 
     @Test
     public void testEmbedContained() {
         testObj = new LdpPreferTag(new PreferTag("return=representation; include=\"" + EMBED_CONTAINED + "\""));
-        assertTrue(testObj.prefersEmbed());
+        assertEquals(preferChoice.SILENT, testObj.preferMinimal());
+        assertEquals(preferChoice.SILENT, testObj.prefersServerManaged());
+        assertEquals(preferChoice.SILENT, testObj.prefersReferences());
+        assertEquals(preferChoice.SILENT, testObj.prefersContainment());
+        assertEquals(preferChoice.SILENT, testObj.prefersMembership());
+        assertEquals(preferChoice.INCLUDE, testObj.prefersEmbed());
     }
 }

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -158,7 +158,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.awaitility</groupId>
+      <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <exclusions>
         <exclusion>

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -17,14 +17,42 @@
  */
 package org.fcrepo.integration.jms.observer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.awaitility.Duration;
-import com.jayway.awaitility.core.ConditionTimeoutException;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.vocabulary.RDF;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.UUID.randomUUID;
+import static javax.jms.Session.AUTO_ACKNOWLEDGE;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
+import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
+import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
+import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.ws.rs.core.UriBuilder;
+
 import org.fcrepo.event.serialization.JsonLDEventMessage;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.Transaction;
@@ -40,6 +68,12 @@ import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.api.services.ReplaceBinariesService;
 import org.fcrepo.kernel.api.services.ReplacePropertiesService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,44 +81,8 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import javax.inject.Inject;
-import javax.jms.Connection;
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import javax.ws.rs.core.UriBuilder;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.UUID.randomUUID;
-
-import static javax.jms.Session.AUTO_ACKNOWLEDGE;
-
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
-import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
-import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
-import static org.fcrepo.kernel.api.observer.EventType.INBOUND_REFERENCE;
-import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_CREATION;
-import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_DELETION;
-import static org.fcrepo.kernel.api.observer.EventType.RESOURCE_MODIFICATION;
-import static org.junit.Assert.fail;
-import static org.slf4j.LoggerFactory.getLogger;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * <p>
@@ -322,7 +320,7 @@ abstract class AbstractJmsIT implements MessageListener {
 
     private void awaitNoMessageOrFail(final String id, final String eventType, final String resourceType) {
         try {
-            await().atMost(new Duration(TIMEOUT, TimeUnit.MILLISECONDS)).until(() -> messages.stream().anyMatch(msg -> {
+            await().atMost(TIMEOUT, TimeUnit.MILLISECONDS).until(() -> messages.stream().anyMatch(msg -> {
                 try {
                     return checkForMatchingMessage(msg, id, eventType, resourceType);
                 } catch (final JMSException | JsonProcessingException e) {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
@@ -25,37 +25,48 @@ package org.fcrepo.kernel.api.rdf;
 public interface LdpTriplePreferences {
 
     /**
-     * @return Whether to return a minimal container.
+     * What the prefer tag choice is.
      */
-    boolean getMinimal();
+    enum preferChoice {
+        INCLUDE("Include"),
+        EXCLUDE("Exclude"),
+        SILENT("Silent");
+
+        private String value;
+
+        preferChoice(final String value) {
+            this.value = value;
+        }
+    }
 
     /**
-     * @return Whether this prefer tag demands membership triples.
+     * @return Whether this preference tag asks to include or omit a minimal container or is silent.
      */
-    boolean prefersMembership();
+    preferChoice preferMinimal();
 
     /**
-     * @return Whether this prefer tag demands containment triples.
+     * @return Whether this preference tag asks to include or omit membership triples or is silent.
      */
-    boolean prefersContainment();
+    preferChoice prefersMembership();
 
     /**
-     * @return Whether this prefer tag demands references triples.
+     * @return Whether this preference tag asks to include or omit containment triples or is silent.
      */
-    boolean prefersReferences();
+    preferChoice prefersContainment();
 
     /**
-     * @return Whether this prefer tag demands embedded triples.
+     * @return Whether this preference tag asks to include or omit reference triples or is silent.
      */
-    boolean prefersEmbed();
+    preferChoice prefersReferences();
 
     /**
-     * @return Whether this prefer tag demands server managed properties.
+     * @return Whether this preference tag asks to include or omit embedded triples or is silent.
      */
-    boolean prefersServerManaged();
+    preferChoice prefersEmbed();
 
     /**
-     * @return Whether this prefer tag demands no minimal container, ie. no user RDF.
+     * @return Whether this preference tag asks to include or omit server managed triples or is silent.
      */
-    boolean preferNoUserRdf();
+    preferChoice prefersServerManaged();
+
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/rdf/LdpTriplePreferences.java
@@ -18,7 +18,7 @@
 package org.fcrepo.kernel.api.rdf;
 
 /**
- * Kernel level API to hold the LdpPreferTag decisions.
+ * Kernel level API to hold the LdpPreferTag and internal logic decisions.
  * @author whikloj
  * @since 6.0.0
  */
@@ -28,45 +28,39 @@ public interface LdpTriplePreferences {
      * What the prefer tag choice is.
      */
     enum preferChoice {
-        INCLUDE("Include"),
-        EXCLUDE("Exclude"),
-        SILENT("Silent");
-
-        private String value;
-
-        preferChoice(final String value) {
-            this.value = value;
-        }
+        INCLUDE,
+        EXCLUDE,
+        SILENT
     }
 
     /**
-     * @return Whether this preference tag asks to include or omit a minimal container or is silent.
+     * @return Whether to display user rdf based on this preference tag and internal defaults.
      */
-    preferChoice preferMinimal();
+    boolean displayUserRdf();
 
     /**
-     * @return Whether this preference tag asks to include or omit membership triples or is silent.
+     * @return Whether to display membership triples based on this preference tag and internal defaults.
      */
-    preferChoice prefersMembership();
+    boolean displayMembership();
 
     /**
-     * @return Whether this preference tag asks to include or omit containment triples or is silent.
+     * @return Whether to display containment triples based on this preference tag and internal defaults.
      */
-    preferChoice prefersContainment();
+    boolean displayContainment();
 
     /**
-     * @return Whether this preference tag asks to include or omit reference triples or is silent.
+     * @return Whether to display inbound reference triples based on this preference tag and internal defaults.
      */
-    preferChoice prefersReferences();
+    boolean displayReferences();
 
     /**
-     * @return Whether this preference tag asks to include or omit embedded triples or is silent.
+     * @return Whether to display contained resources' triples based on this preference tag and internal defaults.
      */
-    preferChoice prefersEmbed();
+    boolean displayEmbed();
 
     /**
-     * @return Whether this preference tag asks to include or omit server managed triples or is silent.
+     * @return Whether to display server managed triples based on this preference tag and internal defaults.
      */
-    preferChoice prefersServerManaged();
+    boolean displayServerManaged();
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <mysql.version>8.0.22</mysql.version>
     <mariadb.version>2.7.0</mariadb.version>
     <!-- test gear -->
-    <awaitility.version>1.7.0</awaitility.version>
+    <awaitility.version>4.0.3</awaitility.version>
     <grizzly.version>2.4.4</grizzly.version>
     <junit.version>4.13.1</junit.version>
     <system-rules.version>1.18.0</system-rules.version>
@@ -581,7 +581,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>com.jayway.awaitility</groupId>
+        <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${awaitility.version}</version>
         <scope>test</scope>


### PR DESCRIPTION
Setup new ITs.

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3334

# What does this Pull Request do?
Makes an new enum to allow for identifying include, exclude or silent prefer headers.

Made new `PrefersLdpIT` to hold prefer header tests. Moved several tests from `FedoraLdpIT`  to `PrefersLdpIT`

# How should this be tested?

As this is essentially about minimal container triples.
Make a resource, add some Rdf, and a contained resource.
GET the resource.
See user triples, server managed triples and containment triples.
GET the resource with `Prefer: return=representation; include="https://www.w3.org/ns/ldp#PreferMinimalContainer"`
See user triples and server managed triples.
GET the resource with `Prefer: return=representation; omit="https://www.w3.org/ns/ldp#PreferMinimalContainer"`
See containment triples.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
