### PR TITLE
Enable updating SMTs when in relaxed mode

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -145,28 +145,27 @@ public class HttpRdfService {
                 } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
                     if (!fedoraPropsConfig.getServerManagedPropsMode().equals(RELAXED)) {
                         exceptions.add(exc);
+                        continue;
                     }
-                } finally {
-                    // Still need to convert the model, incase we are not throwing the exceptions above.
-                    if (stmt.getSubject().isURIResource()) {
-                        final String originalSubj = stmt.getSubject().getURI();
-                        final String subj = idTranslator.translateUri(originalSubj);
+                }
+                if (stmt.getSubject().isURIResource()) {
+                    final String originalSubj = stmt.getSubject().getURI();
+                    final String subj = idTranslator.translateUri(originalSubj);
 
-                        RDFNode obj = stmt.getObject();
-                        if (stmt.getObject().isURIResource()) {
-                            final String objString = stmt.getObject().asResource().getURI();
-                            final String objUri = idTranslator.translateUri(objString);
-                            obj = model.getResource(objUri);
-                        }
-
-                        if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
-                            insertStatements.add(new StatementImpl(model.getResource(subj), stmt.getPredicate(), obj));
-
-                            stmtIterator.remove();
-                        }
-                    } else {
-                        log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
+                    RDFNode obj = stmt.getObject();
+                    if (stmt.getObject().isURIResource()) {
+                        final String objString = stmt.getObject().asResource().getURI();
+                        final String objUri = idTranslator.translateUri(objString);
+                        obj = model.getResource(objUri);
                     }
+
+                    if (!subj.equals(originalSubj) || !obj.equals(stmt.getObject())) {
+                        insertStatements.add(new StatementImpl(model.getResource(subj), stmt.getPredicate(), obj));
+
+                        stmtIterator.remove();
+                    }
+                } else {
+                    log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
                 }
             }
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -20,46 +20,52 @@ package org.fcrepo.http.api.services;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.apache.jena.vocabulary.RDF.Init.type;
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.config.ServerManagedPropsMode.RELAXED;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.fcrepo.kernel.api.RdfLexicon.restrictedType;
-import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.kernel.api.utils.RelaxedPropertiesHelper.checkTripleForDisallowed;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MediaType;
-import org.apache.jena.atlas.RuntimeIOException;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.rdf.model.impl.StatementImpl;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RiotException;
-import org.apache.jena.update.Update;
-import org.apache.jena.update.UpdateFactory;
-import org.apache.jena.update.UpdateRequest;
+
+import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.fcrepo.kernel.api.exception.UnsupportedMediaTypeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+
+import org.apache.jena.atlas.RuntimeIOException;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.impl.StatementImpl;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.update.Update;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateRequest;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonParseException;
 
 /**
  * A service that will translate the resourceURI to Fedora ID in the Rdf InputStream
@@ -72,6 +78,9 @@ import org.springframework.stereotype.Component;
 public class HttpRdfService {
 
     private static final Logger log = getLogger(HttpRdfService.class);
+
+    @Inject
+    private FedoraPropsConfig fedoraPropsConfig;
 
     /**
      * Convert internal IDs to external URIs
@@ -133,6 +142,12 @@ public class HttpRdfService {
             } else {
                 try {
                     checkForDisallowedRdf(stmt);
+                } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+                    if (!fedoraPropsConfig.getServerManagedPropsMode().equals(RELAXED)) {
+                        exceptions.add(exc);
+                    }
+                } finally {
+                    // Still need to convert the model, incase we are not throwing the exceptions above.
                     if (stmt.getSubject().isURIResource()) {
                         final String originalSubj = stmt.getSubject().getURI();
                         final String subj = idTranslator.translateUri(originalSubj);
@@ -152,8 +167,6 @@ public class HttpRdfService {
                     } else {
                         log.debug("Subject {} is not a URI resource, skipping", stmt.getSubject());
                     }
-                } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
-                    exceptions.add(exc);
                 }
             }
         }
@@ -181,7 +194,7 @@ public class HttpRdfService {
         final String externalURI = idTranslator.toExternalId(resourceId.getFullId());
         final UpdateRequest request = UpdateFactory.create(requestBody, externalURI);
         final List<Update> updates = request.getOperations();
-        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator);
+        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig);
         for (final Update update : updates) {
             update.visit(visitor);
         }
@@ -241,28 +254,6 @@ public class HttpRdfService {
      */
     private static void checkForDisallowedRdf(final Statement statement) {
         checkTripleForDisallowed(statement.asTriple());
-    }
-
-    /**
-     * Several tests for invalid or disallowed RDF statements.
-     * @param triple the triple to check.
-     */
-    public static void checkTripleForDisallowed(final Triple triple) {
-        if (triple.getPredicate().equals(type().asNode()) && !triple.getObject().isURI()) {
-            // The object of a rdf:type triple is not a URI.
-            throw new MalformedRdfException(
-                    String.format("Invalid rdf:type: %s", triple.getObject()));
-        } else if (restrictedType.test(triple)) {
-            // The object of a rdf:type triple has a restricted namespace.
-            throw new ServerManagedTypeException(
-                    String.format("The server managed type (%s) cannot be modified by the client.",
-                            triple.getObject()));
-        } else if (isManagedPredicate.test(createProperty(triple.getPredicate().getURI()))) {
-            // The predicate is server managed.
-            throw new ServerManagedPropertyException(
-                    String.format("The server managed predicate (%s) cannot be modified by the client.",
-                            triple.getPredicate()));
-        }
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -170,11 +170,10 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
                     } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
                         if (!isRelaxedMode) {
                             exceptions.add(exc);
+                            return;
                         }
