### PR TITLE
Add total search results to response

### DIFF
--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/PaginationInfo.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/PaginationInfo.java
@@ -29,6 +29,8 @@ public class PaginationInfo {
     private int offset = -1;
     @JsonProperty
     private int maxResults = -1;
+    @JsonProperty
+    private int totalResults;
 
     /**
      * Default constructor
@@ -40,25 +42,32 @@ public class PaginationInfo {
      *
      * @param maxResults max results asked off
      * @param offset     offset of the first result item
+     * @param totalResults The total number of results
      */
-    public PaginationInfo(final int maxResults, final int offset) {
+    public PaginationInfo(final int maxResults, final int offset, final int totalResults) {
         this.maxResults = maxResults;
         this.offset = offset;
+        this.totalResults = totalResults;
     }
 
     /**
-     * The max results of the original query
-     * @return
+     * @return The max results of the original query
      */
     public int getMaxResults() {
         return maxResults;
     }
 
     /**
-     * The offset specified by original query
-     * @return
+     * @return The offset specified by original query
      */
     public int getOffset() {
         return offset;
+    }
+
+    /**
+     * @return The total number of results for this query.
+     */
+    public int getTotalResults() {
+        return this.totalResults;
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3548

# What does this Pull Request do?
Adds a new value to the JSON response with the total number of results for the current query to assist in paging.

# How should this be tested?

Create some resources in Fedora.
Do a generic search ie. `curl -i -ufedoraAdmin:fedoraAdmin 'http://localhost:8080/rest/fcr:search?condition=fedora_id=*&fields=fedora_id'`
There is no `totalResults` value in `paginationInfo` element.
Pull in this PR, run the same query and see the new element
ie.
```
{"pagination":{"offset":0,"maxResults":100,"totalResults":28}, "items": {...
```



# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
