### PR TITLE
Fixes broken ExternalContentHandlerIT tests.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -642,7 +642,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     @Test
     public void testCopyUnreachableHttpContent() throws Exception {
-        final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";
+        final String nonexistentPath = "https://" + getRandomUniqueId() + "-non-existent-domain.com/";
 
         // create a copy of it
         final HttpPost httpPost = postObjMethod();
@@ -674,7 +674,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     @Test
     public void testProxyUnreachableHttpContent() throws Exception {
-        final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";
+        final String nonexistentPath = "https://" + getRandomUniqueId() + "-non-existent-domain.com/";
 
         // create a copy of it
         final HttpPost httpPost = postObjMethod();
@@ -690,7 +690,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
 
     @Test
     public void testRedirectUnreachableHttpContent() throws Exception {
-        final String nonexistentPath = "http://" + getRandomUniqueId() + ".example.com/";
+        final String nonexistentPath = "https://" + getRandomUniqueId() + "-non-existent-domain.com/";
 
         // create a copy of it
         final HttpPost httpPost = postObjMethod();


### PR DESCRIPTION
# What does this Pull Request do?
It appears that <uid>.example.com now responds with a 201.  This update changes those invalid external content links with a non-existent domain.

**WAIT TO MERGE THIS: Apparently others are not seeing this problem - let's wait to see if others begin experiencing it**

# How should this be tested?
mvn clean install

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
