### PR TITLE
Reject disallowed fcr:fixity methods

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.http.api;
 
+import static javax.ws.rs.core.HttpHeaders.ALLOW;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
@@ -32,15 +33,23 @@ import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.micrometer.core.annotation.Timed;
+
+import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
@@ -61,6 +70,8 @@ import org.springframework.context.annotation.Scope;
 public class FedoraFixity extends ContentExposingResource {
 
     private static final Logger LOGGER = getLogger(FedoraFixity.class);
+
+    private static final String OPTIONS_VALUES = "OPTIONS, GET";
 
     @PathParam("path") protected String externalPath;
 
@@ -115,5 +126,37 @@ public class FedoraFixity extends ContentExposingResource {
     @Override
     protected String externalPath() {
         return externalPath;
+    }
+
+    @OPTIONS
+    public Response options() {
+        return Response.ok().header(ALLOW, OPTIONS_VALUES).build();
+    }
+    /*
+     * These methods are disallowed, but need to exist here or the path gets caught by the FedoraLdp path matcher.
+     */
+    @HEAD
+    public Response get() {
+        return methodNotAllowed();
+    }
+    @POST
+    public Response post() {
+        return methodNotAllowed();
+    }
+    @PUT
+    public Response put() {
+        return methodNotAllowed();
+    }
+    @PATCH
+    public Response patch() {
+        return methodNotAllowed();
+    }
+    @DELETE
+    public Response delete() {
+        return methodNotAllowed();
+    }
+
+    private Response methodNotAllowed() {
+        return Response.status(Response.Status.METHOD_NOT_ALLOWED).header(ALLOW, OPTIONS_VALUES).build();
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -20,8 +20,8 @@ package org.fcrepo.http.api;
 import static javax.ws.rs.core.HttpHeaders.ALLOW;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.fcrepo.http.commons.domain.RDFMediaType.JSON_LD;
-import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2_WITH_CHARSET;
+import static org.fcrepo.http.commons.domain.RDFMediaType.N3_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
@@ -46,17 +46,19 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.micrometer.core.annotation.Timed;
-
 import org.fcrepo.http.commons.domain.PATCH;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
 import org.fcrepo.http.commons.responses.RdfNamespacedStream;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.services.FixityService;
+
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.micrometer.core.annotation.Timed;
 
 /**
  * Run a fixity check on a path
@@ -107,7 +109,8 @@ public class FedoraFixity extends ContentExposingResource {
     public RdfNamespacedStream getDatastreamFixity() {
 
         if (!(resource() instanceof Binary)) {
-            throw new NotFoundException(resource() + " is not a binary");
+            throw new NotFoundException("Error: Resource at " + resource().getFedoraId().getFullIdPath() + " is not a" +
+                    " binary");
         }
 
         final Link.Builder resourceLink = Link.fromUri(RESOURCE.getURI()).rel("type");

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraFixityIT.java
@@ -17,6 +17,7 @@
  */
 package org.fcrepo.integration.http.api;
 
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
@@ -71,7 +72,6 @@ import org.springframework.test.context.TestExecutionListeners;
 public class FedoraFixityIT extends AbstractResourceIT {
 
     private static final RDFDatatype IntegerType = TypeMapper.getInstance().getTypeByClass(Integer.class);
-    private static final RDFDatatype StringType = TypeMapper.getInstance().getTypeByClass(String.class);
 
     private OcflPropsConfig ocflConfig;
     private OcflRepository ocflRepo;
@@ -194,6 +194,18 @@ public class FedoraFixityIT extends AbstractResourceIT {
             assertTrue(graphStore.contains(ANY, ANY, HAS_MESSAGE_DIGEST.asNode(), ANY));
             assertTrue(graphStore.contains(ANY, ANY, HAS_SIZE.asNode(), createLiteral("3", IntegerType)));
         }
+    }
+
+    @Test
+    public void testInvalidMethods() throws Exception {
+        final String id = getRandomUniqueId();
+        final String fixityId = id + "/" + FCR_FIXITY;
+        createDatastream(id,"foo");
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(patchObjMethod(fixityId)));
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(deleteObjMethod(fixityId)));
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(putObjMethod(fixityId)));
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(postObjMethod(fixityId)));
+        assertEquals(METHOD_NOT_ALLOWED.getStatusCode(), getStatus(headObjMethod(fixityId)));
     }
 
     private static String postVersion(final String path) throws IOException {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -4081,7 +4081,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     @Test
     public void testPostFcrSlug() throws IOException {
-        final HttpPost httpPost = postObjMethod("/");
+        final HttpPost httpPost = postObjMethod();
         httpPost.addHeader("Slug", "fcr:path");
         try (final CloseableHttpResponse response = execute(httpPost)) {
             assertEquals("Must not be able to POST with fcr namespaced Slug!", CONFLICT.getStatusCode(),
@@ -4100,7 +4100,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     @Test
     public void testPutFcrTx() throws IOException {
-        final HttpPut httpPut = putObjMethod("hello/fcr:fixity");
+        final HttpPut httpPut = putObjMethod("hello/fcr:tx");
         try (final CloseableHttpResponse response = execute(httpPut)) {
             assertEquals("Must not be able to PUT with fcr namespaced path!", CONFLICT.getStatusCode(),
                 getStatus(response));


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3649

# What does this Pull Request do?
Disallows many methods on the `fcr:fixity` endpoints.

# How should this be tested?

See various examples in the ticket, but essentially you should no longer get any response except a 405 Method Not Allowed for any of `DELETE`, `HEAD`, `PUT`, `POST` or `PATCH`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
