### PR TITLE
Escape underscores in wildcard searches

### DIFF
--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
@@ -265,6 +265,9 @@ public class DbSearchIndexImpl implements SearchIndex {
                 final String whereClause;
                 if (object.contains("*")) {
                     object = convertToSqlLikeWildcard(object);
+                    if (object.contains("_")) {
+                        object = object.replaceAll("_", "\\\\_");
+                    }
                     whereClause = field + " like :" + paramName;
                 } else {
                     whereClause = field + " = :" + paramName;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3615

This PR relies on #1853, I will leave this as draft until that one is merged.

# What does this Pull Request do?
Escapes underscores in conditions when the condition also has a wildcard.

# How should this be tested?

* Make a resource called `fedora_11` and a resource called `fedora211`
    ```
     > curl -ufedoraAdmin:fedoraAdmin -XPUT 'http://localhost:8080/rest/fedora_11'
     > curl -ufedoraAdmin:fedoraAdmin -XPUT 'http://localhost:8080/rest/fedora211'
     ```
* Do a query for `fedora_1*`
     ```
      > curl -ufedoraAdmin:fedoraAdmin 'http://localhost:8080/rest/fcr:search?condition=fedora_id=fedora_1*&fields=fedora_id'
     ```
* Get both results back.
     ```
     {"pagination":{"offset":0,"maxResults":100},"items":[{"fedora_id":"http://localhost:8080/rest/fedora211"},{"fedora_id":"http://localhost:8080/rest/fedora_11"}]}
     ```
* Pull in this PR. 
* Run the same query. 
* Only get a single result back.
     ```
     {"pagination":{"offset":0,"maxResults":100,"totalResults":1},"items":[{"fedora_id":"http://localhost:8080/rest/fedora_11"}]}
     ```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
