### PR TITLE
updated to account for header validation on write

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -81,6 +81,10 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
                         resourceId.equals(rootIdentifier),
                         isArchivalPart ? rootIdentifier : null));
 
+        // This covers the case where a resource may have been temporarily deleted if it was changed from an internal
+        // non-RDF resource to an external non-RDF resource
+        headers.setDeleted(false);
+
         if (forExternalBinary(nonRdfSourceOperation)) {
             objectSession.writeResource(headers.asStorageHeaders(), null);
         } else {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateNonRdfSourcePersister.java
@@ -22,6 +22,8 @@ import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.storage.ocfl.OcflObjectSession;
+import org.fcrepo.storage.ocfl.ResourceHeaders;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +62,9 @@ class UpdateNonRdfSourcePersister extends AbstractNonRdfSourcePersister {
             // Read the resource headers prior to updating how the existing resource is stored
             final var headers = objSession.readHeaders(resourceId.getResourceId());
             if (headers.getExternalUrl() == null) {
-                objSession.deleteContentFile(headers);
+                // must mark as deleted here so that the headers a valid
+                objSession.deleteContentFile(ResourceHeaders.builder(headers)
+                        .withDeleted(true).build());
             }
         }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/NonRdfSourcesPersistenceIT.java
@@ -181,6 +181,7 @@ public class NonRdfSourcesPersistenceIT {
         final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .contentDigests(new ArrayList<>(List.of(URI.create("urn:sha1:ohnothisisbad"))))
+                .parentId(FedoraId.getRepositoryRootId())
                 .mimeType("text/plain")
                 .build();
 
@@ -192,6 +193,7 @@ public class NonRdfSourcesPersistenceIT {
         final var op = nonRdfSourceOpFactory.createInternalBinaryBuilder(
                     rescId, IOUtils.toInputStream(BINARY_CONTENT, UTF_8))
                 .contentDigests(asList(URI.create("urn:sha-512:ohnothisisbad"), CONTENT_SHA1))
+                .parentId(FedoraId.getRepositoryRootId())
                 .mimeType("text/plain")
                 .build();
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
@@ -159,11 +159,7 @@ public class AbstractReindexerTest {
         when(((CreateResourceOperation) operation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(operation.getType()).thenReturn(CREATE);
         when(((CreateResourceOperation)operation).isArchivalGroup()).thenReturn(isArchivalGroup);
-        if (isArchivalGroup) {
-            when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
-        } else {
-            when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
-        }
+        when(((CreateResourceOperation) operation).getInteractionModel()).thenReturn(BASIC_CONTAINER.toString());
         session.persist(operation);
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -66,6 +66,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
 import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createFilesystemRepository;
@@ -211,11 +212,18 @@ public class OcflPersistentStorageSessionTest {
                                        final String userPrincipal, final FedoraId resourceId) {
         when(rdfSourceOperation.getTriples()).thenReturn(userStream);
         when(rdfSourceOperation.getResourceId()).thenReturn(FedoraId.create(resourceId.getFullId()));
-        when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(rdfSourceOperation.getType()).thenReturn(CREATE);
         when(rdfSourceOperation.getUserPrincipal()).thenReturn(userPrincipal);
-        when(((CreateResourceOperation) rdfSourceOperation).getInteractionModel())
-                .thenReturn(BASIC_CONTAINER.toString());
+        if (resourceId.isDescription()) {
+            when(((CreateResourceOperation) rdfSourceOperation).getParentId()).thenReturn(resourceId.asBaseId());
+            when(((CreateResourceOperation) rdfSourceOperation).getInteractionModel())
+                    .thenReturn(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI);
+        } else {
+            when(((CreateResourceOperation) rdfSourceOperation).getParentId())
+                    .thenReturn(FedoraId.getRepositoryRootId());
+            when(((CreateResourceOperation) rdfSourceOperation).getInteractionModel())
+                    .thenReturn(BASIC_CONTAINER.toString());
+        }
     }
 
     private void mockResourceOperation(final RdfSourceOperation rdfSourceOperation, final FedoraId resourceId) {
@@ -794,6 +802,7 @@ public class OcflPersistentStorageSessionTest {
         when(((CreateResourceOperation) binOperation).getParentId()).thenReturn(FedoraId.getRepositoryRootId());
         when(binOperation.getType()).thenReturn(CREATE);
         when(binOperation.getUserPrincipal()).thenReturn(userPrincipal);
+        when(binOperation.getMimeType()).thenReturn("text/plain");
         when(((CreateResourceOperation) binOperation).getInteractionModel()).thenReturn(NON_RDF_SOURCE.toString());
         return binOperation;
     }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexServiceTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/ReindexServiceTest.java
@@ -300,7 +300,7 @@ public class ReindexServiceTest extends AbstractReindexerTest {
         assertDoesNotHaveOcflId(parentId);
         assertDoesNotHaveOcflId(childId);
 
-        doThrow(new ValidationException(List.of("validation errors")))
+        doThrow(ValidationException.create(List.of("validation errors")))
                 .when(objectValidator).validate(parentId.getFullId(), false);
 
         reindexManager.start();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3606

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/33**

# What does this Pull Request do?

* Test updates so that the tests produce valid resource headers
* Small behavior tweak when an internal resource is changed to an external resource so that its headers remain valid

# How should this be tested?

No behavior changes. It should not be possible for Fedora to generate invalid headers unless there is a bug somewhere.

# Interested parties
@fcrepo/committers