-                    } finally {
-                        // Still translate in case we don't throw the exceptions.
-                        basicPattern.add(translateTriple(t.asTriple()));
                     }
+                    basicPattern.add(translateTriple(t.asTriple()));
                 }
             });
             return new ElementPathBlock(basicPattern);
@@ -196,15 +195,14 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
                 if (!isRelaxedMode) {
                     // Swallow these exceptions to throw together later.
                     exceptions.add(exc);
+                    continue;
                 }
-            } finally {
-                // Still translate in case we don't throw the exceptions. ie. relaxed mode
-                final Node subject = translateId(q.getSubject());
-                final Node object = translateId(q.getObject());
-                final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
-                LOGGER.trace("Translated quad is: {}", quad);
-                newQuads.add(quad);
             }
+            final Node subject = translateId(q.getSubject());
+            final Node object = translateId(q.getObject());
+            final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
+            LOGGER.trace("Translated quad is: {}", quad);
+            newQuads.add(quad);
         }
         return newQuads;
     }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -17,13 +17,22 @@
  */
 package org.fcrepo.http.api.services;
 
-import static org.fcrepo.http.api.services.HttpRdfService.checkTripleForDisallowed;
+import static org.fcrepo.config.ServerManagedPropsMode.RELAXED;
+import static org.fcrepo.kernel.api.utils.RelaxedPropertiesHelper.checkTripleForDisallowed;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.exception.ConstraintViolationException;
+import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -44,12 +53,6 @@ import org.apache.jena.sparql.syntax.ElementPathBlock;
 import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
