### PR TITLE
Account for servletpath of index.html

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -172,12 +172,15 @@ public class WebACFilter extends RequestContextFilter {
         final String host = request.getScheme() + "://" + request.getServerName() +
                 (request.getServerPort() != 80 ? ":" + request.getServerPort() : "") + "/";
         final String requestUrl = request.getRequestURL().toString();
-        final String contextPath = request.getContextPath() + request.getServletPath();
+        final String contextPath = request.getContextPath();
+        final String servletPath = request.getServletPath();
+        final String combinedPath = contextPath + (!servletPath.equalsIgnoreCase("/index.html") ?
+                servletPath : "");
         final String baseUri;
-        if (contextPath.length() == 0) {
+        if (combinedPath.length() == 0 || !requestUrl.contains(combinedPath)) {
             baseUri = host;
         } else {
-            baseUri = requestUrl.split(contextPath)[0] + contextPath + "/";
+            baseUri = requestUrl.split(combinedPath)[0] + combinedPath + "/";
         }
         return URI.create(baseUri);
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3625

# What does this Pull Request do?
Inside Tomcat if you browse to the root of the context, Tomcat assumes a servletPath of `/index.html`. This caused the existing logic (which assumed a path and not filename) would break.

# How should this be tested?

Deploy fedora to Tomcat at context `fcrepo` (for example), browse to `http://localhost:8080/fcrepo` and get a 500 Server Error.
Rebuild with this PR and re-deploy. Successfully get the splash page.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
