### PR TITLE
Adds support for the fcrepo.rebuild.on.start property which

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -49,6 +49,8 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_SESSION_TIMEOUT = "fcrepo.session.timeout";
     private static final String FCREPO_VELOCITY_RUNTIME_LOG = "fcrepo.velocity.runtime.log";
     private static final String FCREPO_REBUILD_VALIDATION_FIXITY = "fcrepo.rebuild.validation.fixity";
+    private static final String FCREPO_REBUILD_ON_START = "fcrepo.rebuild.on.start";
+
 
     private static final String DATA_DIR_DEFAULT_VALUE = "data";
     private static final String ACTIVE_MQ_DIR_DEFAULT_VALUE = "ActiveMQ/kahadb";
@@ -90,6 +92,9 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${" + FCREPO_REBUILD_VALIDATION_FIXITY + ":true}")
     private boolean rebuildFixityCheck;
+
+    @Value("${" + FCREPO_REBUILD_ON_START + ":false}")
+    private boolean rebuildOnStart;
 
     @PostConstruct
     private void postConstruct() throws IOException {
@@ -206,4 +211,17 @@ public class FedoraPropsConfig extends BasePropsConfig {
         return rebuildFixityCheck;
     }
 
+    /**
+     * @return true if the internal indices should be rebuilt when Fedora starts up.
+     */
+    public boolean isRebuildOnStart() {
+        return rebuildOnStart;
+    }
+
+    /**
+     * @param rebuildOnStart A boolean flag indicating whether or not to rebuild on start
+     */
+    public void setRebuildOnStart(final boolean rebuildOnStart) {
+        this.rebuildOnStart = rebuildOnStart;
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -137,11 +137,15 @@ public abstract class AbstractResourceIT {
     protected static final Node DCTITLE = title.asNode();
 
     @Inject
-    private ContainerWrapper containerWrapper;
+    protected ContainerWrapper containerWrapper;
 
     @Inject
     private static FedoraPropsConfig propsConfig;
 
+    protected void restartContainer() throws Exception {
+        this.containerWrapper.stop();
+        this.containerWrapper.start();
+    }
     /**
      * Decode the Digest header
      * @param digestHeader the digest header value.

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RebuildIT.java
@@ -80,7 +80,6 @@ import static org.springframework.test.util.AssertionErrors.assertTrue;
 public class RebuildIT extends AbstractResourceIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RebuildIT.class);
-    public static final String TARGET_FCREPO_HOME_DATA_OCFL_ROOT = "target/fcrepo-home/data/ocfl-root";
 
     private OcflRepository ocflRepository;
     private RepositoryInitializer initializer;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/IndexBuilderImpl.java
@@ -17,25 +17,23 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
-import java.time.Duration;
-import java.time.Instant;
-
-import javax.inject.Inject;
-
+import edu.wisc.library.ocfl.api.OcflRepository;
+import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.persistence.ocfl.api.FedoraOcflMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.persistence.ocfl.api.IndexBuilder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import edu.wisc.library.ocfl.api.OcflRepository;
+import javax.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * An implementation of {@link IndexBuilder}.  This implementation rebuilds the following indexable state derived
@@ -71,6 +69,9 @@ public class IndexBuilderImpl implements IndexBuilder {
 
     @Inject
     private OcflPropsConfig ocflPropsConfig;
+
+    @Inject
+    private FedoraPropsConfig fedoraPropsConfig;
 
     @Override
     public void rebuildIfNecessary() {
@@ -110,12 +111,13 @@ public class IndexBuilderImpl implements IndexBuilder {
 
     private boolean shouldRebuild() {
         final var repoRoot = getRepoRootMapping();
-
-        if (repoRoot == null) {
+        if (fedoraPropsConfig.isRebuildOnStart()) {
             return true;
+        } else if (repoRoot == null) {
+            return true;
+        } else {
+            return !repoContainsRootObject(repoRoot);
         }
-
-        return !repoContainsRootObject(repoRoot);
     }
 
     private String getRepoRootMapping() {


### PR DESCRIPTION
will cause the indices to be rebuilt on restart.

**JIRA Ticket**:  https://jira.lyrasis.org/browse/FCREPO-3611


* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Adds a new property that allows the user to force Fedora to reindex all content on restart.
# How should this be tested?
`mvn clean install -Pone-click`
1. Start Fedora and add an item via the UI.
2. Delete the corresponding OCFL object from the disk.
3. Verify that the object is still visible as a child of the repository root
4. Attempting to retrieving the link should result in an error.
5. Restart Fedora and verify the deleted links are still present
6. Restart Fedora again with `-Dfcrepo.rebuild.on.start=true`
7. Verify that the link to the resource is gone. (be sure to do a hard refresh of your browser)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