-import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
-import org.fcrepo.kernel.api.exception.ConstraintViolationException;
-import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
-import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
-import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
-import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 import org.slf4j.Logger;
 
 /**
@@ -64,8 +67,11 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
 
     private HttpIdentifierConverter idTranslator;
 
-    public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter) {
+    private boolean isRelaxedMode;
+
+    public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter, final FedoraPropsConfig config) {
         idTranslator = identifierConverter;
+        isRelaxedMode = config.getServerManagedPropsMode().equals(RELAXED);
     }
 
     private List<ConstraintViolationException> exceptions = new ArrayList<>();
@@ -160,9 +166,14 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
             tripleIter.forEachRemaining(t -> {
                 if (t.isTriple()) {
                     try {
-                        basicPattern.add(translateTriple(t.asTriple()));
+                        checkTripleForDisallowed(t.asTriple());
                     } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
-                        exceptions.add(exc);
+                        if (!isRelaxedMode) {
+                            exceptions.add(exc);
+                        }
+                    } finally {
+                        // Still translate in case we don't throw the exceptions.
+                        basicPattern.add(translateTriple(t.asTriple()));
                     }
                 }
             });
@@ -180,15 +191,19 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         final List<Quad> newQuads = new ArrayList<>();
         for (final Quad q : quadsList) {
             try {
+                checkTripleForDisallowed(q.asTriple());
+            } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+                if (!isRelaxedMode) {
+                    // Swallow these exceptions to throw together later.
+                    exceptions.add(exc);
+                }
+            } finally {
+                // Still translate in case we don't throw the exceptions. ie. relaxed mode
                 final Node subject = translateId(q.getSubject());
                 final Node object = translateId(q.getObject());
-                checkTripleForDisallowed(q.asTriple());
                 final Quad quad = new Quad(q.getGraph(), subject, q.getPredicate(), object);
                 LOGGER.trace("Translated quad is: {}", quad);
                 newQuads.add(quad);
-            } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
-                // Swallow these exceptions to throw together later.
-                exceptions.add(exc);
             }
         }
         return newQuads;
@@ -202,7 +217,6 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
     private Triple translateTriple(final Triple triple) {
         final Node subject = translateId(triple.getSubject());
         final Node object = translateId(triple.getObject());
-        checkTripleForDisallowed(triple);
         return Triple.create(subject, triple.getPredicate(), object);
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -25,6 +25,7 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
 
+import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.api.services.EtagService;
 import org.fcrepo.http.api.services.HttpRdfService;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
@@ -110,6 +111,7 @@ import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
+import static org.fcrepo.config.ServerManagedPropsMode.STRICT;
 import static org.fcrepo.http.api.ContentExposingResource.buildLink;
 import static org.fcrepo.http.api.ContentExposingResource.getSimpleContentType;
 import static org.fcrepo.http.api.FedoraLdp.HTTP_HEADER_ACCEPT_PATCH;
@@ -250,6 +252,9 @@ public class FedoraLdpTest {
     @Mock
     private EtagService etagService;
 
+    @Mock
+    private FedoraPropsConfig fedoraPropsConfig;
+
     private final List<URI> typeList = new ArrayList<>();
 
     private static final Logger log = getLogger(FedoraLdpTest.class);
@@ -261,6 +266,8 @@ public class FedoraLdpTest {
         mockResponse = new MockHttpServletResponse();
 
         final HttpRdfService httpRdfService = new HttpRdfService();
+        setField(httpRdfService, "fedoraPropsConfig", fedoraPropsConfig);
+        when(fedoraPropsConfig.getServerManagedPropsMode()).thenReturn(STRICT);
 
         setField(testObj, "request", mockRequest);
         setField(testObj, "servletResponse", mockResponse);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api.services;
 
+import static org.fcrepo.config.ServerManagedPropsMode.STRICT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +40,8 @@ import org.junit.Test;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
 import org.junit.runner.RunWith;
+
+import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -59,10 +62,13 @@ public class HttpRdfServiceTest {
     private static final Logger log = getLogger(HttpRdfService.class);
 
     @Mock
-    HttpIdentifierConverter idTranslator;
+    private HttpIdentifierConverter idTranslator;
 
     @Mock
-    FedoraResource resource;
+    private FedoraResource resource;
+
+    @Mock
+    private FedoraPropsConfig fedoraPropsConfig;
 
     @InjectMocks
     private HttpRdfService httpRdfService;
@@ -93,6 +99,7 @@ public class HttpRdfServiceTest {
 
     @Before
     public void setup() {
+        when(fedoraPropsConfig.getServerManagedPropsMode()).thenReturn(STRICT);
         when(idTranslator.translateUri(FEDORA_URI_1)).thenReturn(FEDORA_ID_1.getFullId());
         when(idTranslator.translateUri(FEDORA_URI_2)).thenReturn(FEDORA_ID_2.getFullId());
         when(idTranslator.translateUri(NON_FEDORA_URI)).thenReturn(NON_FEDORA_URI);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraRelaxedLdpIT.java
@@ -17,48 +17,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.util.EntityUtils;
-import org.apache.jena.datatypes.xsd.XSDDatatype;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
-
-import org.fcrepo.config.ServerManagedPropsMode;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.kernel.api.utils.GraphDifferencer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import javax.ws.rs.core.Link;
-import javax.xml.bind.DatatypeConverter;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Stream;
-
 import static java.util.Calendar.getInstance;
 import static java.util.Spliterator.IMMUTABLE;
 import static java.util.Spliterators.spliteratorUnknownSize;
@@ -88,6 +46,51 @@ import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.ws.rs.core.Link;
+import javax.xml.bind.DatatypeConverter;
+
+import org.fcrepo.config.ServerManagedPropsMode;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.api.utils.GraphDifferencer;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.datatypes.xsd.XSDDateTime;
+import org.apache.jena.datatypes.xsd.impl.XSDDateTimeType;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Mike Durbin
@@ -112,7 +115,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     }
 
 
-    @Ignore //TODO Fix this test
     @Test
     public void testBasicPutRoundtrip() throws IOException {
         final String subjectURI;
@@ -134,7 +136,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(put));
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testCreateResourceWithSpecificCreationInformationIsAllowed() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -152,7 +153,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testUpdateNonRdfResourceWithSpecificInformationIsAllowed() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -180,7 +180,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testValidSparqlUpdate() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -211,7 +210,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testInvalidSparqlUpdate() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -241,7 +239,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
         }
     }
 
-    @Ignore //TODO Fix this test
     @Test
     public void testUpdateResourceWithSpecificModificationInformationIsAllowed() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -271,7 +268,6 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
      * Tests a lossless roundtrip of a resource.
      * @throws IOException if an error occurs while reading or writing to repository over HTTP
      */
