### PR TITLE
Change ServerManaged URI

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -189,7 +189,7 @@ public final class RdfLexicon {
 
     // RDF EXTRACTION
     public static final Property INBOUND_REFERENCES = createProperty(FCREPO_API_NAMESPACE + "PreferInboundReferences");
-    public static final Property PREFER_SERVER_MANAGED = createProperty(REPOSITORY_NAMESPACE + "ServerManaged");
+    public static final Property PREFER_SERVER_MANAGED = createProperty(FCREPO_API_NAMESPACE + "ServerManaged");
     public static final Property PREFER_MINIMAL_CONTAINER = createProperty(LDP_NAMESPACE +
             "PreferMinimalContainer");
     public static final Property PREFER_CONTAINMENT = createProperty(LDP_NAMESPACE + "PreferContainment");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3616

# What does this Pull Request do?
Changes the Prefer URI used to include/omit Server Managed Triples to the new one from the Fedora specification

https://github.com/fcrepo/fcrepo-specification/pull/412

# How should this be tested?

1. Create an RDF resource.
2. Before the PR, do a GET of that resource with the Fedora API prefer header.
     ```
     curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_resource -H"Prefer: return=representation; omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\""
    ```
1. Get all the server managed triples.
2. Pull in this PR
3. Do the same GET and see no server managed triples.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
