### PR TITLE
Don't try to PUT descriptions to non-existant binaries

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -49,6 +49,7 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_TYPE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_OCTET_STREAM_TYPE;
 
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.fcrepo.kernel.api.RdfLexicon.ARCHIVAL_GROUP;
 import static org.fcrepo.kernel.api.RdfLexicon.INTERACTION_MODEL_RESOURCES;
 import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
@@ -422,7 +423,13 @@ public class FedoraLdp extends ContentExposingResource {
 
             if (!resourceExists && fedoraId.isDescription()) {
                 // Can't PUT a description to a non-existant binary.
-                throw new PathNotFoundException("Binary at path " + fedoraId.asBaseId().getFullIdPath() + " not found");
+                final String message;
+                if (fedoraId.asBaseId().isRepositoryRoot()) {
+                    message = "The root of the repository is not a binary, so /" + FCR_METADATA + " does not exist.";
+                } else {
+                    message = "Binary at path " + fedoraId.asBaseId().getFullIdPath() + " not found";
+                }
+                throw new PathNotFoundException(message);
             }
 
             final var providedContentType = getSimpleContentType(requestContentType);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -420,6 +420,11 @@ public class FedoraLdp extends ContentExposingResource {
                 throw new GhostNodeException("Resource path " + externalPath() + " is an immutable resource.");
             }
 
+            if (!resourceExists && fedoraId.isDescription()) {
+                // Can't PUT a description to a non-existant binary.
+                throw new PathNotFoundException("Binary at path " + fedoraId.asBaseId().getFullIdPath() + " not found");
+            }
+
             final var providedContentType = getSimpleContentType(requestContentType);
 
             boolean created = false;

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4654,6 +4654,17 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testNonExistantFcrMetadata() throws Exception {
+        final var id = getRandomUniqueId();
+        // Ensure the object does not exist
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObjMethod(id)));
+        // Ensure the metadata of a non-existant object also doesn't exist.
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObjMethod(id + "/" + FCR_METADATA)));
+        // Ensure you can't PUT at non-existant binary.
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(putObjMethod(id + "/" + FCR_METADATA)));
+    }
+
     private void assertIdStringConstraint(final String id) throws IOException {
         assertInvalidId(id);
         assertValidId(id + "-suffix");


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3648

# What does this Pull Request do?
Adds a check to stop an attempt to `PUT` a binary description to a binary that doesn't exist

# How should this be tested?

Before PR
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/bob                   
HTTP/1.1 404 Not Found
Date: Fri, 19 Feb 2021 15:50:08 GMT
Set-Cookie: JSESSIONID=node01ggergt4zt1gw1nxk193s7u6cg0.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 18-Feb-2021 15:50:09 GMT; SameSite=lax
Content-Type: text/turtle;charset=utf-8
Content-Length: 48
Server: Jetty(9.4.34.v20201102)

Error: No OCFL mapping found for info:fedora/bob

> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/bob/fcr:metadata -XPUT
HTTP/1.1 500 Internal Server Error
Set-Cookie: JSESSIONID=node01ksys0g9n7mxs12ow2beuziqp1.node0; Path=/
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 18-Feb-2021 15:50:11 GMT; SameSite=lax
Content-Length: 0
Server: Jetty(9.4.34.v20201102)
```

After this PR
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/bob
HTTP/1.1 404 Not Found
Date: Fri, 19 Feb 2021 15:33:34 GMT
Set-Cookie: JSESSIONID=node0bkyb2qrk8qjs7cw9jfrjivf60.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 18-Feb-2021 15:33:34 GMT; SameSite=lax
Content-Type: text/turtle;charset=utf-8
Content-Length: 48
Server: Jetty(9.4.34.v20201102)

Error: No OCFL mapping found for info:fedora/bob

> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/bob/fcr:metadata -XPUT
HTTP/1.1 404 Not Found
Date: Fri, 19 Feb 2021 16:06:48 GMT
Set-Cookie: JSESSIONID=node0abt77vjok7n41nppcclaq2xcd0.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Thu, 18-Feb-2021 16:06:48 GMT; SameSite=lax
Content-Type: text/plain
Content-Length: 36
Server: Jetty(9.4.34.v20201102)

Error: Binary at path /bob not found
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
