### PR TITLE
Throw exceptions for managed types when in RELAXED mode

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -21,7 +21,7 @@ package org.fcrepo.http.api.services;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
-import static org.fcrepo.config.ServerManagedPropsMode.RELAXED;
+import static org.fcrepo.config.ServerManagedPropsMode.STRICT;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
 import static org.fcrepo.kernel.api.RdfLexicon.restrictedType;
 import static org.fcrepo.kernel.api.utils.RelaxedPropertiesHelper.checkTripleForDisallowed;
@@ -136,17 +136,26 @@ public class HttpRdfService {
 
         while (stmtIterator.hasNext()) {
             final Statement stmt = stmtIterator.nextStatement();
-            if (lenientHandling && stmtIsServerManaged(stmt)) {
+            if (lenientHandling && stmtIsServerManaged(stmt) &&
+                    fedoraPropsConfig.getServerManagedPropsMode().equals(STRICT)) {
                 // Remove any statement that touches a server managed property or namespace.
                 stmtIterator.remove();
             } else {
                 try {
                     checkForDisallowedRdf(stmt);
-                } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
-                    if (!fedoraPropsConfig.getServerManagedPropsMode().equals(RELAXED)) {
+                } catch (final ServerManagedPropertyException exc) {
+                    if (fedoraPropsConfig.getServerManagedPropsMode().equals(STRICT)) {
                         exceptions.add(exc);
                         continue;
                     }
+                } catch (final ServerManagedTypeException exc) {
+                    if (lenientHandling) {
+                        // Remove the invalid statement because client specified lenient handling.
+                        stmtIterator.remove();
+                    } else {
+                        exceptions.add(exc);
+                    }
+                    continue;
                 }
                 if (stmt.getSubject().isURIResource()) {
                     final String originalSubj = stmt.getSubject().getURI();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -41,6 +41,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
+import org.fcrepo.kernel.api.exception.RelaxableServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
@@ -143,12 +144,12 @@ public class HttpRdfService {
             } else {
                 try {
                     checkForDisallowedRdf(stmt);
-                } catch (final ServerManagedPropertyException exc) {
+                } catch (final RelaxableServerManagedPropertyException exc) {
                     if (fedoraPropsConfig.getServerManagedPropsMode().equals(STRICT)) {
                         exceptions.add(exc);
                         continue;
                     }
-                } catch (final ServerManagedTypeException exc) {
+                } catch (final ServerManagedTypeException | ServerManagedPropertyException exc) {
                     if (lenientHandling) {
                         // Remove the invalid statement because client specified lenient handling.
                         stmtIterator.remove();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -191,12 +191,15 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         for (final Quad q : quadsList) {
             try {
                 checkTripleForDisallowed(q.asTriple());
-            } catch (final ServerManagedPropertyException | ServerManagedTypeException exc) {
+            } catch (final ServerManagedPropertyException exc) {
                 if (!isRelaxedMode) {
                     // Swallow these exceptions to throw together later.
                     exceptions.add(exc);
                     continue;
                 }
+            } catch (final ServerManagedTypeException exc) {
+                exceptions.add(exc);
+                continue;
             }
             final Node subject = translateId(q.getSubject());
             final Node object = translateId(q.getObject());

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -30,6 +30,7 @@ import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
+import org.fcrepo.kernel.api.exception.RelaxableServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
@@ -191,13 +192,13 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
         for (final Quad q : quadsList) {
             try {
                 checkTripleForDisallowed(q.asTriple());
-            } catch (final ServerManagedPropertyException exc) {
+            } catch (final RelaxableServerManagedPropertyException exc) {
                 if (!isRelaxedMode) {
                     // Swallow these exceptions to throw together later.
                     exceptions.add(exc);
                     continue;
                 }
-            } catch (final ServerManagedTypeException exc) {
+            } catch (final ServerManagedTypeException | ServerManagedPropertyException exc) {
                 exceptions.add(exc);
                 continue;
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -805,4 +805,27 @@ public abstract class AbstractResourceIT {
                         .anyMatch(l -> l.getRel().equals(CONSTRAINED_BY.getURI())));
     }
 
+
+    /**
+     * Create a Prefer header
+     * @param includes String of include URIs or null if none
+     * @param omits String of omit URIs or null if none
+     * @return The Prefer header.
+     */
+    protected String preferLink(final String includes, final String omits) {
+        if (includes != null || omits != null) {
+            String link = "return=representation; ";
+            if (includes != null) {
+                link += "include=\"" + includes + "\"";
+            }
+            if (includes != null && omits != null) {
+                link += "; ";
+            }
+            if (omits != null) {
+                link += "omit=\"" + omits + "\"";
+            }
+            return link;
+        }
+        return "";
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -113,6 +113,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PREFER_SERVER_MANAGED;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -812,7 +813,7 @@ public abstract class AbstractResourceIT {
      * @param omits String of omit URIs or null if none
      * @return The Prefer header.
      */
-    protected String preferLink(final String includes, final String omits) {
+    protected static String preferLink(final String includes, final String omits) {
         if (includes != null || omits != null) {
             String link = "return=representation; ";
             if (includes != null) {
@@ -827,5 +828,18 @@ public abstract class AbstractResourceIT {
             return link;
         }
         return "";
+    }
+
+    /**
+     * Compare two N-Triple response bodies to determine if they are identical
+     * @param responseBodyA the first n-triple body
+     * @param responseBodyB the second n-triple body
+     */
+    protected static void confirmResponseBodyNTriplesAreEqual(final String responseBodyA, final String responseBodyB) {
+        final String[] aTriples = responseBodyA.split(".(\\r\\n|\\r|\\n)");
+        final String[] bTriples = responseBodyB.split(".(\\r\\n|\\r|\\n)");
+        Arrays.stream(aTriples).map(String::trim).sorted().toArray(unused -> aTriples);
+        Arrays.stream(bTriples).map(String::trim).sorted().toArray(unused -> bTriples);
+        assertArrayEquals(aTriples, bTriples);
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -83,7 +83,6 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -1615,14 +1614,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         // Assert they are all the same
         confirmResponseBodyNTriplesAreEqual(originalTriples, mementoTriples);
         confirmResponseBodyNTriplesAreEqual(updatedTriples, mementoTriples);
-    }
-
-    private void confirmResponseBodyNTriplesAreEqual(final String responseBodyA, final String responseBodyB) {
-        final String[] aTriples = responseBodyA.split(".(\\r\\n|\\r|\\n)");
-        final String[] bTriples = responseBodyB.split(".(\\r\\n|\\r|\\n)");
-        Arrays.stream(aTriples).map(String::trim).sorted().toArray(unused -> aTriples);
-        Arrays.stream(bTriples).map(String::trim).sorted().toArray(unused -> bTriples);
-        assertArrayEquals(aTriples, bTriples);
     }
 
     private void createVersionedExternalBinaryMemento(final String rescId, final String handling,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/PrefersLdpIT.java
@@ -142,29 +142,6 @@ public class PrefersLdpIT extends AbstractResourceIT {
     }
 
     /**
-     * Create a Prefer header
-     * @param includes String of include URIs or null if none
-     * @param omits String of omit URIs or null if none
-     * @return The Prefer header.
-     */
-    private String preferLink(final String includes, final String omits) {
-        if (includes != null || omits != null) {
-            String link = "return=representation; ";
-            if (includes != null) {
-                link += "include=\"" + includes + "\"";
-            }
-            if (includes != null && omits != null) {
-                link += "; ";
-            }
-            if (omits != null) {
-                link += "omit=\"" + omits + "\"";
-            }
-            return link;
-        }
-        return "";
-    }
-
-    /**
      * Generate a common set of triples for the Prefer header tests.
      * @throws Exception problems with a http request.
      */

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -224,11 +224,21 @@ public final class RdfLexicon {
     private static Predicate<Property> hasMementoNamespace =
         p -> !p.isAnon() && p.getNameSpace().startsWith(MEMENTO_NAMESPACE);
 
+    // Set of relaxable server managed properties
+    private static final Set<Property> serverManagedRelaxableProperties = Set.of(
+            CREATED_DATE, CREATED_BY, LAST_MODIFIED_DATE, LAST_MODIFIED_BY
+    );
+
     /**
      * Detects whether an RDF property is managed by the repository.
      */
     public static final Predicate<Property> isManagedPredicate =
-            hasFedoraNamespace.or(hasMementoNamespace).or(p -> serverManagedProperties.contains(p));
+            hasFedoraNamespace.or(hasMementoNamespace).or(serverManagedProperties::contains);
+
+    /**
+     * Tests if a property is relaxable (if the server is in relaxed mode).
+     */
+    public static final Predicate<Property> isRelaxablePredicate = serverManagedRelaxableProperties::contains;
 
     // VERSIONING
     /**

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RelaxableServerManagedPropertyException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/RelaxableServerManagedPropertyException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ * Exception thrown if a Relaxable SMT is altered.
+ * @author whikloj
+ * @since 6.0.0
+ */
+public class RelaxableServerManagedPropertyException extends ServerManagedPropertyException {
+
+    /**
+     *
+     * @param msg the message
+     */
+    public RelaxableServerManagedPropertyException(final String msg) {
+        super(msg);
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
@@ -24,11 +24,13 @@ import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
+import static org.fcrepo.kernel.api.RdfLexicon.isRelaxablePredicate;
 import static org.fcrepo.kernel.api.RdfLexicon.restrictedType;
 
 import java.util.Calendar;
 
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
+import org.fcrepo.kernel.api.exception.RelaxableServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedPropertyException;
 import org.fcrepo.kernel.api.exception.ServerManagedTypeException;
 
@@ -159,9 +161,13 @@ public class RelaxedPropertiesHelper {
                             triple.getObject()));
         } else if (isManagedPredicate.test(createProperty(triple.getPredicate().getURI()))) {
             // The predicate is server managed.
-            throw new ServerManagedPropertyException(
-                    String.format("The server managed predicate (%s) cannot be modified by the client.",
-                            triple.getPredicate()));
+            final var message = String.format("The server managed predicate (%s) cannot be modified by the client.",
+                    triple.getPredicate());
+            if (isRelaxablePredicate.test(createProperty(triple.getPredicate().getURI()))) {
+                // It is a relaxable predicate so throw the appropriate exception.
+                throw new RelaxableServerManagedPropertyException(message);
+            }
+            throw new ServerManagedPropertyException(message);
         }
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/utils/RelaxedPropertiesHelper.java
@@ -147,8 +147,9 @@ public class RelaxedPropertiesHelper {
      * @param triple the triple to check.
      */
     public static void checkTripleForDisallowed(final Triple triple) {
-        if (triple.getPredicate().equals(type().asNode()) && !triple.getObject().isURI()) {
-            // The object of a rdf:type triple is not a URI.
+        if (triple.getPredicate().equals(type().asNode()) && !triple.getObject().isVariable() &&
+                !triple.getObject().isURI()) {
+            // The object of a rdf:type triple is not a variable and not a URI.
             throw new MalformedRdfException(
                     String.format("Invalid rdf:type: %s", triple.getObject()));
         } else if (restrictedType.test(triple)) {

--- a/fcrepo-webapp/src/test/java/org/fcrepo/webapp/ConstraintExceptionsTest.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/webapp/ConstraintExceptionsTest.java
@@ -20,6 +20,8 @@ package org.fcrepo.webapp;
 import org.fcrepo.kernel.api.exception.MultipleConstraintViolationException;
 import org.junit.Assert;
 import org.fcrepo.kernel.api.exception.ConstraintViolationException;
+import org.fcrepo.kernel.api.exception.RelaxableServerManagedPropertyException;
+
 import org.junit.Test;
 import org.reflections.Reflections;
 
@@ -39,9 +41,12 @@ public class ConstraintExceptionsTest {
                 reflections.getSubTypesOf(ConstraintViolationException.class);
         // Multiple is a wrapper to hold other constraint violations, it has no static file.
         subTypes.remove(MultipleConstraintViolationException.class);
+        // Relaxable is a sub-type of ServerManagedPropertyException to specially handle relaxable properties, it has
+        // no static file.
+        subTypes.remove(RelaxableServerManagedPropertyException.class);
         subTypes.add(ConstraintViolationException.class);
 
-        for (final Class c : subTypes) {
+        for (final Class<? extends ConstraintViolationException> c : subTypes) {
             final File file = new File("src/main/webapp/static/constraints/" + c.getSimpleName() + ".rdf");
             Assert.assertTrue("Expected to find: " + file.getPath(), file.exists());
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3645

# What does this Pull Request do?
To more closely mimic Fedora 5s behaviour this alters Fedora 6 to throw an exception when a user adds a managed type in their RDF when the server is in relaxed mode. Previously it just ignored the triple.

# How should this be tested?

1. Start Fedora in relaxed mode. ie. (`fcrepo.properties.management=relaxed`)
1. Create a resource a new resource.
1. GET the resource without server managed properties, or remove them from the result to make it easier to see what is happening.
1. Add a server managed type to the body, like `<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/ldp#NonRDFSource>`
1. Try to PUT this back to the server.
1. In `main` you will succeed but nothing changes.
1. In this PR you will get a 409 Conflict.

# Interested parties
@fcrepo/committers, specifically @bbpennel 