-    @Ignore //TODO Fix this test
     @Test
     public void testRoundtripping() throws IOException {
         assertEquals(ServerManagedPropsMode.RELAXED, propsConfig.getServerManagedPropsMode()); // sanity check
@@ -368,13 +364,52 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
                 final Iterator<Quad> originalQuadIt = originalGraph.find();
                 while (originalQuadIt.hasNext()) {
                     final Quad q = originalQuadIt.next();
-                    assertTrue(q + " should be preserved through a roundtrip! \nOriginal RDF: " + originalRdf
-                            + "\nRoundtripped Graph:\n" + roundtrippedGraph, roundtrippedGraph.contains(q));
+                    if (!assertQuadsAreSimilar(q, roundtrippedGraph)) {
+                        fail(q + " should be preserved through a roundtrip! \nOriginal RDF: " + originalRdf
+                                + "\nRoundtripped Graph:\n" + roundtrippedGraph);
+                    }
                     roundtrippedGraph.delete(q);
                 }
                 assertTrue("Roundtripped graph had extra quads! " + roundtrippedGraph, roundtrippedGraph.isEmpty());
             }
         }
+    }
+
+    /**
+     * In roundtripping XSDDateTimes get truncated to 3 digits of microseconds. This checks that if the quad doesn't
+     * match and is a XSDDateTime that it is within .001 of a second.
+     *
+     * @param testQuad the quad to check
+     * @param checkGraph the graph to verify against
+     * @return true if the quad is exact or very close, false if not.
+     */
+    private boolean assertQuadsAreSimilar(final Quad testQuad, final DatasetGraph checkGraph) {
+        if (checkGraph.contains(testQuad)) {
+            return true;
+        } else if (testQuad.getObject().isLiteral() &&
+                testQuad.getObject().getLiteral().getDatatype() instanceof XSDDateTimeType) {
+            final var testLiteral = (XSDDateTime)testQuad.getObject().getLiteralValue();
+            if (checkGraph.contains(ANY, testQuad.getSubject(), testQuad.getPredicate(), ANY)) {
+                final var roundTripIter =
+                        checkGraph.find(ANY, testQuad.getSubject(), testQuad.getPredicate(), ANY);
+                while (roundTripIter.hasNext()) {
+                    final var dateStmt = roundTripIter.next();
+                    final var comparisonVal = (XSDDateTime) dateStmt.getObject().getLiteralValue();
+                    if (testLiteral.getYears() == comparisonVal.getYears() &&
+                        testLiteral.getMonths() == comparisonVal.getMonths() &&
+                        testLiteral.getDays() == comparisonVal.getDays() &&
+                        testLiteral.getHours() == comparisonVal.getHours() &&
+                        testLiteral.getMinutes() == comparisonVal.getMinutes() &&
+                        testLiteral.getFullSeconds() == comparisonVal.getFullSeconds() &&
+                        Math.abs(testLiteral.getSeconds() - comparisonVal.getSeconds()) < .001) {
+                            // Delete here as it won't actually match the quad
+                            checkGraph.delete(dateStmt);
+                            return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private String buildSparqlUpdate(final Stream<Triple> toRemove, final Stream<Triple> toAdd,
@@ -466,9 +501,7 @@ public class FedoraRelaxedLdpIT extends AbstractResourceIT {
     private CloseableHttpResponse putResourceWithTTL(final String uri, final String ttl)
             throws IOException {
         final HttpPut httpPut = new HttpPut(uri);
-        httpPut.addHeader("Prefer", "handling=lenient; received=\"minimal\"");
         httpPut.addHeader(CONTENT_TYPE, "text/turtle");
-        httpPut.addHeader(LINK, "<" + BASIC_CONTAINER.toString() + ">; rel=\"type\"");
         httpPut.setEntity(new StringEntity(ttl));
         return execute(httpPut);
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
@@ -34,7 +34,6 @@ import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
@@ -52,63 +51,59 @@ public class RelaxedPropertiesHelper {
 
     /**
      * Gets the created date (if any) that was included in the statements.
-     * @param model model to consider
      * @param resource the resource we are looking for properties of
      * @return the date that should be set for the CREATED_DATE or null if it should be
      *         untouched
      */
-    public static Calendar getCreatedDate(final Model model, final Resource resource) {
-        final Iterable<Statement> iter = getIterable(model, resource, CREATED_DATE);
+    public static Calendar getCreatedDate(final Resource resource) {
+        final Iterable<Statement> iter = getIterable(resource, CREATED_DATE);
         return extractSingleCalendarValue(iter, CREATED_DATE);
     }
 
     /**
      * Gets the created by user (if any) that is included within the statements.
-     * @param model the model to consider
      * @param resource the resource we are looking for properties of
      * @return the string that should be set for the CREATED_BY or null if it should be
      *         untouched
      */
-    public static String getCreatedBy(final Model model, final Resource resource) {
-        final Iterable<Statement> iter = getIterable(model, resource, CREATED_BY);
+    public static String getCreatedBy(final Resource resource) {
+        final Iterable<Statement> iter = getIterable(resource, CREATED_BY);
         return extractSingleStringValue(iter, CREATED_BY);
     }
 
     /**
      * Gets the modified date (if any) that was included within the statements.
-     * @param model model to consider
      * @param resource the resource we are looking for properties of
      * @return the date that should be set for the LAST_MODIFIED_DATE or null if it should be
      *         untouched
      */
-    public static Calendar getModifiedDate(final Model model, final Resource resource) {
-        final Iterable<Statement> iter = getIterable(model, resource, LAST_MODIFIED_DATE);
+    public static Calendar getModifiedDate(final Resource resource) {
+        final Iterable<Statement> iter = getIterable(resource, LAST_MODIFIED_DATE);
         return extractSingleCalendarValue(iter, LAST_MODIFIED_DATE);
     }
 
     /**
      * Gets the modified by user (if any) that was included within the statements.
-     * @param model model to consider
      * @param resource the resource we are looking for properties of
      * @return the string that should be set for the MODIFIED_BY or null if it should be
      *         untouched
      */
-    public static String getModifiedBy(final Model model, final Resource resource) {
-        final Iterable<Statement> iter = getIterable(model, resource, LAST_MODIFIED_BY);
+    public static String getModifiedBy(final Resource resource) {
+        final Iterable<Statement> iter = getIterable(resource, LAST_MODIFIED_BY);
         return extractSingleStringValue(iter, LAST_MODIFIED_BY);
     }
 
     private static String extractSingleStringValue(final Iterable<Statement> statements,
                                                    final Property predicate) {
-        String username = null;
+        String textValue = null;
         for (final Statement added : statements) {
-            if (username == null) {
-                username = added.getObject().asLiteral().getString();
+            if (textValue == null) {
+                textValue = added.getObject().asLiteral().getString();
             } else {
                 throw new MalformedRdfException(predicate + " may only appear once!");
             }
         }
-        return username;
+        return textValue;
     }
 
     private static Calendar extractSingleCalendarValue(final Iterable<Statement> statements, final Property predicate) {
@@ -142,13 +137,10 @@ public class RelaxedPropertiesHelper {
         }
     }
 
-    private static Iterable<Statement> getIterable(final Model model,
-                                                   final Resource resource,
-                                                   final Property predicate) {
-        final var iterator = model.listStatements(resource, predicate, (String)null);
+    private static Iterable<Statement> getIterable(final Resource resource, final Property predicate) {
+        final var iterator = resource.listProperties(predicate);
         return () -> iterator;
     }
-
 
     /**
      * Several tests for invalid or disallowed RDF statements.

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
@@ -17,18 +17,28 @@
  */
 package org.fcrepo.kernel.api.utils;
 
-import org.apache.jena.datatypes.xsd.XSDDateTime;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Statement;
-import org.fcrepo.kernel.api.exception.MalformedRdfException;
-
-import java.util.Calendar;
-
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.vocabulary.RDF.Init.type;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
+import static org.fcrepo.kernel.api.RdfLexicon.restrictedType;
+
+import java.util.Calendar;
+
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
+import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
+
+import org.apache.jena.datatypes.xsd.XSDDateTime;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 
 /**
  * Some server managed triples can have the prohibition on user-management overridden.  While
@@ -36,73 +46,82 @@ import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
  * request to override them.
  *
  * @author Mike Durbin
+ * @author whikloj
  */
 public class RelaxedPropertiesHelper {
 
     /**
      * Gets the created date (if any) that was included in the statements.
-     * @param statements statements to consider
+     * @param model model to consider
+     * @param resource the resource we are looking for properties of
      * @return the date that should be set for the CREATED_DATE or null if it should be
      *         untouched
      */
-    public static Calendar getCreatedDate(final Iterable<Statement> statements) {
-        return extractSingleCalendarValue(statements, CREATED_DATE);
+    public static Calendar getCreatedDate(final Model model, final Resource resource) {
+        final Iterable<Statement> iter = getIterable(model, resource, CREATED_DATE);
+        return extractSingleCalendarValue(iter, CREATED_DATE);
     }
 
     /**
      * Gets the created by user (if any) that is included within the statements.
-     * @param statements statements to consider
-     * @return the date that should be set for the CREATED_BY or null if it should be
+     * @param model the model to consider
+     * @param resource the resource we are looking for properties of
+     * @return the string that should be set for the CREATED_BY or null if it should be
      *         untouched
      */
-    public static String getCreatedBy(final Iterable<Statement> statements) {
-        return extractSingleStringValue(statements, CREATED_BY);
+    public static String getCreatedBy(final Model model, final Resource resource) {
+        final Iterable<Statement> iter = getIterable(model, resource, CREATED_BY);
+        return extractSingleStringValue(iter, CREATED_BY);
     }
 
     /**
      * Gets the modified date (if any) that was included within the statements.
-     * @param statements statements to consider
+     * @param model model to consider
+     * @param resource the resource we are looking for properties of
      * @return the date that should be set for the LAST_MODIFIED_DATE or null if it should be
      *         untouched
      */
-    public static Calendar getModifiedDate(final Iterable<Statement> statements) {
-        return extractSingleCalendarValue(statements, LAST_MODIFIED_DATE);
+    public static Calendar getModifiedDate(final Model model, final Resource resource) {
+        final Iterable<Statement> iter = getIterable(model, resource, LAST_MODIFIED_DATE);
+        return extractSingleCalendarValue(iter, LAST_MODIFIED_DATE);
     }
 
     /**
      * Gets the modified by user (if any) that was included within the statements.
-     * @param statements statements to consider
-     * @return the date that should be set for the MODIFIED_BY or null if it should be
+     * @param model model to consider
+     * @param resource the resource we are looking for properties of
+     * @return the string that should be set for the MODIFIED_BY or null if it should be
      *         untouched
      */
-    public static String getModifiedBy(final Iterable<Statement> statements) {
-       return extractSingleStringValue(statements, LAST_MODIFIED_BY);
+    public static String getModifiedBy(final Model model, final Resource resource) {
+        final Iterable<Statement> iter = getIterable(model, resource, LAST_MODIFIED_BY);
+        return extractSingleStringValue(iter, LAST_MODIFIED_BY);
     }
 
-    private static String extractSingleStringValue(final Iterable<Statement> statements, final Property predicate) {
+    private static String extractSingleStringValue(final Iterable<Statement> statements,
+                                                   final Property predicate) {
         String username = null;
         for (final Statement added : statements) {
-            if (added.getPredicate().equals(predicate)) {
-                if (username == null) {
-                    username = added.getObject().asLiteral().getString();
-                } else {
-                    throw new MalformedRdfException(predicate + " may only appear once!");
-                }
+            if (username == null) {
+                username = added.getObject().asLiteral().getString();
+            } else {
+                throw new MalformedRdfException(predicate + " may only appear once!");
             }
         }
         return username;
     }
 
-    private static Calendar extractSingleCalendarValue(final Iterable<Statement> statements,
-                                                       final Property predicate) {
+    private static Calendar extractSingleCalendarValue(final Iterable<Statement> statements, final Property predicate) {
         Calendar cal = null;
         for (final Statement added : statements) {
-            if (added.getPredicate().equals(predicate)) {
-                if (cal == null) {
+            if (cal == null) {
+                try {
                     cal = RelaxedPropertiesHelper.parseExpectedXsdDateTimeValue(added.getObject());
-                } else {
-                    throw new MalformedRdfException(predicate + " may only appear once!");
+                } catch (final IllegalArgumentException e) {
+                    throw new MalformedRdfException("Expected a xsd:datetime for " + predicate, e);
                 }
+            } else {
+                throw new MalformedRdfException(predicate + " may only appear once!");
             }
         }
         return cal;
@@ -120,6 +139,36 @@ public class RelaxedPropertiesHelper {
             return ((XSDDateTime) value).asCalendar();
         } else {
             throw new IllegalArgumentException("Expected an xsd:dateTime!");
+        }
+    }
+
+    private static Iterable<Statement> getIterable(final Model model,
+                                                   final Resource resource,
+                                                   final Property predicate) {
+        final var iterator = model.listStatements(resource, predicate, (String)null);
+        return () -> iterator;
+    }
+
+
+    /**
+     * Several tests for invalid or disallowed RDF statements.
+     * @param triple the triple to check.
+     */
+    public static void checkTripleForDisallowed(final Triple triple) {
+        if (triple.getPredicate().equals(type().asNode()) && !triple.getObject().isURI()) {
+            // The object of a rdf:type triple is not a URI.
+            throw new MalformedRdfException(
+                    String.format("Invalid rdf:type: %s", triple.getObject()));
+        } else if (restrictedType.test(triple)) {
+            // The object of a rdf:type triple has a restricted namespace.
+            throw new ServerManagedTypeException(
+                    String.format("The server managed type (%s) cannot be modified by the client.",
+                            triple.getObject()));
+        } else if (isManagedPredicate.test(createProperty(triple.getPredicate().getURI()))) {
+            // The predicate is server managed.
+            throw new ServerManagedPropertyException(
+                    String.format("The server managed predicate (%s) cannot be modified by the client.",
+                            triple.getPredicate()));
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRdfSourceOperationBuilder.java
@@ -85,15 +85,19 @@ public abstract class AbstractRdfSourceOperationBuilder implements RdfSourceOper
 
     @Override
     public RdfSourceOperationBuilder triples(final RdfStream triples) {
-        // Filter out server managed properties, they should only matter to the relaxedProperties method.
-        this.tripleStream = new DefaultRdfStream(triples.topic(), triples.filter(t -> {
-            try {
-                checkTripleForDisallowed(t);
-            } catch (final Exception e) {
-                return false;
-            }
-            return true;
-        }));
+        if (this.serverManagedPropsMode.equals(ServerManagedPropsMode.RELAXED)) {
+            // Filter out server managed properties, they should only matter to the relaxedProperties method.
+            this.tripleStream = new DefaultRdfStream(triples.topic(), triples.filter(t -> {
+                try {
+                    checkTripleForDisallowed(t);
+                } catch (final Exception e) {
+                    return false;
+                }
+                return true;
+            }));
+        } else {
+            this.tripleStream = triples;
+        }
         return this;
     }
 
@@ -103,19 +107,19 @@ public abstract class AbstractRdfSourceOperationBuilder implements RdfSourceOper
         if (model != null && serverManagedPropsMode == ServerManagedPropsMode.RELAXED) {
             final var resc = model.getResource(resourceId.getResourceId());
 
-            final var createdDateVal = getCreatedDate(model, resc);
+            final var createdDateVal = getCreatedDate(resc);
             if (createdDateVal != null) {
                 this.createdDate = createdDateVal.toInstant();
             }
-            final var createdByVal = getCreatedBy(model, resc);
+            final var createdByVal = getCreatedBy(resc);
             if (createdByVal != null) {
                 this.createdBy = createdByVal;
             }
-            final var modifiedDate = getModifiedDate(model, resc);
+            final var modifiedDate = getModifiedDate(resc);
             if (modifiedDate != null) {
                 this.lastModifiedDate = modifiedDate.toInstant();
             }
-            final var modifiedBy = getModifiedBy(model, resc);
+            final var modifiedBy = getModifiedBy(resc);
             if (modifiedBy != null) {
                 this.lastModifiedBy = modifiedBy;
             }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -183,7 +183,7 @@ public class CreateResourceServiceImplTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         rdfSourceOperationFactory = new RdfSourceOperationFactoryImpl();
         setField(createResourceService, "rdfSourceOperationFactory", rdfSourceOperationFactory);
         nonRdfSourceOperationFactory = new NonRdfSourceOperationFactoryImpl();
@@ -193,6 +193,7 @@ public class CreateResourceServiceImplTest {
         setField(createResourceService, "referenceService", referenceService);
         setField(createResourceService, "membershipService", membershipService);
         setField(createResourceService, "fedoraPropsConfig", propsConfig);
+        propsConfig.setServerManagedPropsMode(ServerManagedPropsMode.STRICT);
         when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
         when(transaction.getId()).thenReturn(TX_ID);
         // Always try to clean up root.

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -48,12 +48,14 @@ import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 
@@ -338,16 +340,21 @@ public class CreateResourceServiceImplTest {
     @Test
     public void testRdfSetRelaxedProperties_Post() throws Exception {
         final var createdDate = Instant.parse("2019-11-12T10:00:30.0Z");
+        final var calendar = Calendar.getInstance();
+        calendar.setTime(Date.from(createdDate));
+        final var createdDateXsd = new XSDDateTime(calendar);
         final var lastModifiedDate = Instant.parse("2019-11-12T14:11:05.0Z");
+        calendar.setTime(Date.from(lastModifiedDate));
+        final var lastModifiedDateXsd = new XSDDateTime(calendar);
         final String relaxedUser = "relaxedUser";
         final FedoraId fedoraId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childId = fedoraId.resolve("testSlug");
         containmentIndex.addContainedBy(TX_ID, rootId, fedoraId);
 
         final var resc = model.getResource(childId.getFullId());
-        resc.addLiteral(LAST_MODIFIED_DATE, Date.from(lastModifiedDate));
+        resc.addLiteral(LAST_MODIFIED_DATE, lastModifiedDateXsd);
         resc.addLiteral(LAST_MODIFIED_BY, relaxedUser);
-        resc.addLiteral(CREATED_DATE, Date.from(createdDate));
+        resc.addLiteral(CREATED_DATE, createdDateXsd);
         resc.addLiteral(CREATED_BY, relaxedUser);
 
         when(psSession.getHeaders(fedoraId, null)).thenReturn(resourceHeaders);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3225

# What does this Pull Request do?
Alters the HTTP layer to not throw exceptions for SMTs if we are in relaxed mode and instead continue passing the model down.
Then it changes the kernel layer to filter any SMTs so they are not persisted to the user RDF and are only used by the relaxedProperties method.
Lastly it uses some existing work from @mikedurbin because the tests we had put `Date`s in the RDF but when we actually get the RDF back it is a `XSDDateTime` and these methods properly parse that.

# How should this be tested?

Switch the server to relaxed mode by adding a `fcrepo.properties.management=relaxed` to your configuration file. Then try PUT/POST or PATCH with server managed triples.
ie.
```
curl -ufedoraAdmin:fedoraAdmin -H"Slug: test" -XPOST -H"Content-type: text/turtle" -d" <> <http://purl.org/dc/elements/1.1/title> \"Some title\" ; <http://fedora.info/definitions/v4/repository#created> \"1900-01-01T01:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> ." http://localhost:8080/rest
```
Then GET `http://localhost:8080/rest/test` and see a very old object 😉 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
