### PR TITLE
make the event bus async

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -58,6 +58,7 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_JMS_DESTINATION_TYPE = "fcrepo.jms.destination.type";
     private static final String FCREPO_JMS_DESTINATION_NAME = "fcrepo.jms.destination.name";
     public static final String FCREPO_JMS_ENABLED = "fcrepo.jms.enabled";
+    private static final String FCREPO_EVENT_THREADS = "fcrepo.event.threads";
 
     private static final String DATA_DIR_DEFAULT_VALUE = "data";
     private static final String LOG_DIR_DEFAULT_VALUE = "logs";
@@ -121,6 +122,9 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${" + FCREPO_JMS_DESTINATION_NAME + ":fedora}")
     private String jmsDestinationName;
+
+    @Value("${" + FCREPO_EVENT_THREADS + ":1}")
+    private int eventBusThreads;
 
     @PostConstruct
     private void postConstruct() throws IOException {
@@ -303,4 +307,14 @@ public class FedoraPropsConfig extends BasePropsConfig {
         return jmsDestinationName;
     }
 
+    /**
+     * @return the number of threads to allocate in the event bus thread pool
+     *         if this number is less than 1, 1 is returned
+     */
+    public int getEventBusThreads() {
+        if (eventBusThreads < 1) {
+            return 1;
+        }
+        return eventBusThreads;
+    }
 }

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -28,6 +28,8 @@ import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -42,6 +44,8 @@ import com.google.common.eventbus.EventBus;
  */
 @Configuration
 public class WebappConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebappConfig.class);
 
     /**
      * Task scheduler used for cleaning up transactions
@@ -80,8 +84,9 @@ public class WebappConfig {
      * @return executor intended to be used by the Guava event bus
      */
     @Bean
-    public ExecutorService eventBusExecutor() {
-        return Executors.newCachedThreadPool();
+    public ExecutorService eventBusExecutor(final FedoraPropsConfig propsConfig) {
+        LOGGER.debug("Event bus threads: {}", propsConfig);
+        return Executors.newFixedThreadPool(propsConfig.getEventBusThreads());
     }
 
     /**

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -73,6 +73,7 @@ public class WebappConfig {
     /**
      * Fedora's lightweight internal event bus. Currently memory-resident.
      *
+     * @param propsConfig config
      * @return event bus
      */
     @Bean
@@ -81,6 +82,7 @@ public class WebappConfig {
     }
 
     /**
+     * @param propsConfig config
      * @return executor intended to be used by the Guava event bus
      */
     @Bean

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -18,6 +18,9 @@
 
 package org.fcrepo.webapp;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.api.ExternalContentHandlerFactory;
 import org.fcrepo.http.api.ExternalContentPathValidator;
@@ -29,6 +32,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
 
 /**
@@ -69,8 +73,15 @@ public class WebappConfig {
      */
     @Bean
     public EventBus eventBus() {
-        // TODO this should be an async event bus: https://jira.lyrasis.org/browse/FCREPO-3587
-        return new EventBus();
+        return new AsyncEventBus(eventBusExecutor());
+    }
+
+    /**
+     * @return executor intended to be used by the Guava event bus
+     */
+    @Bean
+    public ExecutorService eventBusExecutor() {
+        return Executors.newCachedThreadPool();
     }
 
     /**

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -76,8 +76,8 @@ public class WebappConfig {
      * @return event bus
      */
     @Bean
-    public EventBus eventBus() {
-        return new AsyncEventBus(eventBusExecutor());
+    public EventBus eventBus(final FedoraPropsConfig propsConfig) {
+        return new AsyncEventBus(eventBusExecutor(propsConfig));
     }
 
     /**


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3587

# What does this Pull Request do?

Makes the guava event bus that's used to emit messages asynchronous, which is, I believe, how people were already assuming it was operating.

# How should this be tested?

Fire up Fedora, listen for events, create a resource, and see that events still work.

# Interested parties
@fcrepo/committers
