### PR TITLE
allow conditions to see values definied in prop files

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/ConditionOnProperty.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/ConditionOnProperty.java
@@ -20,8 +20,11 @@ package org.fcrepo.config;
 
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
@@ -31,7 +34,9 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  *
  * @author pwinckles
  */
-public abstract class ConditionOnProperty<T> implements Condition {
+public abstract class ConditionOnProperty<T> implements ConfigurationCondition {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConditionOnProperty.class);
 
     private final String name;
     private final T expected;
@@ -47,7 +52,14 @@ public abstract class ConditionOnProperty<T> implements Condition {
 
     @Override
     public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+        LOGGER.debug("Prop {}: {}", name, context.getEnvironment().getProperty(name));
         return Objects.equals(expected, context.getEnvironment().getProperty(name, clazz, defaultValue));
     }
 
+    @Override
+    public ConfigurationPhase getConfigurationPhase() {
+        // This forces spring to not evaluate these conditions until after it has loaded other @Configuration classes,
+        // ensuring that the properties have been loaded.
+        return ConfigurationPhase.REGISTER_BEAN;
+    }
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/ConditionOnProperty.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/ConditionOnProperty.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.core.type.AnnotatedTypeMetadata;


### PR DESCRIPTION
**Jira** https://jira.lyrasis.org/browse/FCREPO-3637

# What does this Pull Request do?

Fixes bug where `@Conditional` tests were not seeing properties defined in property files.

# How should this be tested?

Create a property file that contains:

```
fcrepo.auth.enabled=false
```

Start Fedora:

```
mvn -Dfcrepo.config.file=fcrepo.properties jetty:run
```

See that auth is disabled

# Interested parties
@fcrepo/committers
