### PR TITLE
Make the default persistence digest algorithm configurable from the p…

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/DigestAlgorithm.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/DigestAlgorithm.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.config;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * Digest Algorith enum
+ * @author cbeer
+ *
+ * Moved to its own class for Fedora 6.0.0
+ */
+public enum DigestAlgorithm {
+    SHA1("SHA", "urn:sha1", "sha-1", "sha1"),
+    SHA256("SHA-256", "urn:sha-256", "sha256"),
+    SHA512("SHA-512", "urn:sha-512", "sha512"),
+    SHA512256("SHA-512/256", "urn:sha-512/256", "sha512/256"),
+    MD5("MD5", "urn:md5"),
+    MISSING("NONE", "missing");
+
+    final private String algorithm;
+    final private String scheme;
+    final private Set<String> aliases;
+
+    DigestAlgorithm(final String alg, final String scheme, final String... aliases) {
+        this.algorithm = alg;
+        this.scheme = scheme;
+        this.aliases = Stream.concat(Arrays.stream(aliases), Stream.of(algorithm)).map(String::valueOf)
+                        .map(String::toLowerCase).collect(toSet());
+    }
+
+    /**
+     * Return the scheme associated with the provided algorithm (e.g. SHA-1 returns urn:sha1)
+     *
+     * @param alg for which scheme is requested
+     * @return scheme
+     */
+    public static String getScheme(final String alg) {
+        return Arrays.stream(values()).filter(value ->
+                value.algorithm.equalsIgnoreCase(alg) || value.algorithm.replace("-", "").equalsIgnoreCase(alg)
+        ).findFirst().orElse(MISSING).scheme;
+    }
+
+    /**
+     * Return enum value for the provided scheme (e.g. urn:sha1 returns SHA-1)
+     *
+     * @param argScheme for which enum is requested
+     * @return enum value associated with the arg scheme
+     */
+    public static DigestAlgorithm fromScheme(final String argScheme) {
+        return Arrays.stream(values()).filter(value -> value.scheme.equalsIgnoreCase(argScheme)
+        ).findFirst().orElse(MISSING);
+    }
+
+    /**
+     * Return enum value for the provided algorithm
+     *
+     * @param alg algorithm name to seek
+     * @return enum value associated with the algorithm name, or missing if not found
+     */
+    public static DigestAlgorithm fromAlgorithm(final String alg) {
+        final String seek = alg.toLowerCase();
+        return Arrays.stream(values())
+                .filter(value -> value.aliases.contains(seek))
+                .findFirst()
+                .orElse(MISSING);
+    }
+
+    /**
+     * Return true if the provided algorithm is included in this enum
+     *
+     * @param alg to test
+     * @return true if arg algorithm is supported
+     */
+    public static boolean isSupportedAlgorithm(final String alg) {
+        return !getScheme(alg).equals(MISSING.scheme);
+    }
+
+    /**
+     * @return the aliases
+     */
+    public Set<String> getAliases() {
+        return aliases;
+    }
+
+    /**
+     * @return the algorithm
+     */
+    public String getAlgorithm() {
+        return algorithm;
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -136,7 +136,7 @@ import org.fcrepo.kernel.api.services.ResourceTripleService;
 import org.fcrepo.kernel.api.services.UpdatePropertiesService;
 import org.fcrepo.kernel.api.services.policy.StoragePolicyDecisionPoint;
 import org.fcrepo.kernel.api.utils.ContentDigest;
-import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.config.DigestAlgorithm;
 
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPut;
@@ -940,7 +940,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         try {
             final var digestPairs = RFC3230_SPLITTER.split(nullToEmpty(digest));
             final var unsupportedAlgs = digestPairs.keySet().stream()
-                    .filter(Predicate.not(DIGEST_ALGORITHM::isSupportedAlgorithm))
+                    .filter(Predicate.not(DigestAlgorithm::isSupportedAlgorithm))
                     .collect(Collectors.toSet());
 
             // If you have one or more digests that are all valid or no digests.

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -114,7 +114,8 @@ import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.services.FixityService;
 import org.fcrepo.kernel.api.services.ReplaceBinariesService;
-import org.fcrepo.kernel.api.utils.ContentDigest;
+import org.fcrepo.config.DigestAlgorithm;
+
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -769,7 +770,7 @@ public class FedoraLdp extends ContentExposingResource {
 
             return digestPairs.entrySet().stream().filter(entry -> entry.getValue() > 0)
                     .map(Map.Entry::getKey)
-                    .filter(ContentDigest.DIGEST_ALGORITHM::isSupportedAlgorithm)
+                    .filter(DigestAlgorithm::isSupportedAlgorithm)
                     .collect(Collectors.toSet());
         } catch (final NumberFormatException e) {
             throw new ClientErrorException("Invalid 'Want-Digest' header value: " + wantDigest, SC_BAD_REQUEST, e);

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -35,6 +35,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.fcrepo</groupId>
+      <artifactId>fcrepo-configs</artifactId>
+      <version>6.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/ContentDigest.java
@@ -18,16 +18,12 @@
 package org.fcrepo.kernel.api.utils;
 
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
-import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.ArrayUtils;
+import org.fcrepo.config.DigestAlgorithm;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.slf4j.Logger;
 
@@ -41,98 +37,6 @@ public final class ContentDigest {
 
     private static final Logger LOGGER = getLogger(ContentDigest.class);
 
-    private final static String DEFAULT_DIGEST_ALGORITHM_PROPERTY = "fcrepo.persistence.defaultDigestAlgorithm";
-    public final static DIGEST_ALGORITHM DEFAULT_DIGEST_ALGORITHM;
-
-    static {
-        // Establish the default digest algorithm for fedora, defaulting to SHA512
-        DEFAULT_DIGEST_ALGORITHM = DIGEST_ALGORITHM.fromAlgorithm(
-                System.getProperty(DEFAULT_DIGEST_ALGORITHM_PROPERTY, DIGEST_ALGORITHM.SHA512.algorithm));
-
-        // Throw error if the configured default digest is not known to fedora
-        if (DIGEST_ALGORITHM.MISSING.equals(DEFAULT_DIGEST_ALGORITHM)) {
-            throw new IllegalArgumentException("Invalid " + DEFAULT_DIGEST_ALGORITHM_PROPERTY
-                    + " property configured: " + System.getProperty(DEFAULT_DIGEST_ALGORITHM_PROPERTY));
-        }
-    }
-
-    public enum DIGEST_ALGORITHM {
-        SHA1("SHA", "urn:sha1", "sha-1", "sha1"),
-        SHA256("SHA-256", "urn:sha-256", "sha256"),
-        SHA512("SHA-512", "urn:sha-512", "sha512"),
-        SHA512256("SHA-512/256", "urn:sha-512/256", "sha512/256"),
-        MD5("MD5", "urn:md5"),
-        MISSING("NONE", "missing");
-
-        final public String algorithm;
-        final private String scheme;
-        final private Set<String> aliases;
-
-        DIGEST_ALGORITHM(final String alg, final String scheme, final String... aliases) {
-            this.algorithm = alg;
-            this.scheme = scheme;
-            this.aliases = Arrays.stream(ArrayUtils.add(aliases, algorithm))
-                    .map(String::toLowerCase)
-                    .collect(Collectors.toSet());
-        }
-
-        /**
-         * Return the scheme associated with the provided algorithm (e.g. SHA-1 returns urn:sha1)
-         *
-         * @param alg for which scheme is requested
-         * @return scheme
-         */
-        public static String getScheme(final String alg) {
-            return Arrays.stream(values()).filter(value ->
-                    value.algorithm.equalsIgnoreCase(alg) || value.algorithm.replace("-", "").equalsIgnoreCase(alg)
-            ).findFirst().orElse(MISSING).scheme;
-        }
-
-        /**
-         * Return enum value for the provided scheme (e.g. urn:sha1 returns SHA-1)
-         *
-         * @param argScheme for which enum is requested
-         * @return enum value associated with the arg scheme
-         */
-        public static DIGEST_ALGORITHM fromScheme(final String argScheme) {
-            return Arrays.stream(values()).filter(value -> value.scheme.equalsIgnoreCase(argScheme)
-            ).findFirst().orElse(MISSING);
-        }
-
-        /**
-         * Return enum value for the provided algorithm
-         *
-         * @param alg algorithm name to seek
-         * @return enum value associated with the algorithm name, or missing if not found
-         */
-        public static DIGEST_ALGORITHM fromAlgorithm(final String alg) {
-            final String seek = alg.toLowerCase();
-            return Arrays.stream(values())
-                    .filter(value -> value.aliases.contains(seek))
-                    .findFirst()
-                    .orElse(MISSING);
-        }
-
-        /**
-         * Return true if the provided algorithm is included in this enum
-         *
-         * @param alg to test
-         * @return true if arg algorithm is supported
-         */
-        public static boolean isSupportedAlgorithm(final String alg) {
-            return !getScheme(alg).equals(MISSING.scheme);
-        }
-
-        /**
-         * @return the aliases
-         */
-        public Set<String> getAliases() {
-            return aliases;
-        }
-    }
-
-    public static final String DEFAULT_ALGORITHM = DIGEST_ALGORITHM.SHA1.algorithm;
-
     private ContentDigest() {
     }
 
@@ -144,7 +48,7 @@ public final class ContentDigest {
      */
     public static URI asURI(final String algorithm, final String value) {
         try {
-            final String scheme = DIGEST_ALGORITHM.getScheme(algorithm);
+            final String scheme = DigestAlgorithm.getScheme(algorithm);
 
             return new URI(scheme, value, null);
         } catch (final URISyntaxException unlikelyException) {
@@ -170,23 +74,12 @@ public final class ContentDigest {
      * @return MessageDigest algorithm
      */
     public static String getAlgorithm(final URI digestUri) {
-        if (digestUri == null) {
-            return DEFAULT_ALGORITHM;
-        }
-        return DIGEST_ALGORITHM.fromScheme(digestUri.getScheme() + ":" +
-             digestUri.getSchemeSpecificPart().split(":", 2)[0]).algorithm;
+        return DigestAlgorithm.fromScheme(digestUri.getScheme() + ":" +
+             digestUri.getSchemeSpecificPart().split(":", 2)[0]).getAlgorithm();
     }
 
     private static String asString(final byte[] data) {
         return encodeHexString(data);
-    }
-
-    /**
-     * Placeholder checksum value.
-     * @return URI
-     */
-    public static URI missingChecksum() {
-        return asURI(SHA1.algorithm, SHA1.scheme);
     }
 
 }

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -18,12 +18,13 @@
 package org.fcrepo.kernel.api.utils;
 
 import static java.net.URI.create;
-import static org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM.SHA1;
+import static org.fcrepo.config.DigestAlgorithm.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
 import static org.junit.Assert.assertEquals;
 
-import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.config.DigestAlgorithm;
+
 import org.junit.Test;
 
 /**
@@ -36,7 +37,7 @@ public class ContentDigestTest {
     @Test
     public void testSHA_1() {
         assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha1:fake"), asURI(SHA1.algorithm, "fake"));
+                create("urn:sha1:fake"), asURI(SHA1.getAlgorithm(), "fake"));
     }
 
     @Test
@@ -47,8 +48,8 @@ public class ContentDigestTest {
 
     @Test
     public void testGetAlgorithm() {
-        assertEquals("Failed to produce a proper digest algorithm!", SHA1.algorithm,
-                getAlgorithm(asURI(SHA1.algorithm, "fake")));
+        assertEquals("Failed to produce a proper digest algorithm!", SHA1.getAlgorithm(),
+                getAlgorithm(asURI(SHA1.getAlgorithm(), "fake")));
     }
 
     @Test
@@ -65,12 +66,12 @@ public class ContentDigestTest {
 
     @Test
     public void testFromAlgorithm() {
-        assertEquals(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.fromAlgorithm("SHA"));
-        assertEquals(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.fromAlgorithm("sha-1"));
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("SHA"));
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("sha-1"));
     }
 
     @Test
     public void testFromAlgorithmMissing() {
-        assertEquals(DIGEST_ALGORITHM.MISSING, DIGEST_ALGORITHM.fromAlgorithm("what"));
+        assertEquals(DigestAlgorithm.MISSING, DigestAlgorithm.fromAlgorithm("what"));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/FixityServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/FixityServiceImpl.java
@@ -37,7 +37,7 @@ import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.FixityService;
-import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.config.DigestAlgorithm;
 import org.fcrepo.persistence.common.MultiDigestInputStreamWrapper;
 import org.springframework.stereotype.Component;
 
@@ -65,7 +65,7 @@ public class FixityServiceImpl extends AbstractService implements FixityService 
     public Collection<URI> getFixity(final Binary binary, final Collection<String> algorithms)
             throws UnsupportedAlgorithmException {
         final var digestAlgs = algorithms.stream()
-                .map(DIGEST_ALGORITHM::fromAlgorithm)
+                .map(DigestAlgorithm::fromAlgorithm)
                 .collect(Collectors.toList());
 
         try (final var content = binary.getContent()) {
@@ -97,7 +97,7 @@ public class FixityServiceImpl extends AbstractService implements FixityService 
         final var digestAlgs = existingDigestList.stream()
                 .map(URI::toString)
                 .map(a -> a.replace("urn:", "").split(":")[0])
-                .map(DIGEST_ALGORITHM::fromAlgorithm)
+                .map(DigestAlgorithm::fromAlgorithm)
                 .collect(Collectors.toList());
 
         try (final var content = binary.getContent()) {

--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapper.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapper.java
@@ -39,7 +39,7 @@ import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.UnsupportedAlgorithmException;
 import org.fcrepo.kernel.api.utils.ContentDigest;
-import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.config.DigestAlgorithm;
 
 /**
  * Wrapper for an InputStream that allows for the computation and evaluation
@@ -67,7 +67,7 @@ public class MultiDigestInputStreamWrapper {
      * @param wantDigests list of additional digest algorithms to compute for the input stream
      */
     public MultiDigestInputStreamWrapper(final InputStream sourceStream, final Collection<URI> digests,
-            final Collection<DIGEST_ALGORITHM> wantDigests) {
+            final Collection<DigestAlgorithm> wantDigests) {
         this.sourceStream = sourceStream;
         algToDigest = new HashMap<>();
         algToDigestStream = new HashMap<>();
@@ -82,9 +82,9 @@ public class MultiDigestInputStreamWrapper {
 
         // Merge the list of wanted digest algorithms with set of provided digests
         if (wantDigests != null) {
-            for (final DIGEST_ALGORITHM wantDigest : wantDigests) {
-                if (!algToDigest.containsKey(wantDigest.algorithm)) {
-                    algToDigest.put(wantDigest.algorithm, null);
+            for (final DigestAlgorithm wantDigest : wantDigests) {
+                if (!algToDigest.containsKey(wantDigest.getAlgorithm())) {
+                    algToDigest.put(wantDigest.getAlgorithm(), null);
                 }
             }
         }
@@ -160,11 +160,11 @@ public class MultiDigestInputStreamWrapper {
      * @param alg algorithm of the digest to retrieve
      * @return the calculated digest, or null if no digest of that type was calculated
      */
-    public String getDigest(final DIGEST_ALGORITHM alg) {
+    public String getDigest(final DigestAlgorithm alg) {
         calculateDigests();
 
         return computedDigests.entrySet().stream()
-                .filter(entry -> alg.algorithm.equals(entry.getKey()))
+                .filter(entry -> alg.getAlgorithm().equals(entry.getKey()))
                 .map(Entry::getValue)
                 .findFirst()
                 .orElse(null);

--- a/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapperTest.java
+++ b/fcrepo-persistence-common/src/test/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapperTest.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 import org.apache.commons.io.IOUtils;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.utils.ContentDigest.DIGEST_ALGORITHM;
+import org.fcrepo.config.DigestAlgorithm;
 import org.junit.Test;
 
 /**
@@ -122,7 +122,7 @@ public class MultiDigestInputStreamWrapperTest {
 
     @Test
     public void checkFixity_OnlyWantDigest() throws Exception {
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wantDigests = asList(DigestAlgorithm.SHA1);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
 
         // Read the stream to allow digest calculation
@@ -135,7 +135,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test
     public void checkFixity_OverlappingWantDigestAndProvided() throws Exception {
         final var digests = asList(SHA1_URI);
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wantDigests = asList(DigestAlgorithm.SHA1);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
 
         // Read the stream to allow digest calculation
@@ -148,7 +148,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test(expected = InvalidChecksumException.class)
     public void checkFixity_OverlappingWantDigestAndProvided_InvalidDigest() throws Exception {
         final var digests = asList(URI.create("urn:sha1:totallybusted"));
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1);
+        final var wantDigests = asList(DigestAlgorithm.SHA1);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
 
         // Read the stream to allow digest calculation
@@ -161,7 +161,7 @@ public class MultiDigestInputStreamWrapperTest {
     @Test
     public void checkFixity_DifferentWantDigestAndProvided() throws Exception {
         final var digests = asList(SHA1_URI);
-        final var wantDigests = asList(DIGEST_ALGORITHM.MD5);
+        final var wantDigests = asList(DigestAlgorithm.MD5);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
 
         // Read the stream to allow digest calculation
@@ -173,7 +173,7 @@ public class MultiDigestInputStreamWrapperTest {
 
     @Test
     public void getDigests_FromWantDigests() throws Exception {
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.SHA512);
+        final var wantDigests = asList(DigestAlgorithm.SHA1, DigestAlgorithm.SHA512);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
 
         final var computed = wrapper.getDigests();
@@ -193,7 +193,7 @@ public class MultiDigestInputStreamWrapperTest {
 
     @Test
     public void getDigests_FromWantDigestsAndProvided() throws Exception {
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA1, DIGEST_ALGORITHM.SHA512);
+        final var wantDigests = asList(DigestAlgorithm.SHA1, DigestAlgorithm.SHA512);
         final var digests = asList(SHA1_URI, MD5_URI);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
 
@@ -218,7 +218,7 @@ public class MultiDigestInputStreamWrapperTest {
 
     @Test
     public void getDigests_FromConsumedStream() throws Exception {
-        final var wantDigests = asList(DIGEST_ALGORITHM.SHA512);
+        final var wantDigests = asList(DigestAlgorithm.SHA512);
         final var wrapper = new MultiDigestInputStreamWrapper(contentStream, null, wantDigests);
 
         IOUtils.toString(wrapper.getInputStream(), UTF_8);

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -86,9 +86,11 @@ public class OcflPersistenceConfig {
                     s3Client(),
                     ocflPropsConfig.getOcflS3Bucket(),
                     ocflPropsConfig.getOcflS3Prefix(),
-                    ocflPropsConfig.getOcflTemp());
+                    ocflPropsConfig.getOcflTemp(),
+                    ocflPropsConfig.getDefaultDigestAlgorithm());
         } else {
-            return createFilesystemRepository(ocflPropsConfig.getOcflRepoRoot(), ocflPropsConfig.getOcflTemp());
+            return createFilesystemRepository(ocflPropsConfig.getOcflRepoRoot(), ocflPropsConfig.getOcflTemp(),
+                    ocflPropsConfig.getDefaultDigestAlgorithm());
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
@@ -40,6 +40,8 @@ import java.util.UUID;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.ResourceFactory;
+
+import org.fcrepo.config.DigestAlgorithm;
 import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.FedoraTypes;
@@ -106,13 +108,15 @@ public class AbstractReindexerTest {
     protected final FedoraId resource1 = FedoraId.create("resource1");
     protected final FedoraId resource2 =  resource1.resolve("resource2");
 
+    private static final DigestAlgorithm DEFAULT_FEDORA_ALGORITHM = DigestAlgorithm.SHA512;
+
     public void setup() throws Exception {
         final var targetDir = Paths.get("target");
         final var dataDir = targetDir.resolve("test-fcrepo-data-" + currentTimeMillis());
         final var repoDir = dataDir.resolve("ocfl-repo");
         final var workDir = dataDir.resolve("ocfl-work");
 
-        repository = createFilesystemRepository(repoDir, workDir);
+        repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM);
 
         ocflIndex = new TestOcflObjectIndex();
         ocflIndex.reset();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -22,6 +22,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.vocabulary.DC;
+
+import org.fcrepo.config.DigestAlgorithm;
 import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -147,6 +149,8 @@ public class OcflPersistentStorageSessionTest {
     @Mock
     private ResourceOperation unsupportedOperation;
 
+    private static final DigestAlgorithm DEFAULT_FEDORA_ALGORITHM = DigestAlgorithm.SHA512;
+
     @Before
     public void setUp() throws Exception {
         stagingDir = tempFolder.newFolder("ocfl-staging").toPath();
@@ -154,7 +158,7 @@ public class OcflPersistentStorageSessionTest {
         final var workDir = tempFolder.newFolder("ocfl-work").toPath();
 
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
-        final var repository = createFilesystemRepository(repoDir, workDir);
+        final var repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM);
         objectSessionFactory = new DefaultOcflObjectSessionFactory(repository, stagingDir,
                 objectMapper,
                 new NoOpCache<>(),


### PR DESCRIPTION
…roperties file.

**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3520

# What does this Pull Request do?
Enables the use of `fcrepo.persistence.defaultDigestAlgorithm` in the configuration file to change the default OCFL digest algorithm

# How should this be tested?

1. Try creating a new Fedora repository and add a binary object. View the binary description and see the `premis:hasMessageDigest` starts wtith `urn:sha-512:`
1. Create a text file with the line
     ```
     fcrepo.persistence.defaultDigestAlgorithm=sha256
     ```
1. Restart Fedora and add another binary object. View the description for this second object and see that now the `premis:hasMessageDigest` starts wtith `urn:sha-256:`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
