### PR TITLE
Only update mementoCreatedDate on new version

### DIFF
--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/ResourceHeaderUtils.java
@@ -118,10 +118,30 @@ public class ResourceHeaderUtils {
         }
         headers.setLastModifiedDate(instant);
         headers.setLastModifiedBy(userPrincipal);
-        headers.setMementoCreatedDate(instant);
+        touchMementoCreateHeaders(headers, instant);
 
         final String stateToken = DigestUtils.md5Hex(String.valueOf(instant.toEpochMilli())).toUpperCase();
         headers.setStateToken(stateToken);
+    }
+
+    /**
+     * Update the mementoCreatedDate header
+     * @param headers headers object to update.
+     * @param versionDate time this version is created.
+     */
+    public static void touchMementoCreateHeaders(final ResourceHeadersImpl headers, final Instant versionDate) {
+        final Instant instant;
+        if (versionDate == null) {
+            final ZonedDateTime now = ZonedDateTime.now();
+            instant = now.toInstant();
+        } else {
+            instant = versionDate;
+        }
+        headers.setMementoCreatedDate(instant);
+    }
+
+    public static void touchMementoCreateHeaders(final ResourceHeadersImpl headers) {
+        touchMementoCreateHeaders(headers, null);
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersister.java
@@ -65,7 +65,7 @@ public class CreateVersionPersister extends AbstractPersister {
         // still versioned
         final var headers = new ResourceHeadersAdapter(ocflObjectSession.readHeaders(resourceId.getResourceId()))
                 .asKernelHeaders();
-        ResourceHeaderUtils.touchModificationHeaders(headers, operation.getUserPrincipal());
+        ResourceHeaderUtils.touchMementoCreateHeaders(headers);
 
         ocflObjectSession.writeHeaders(new ResourceHeadersAdapter(headers).asStorageHeaders());
         // The version is not actually created until the session is committed

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/CreateVersionPersisterTest.java
@@ -18,6 +18,15 @@
 
 package org.fcrepo.persistence.ocfl.impl;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.operations.CreateVersionResourceOperation;
 import org.fcrepo.kernel.api.operations.ResourceOperationType;
@@ -28,6 +37,7 @@ import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.OcflObjectSession;
 import org.fcrepo.storage.ocfl.ResourceHeaders;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,16 +45,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.time.Duration;
-import java.time.Instant;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author pwinckles
@@ -145,9 +145,8 @@ public class CreateVersionPersisterTest {
     private void verifyHeaders(final OcflObjectSession objectSession) {
         verify(objectSession).writeHeaders(headersCaptor.capture());
         final var actualHeaders = headersCaptor.getValue();
-        assertNotNull(actualHeaders.getStateToken());
         assertTrue("Timestamp should be within 1 second of now",
-                Duration.between(actualHeaders.getLastModifiedDate(), Instant.now())
+                Duration.between(actualHeaders.getMementoCreatedDate(), Instant.now())
                         .compareTo(Duration.ofSeconds(1)) < 0);
     }
 


### PR DESCRIPTION
**JIRA Ticket**: Follow on from https://jira.lyrasis.org/browse/FCREPO-3608

# What does this Pull Request do?
Updates the CreateVersionPersister to only update the mementoCreatedDate on a new version.
Also adds a new test to ensure the memento and original resource remain the same.

# How should this be tested?

Create a resource, get the body of the resource.
Create a memento of the resource, get the body of the Memento.
They should match.
Get a new copy of the resource body.
It should also match the two previous. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
