### PR TITLE
fix reindx thread count calculation

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -417,7 +417,7 @@ public class OcflPropsConfig extends BasePropsConfig {
      * @return number of available processors minus 1.
      */
     private static long computeDefaultReindexThreads() {
-        return availableThreads - 1;
+        return Math.max(availableThreads - 1, 1);
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
@@ -78,7 +78,15 @@ public class ReindexManager {
         workers = new ArrayList<>();
         completedCount = new AtomicInteger(0);
         errorCount = new AtomicInteger(0);
-        for (var foo = 0; foo < config.getReindexingThreads(); foo += 1) {
+
+        final var workerCount = config.getReindexingThreads();
+
+        if (workerCount < 1) {
+            throw new IllegalStateException(String.format("Reindexing requires at least 1 thread. Found: %s",
+                    workerCount));
+        }
+
+        for (var foo = 0; foo < workerCount; foo += 1) {
             workers.add(new ReindexWorker(this, this.reindexService, transactionId, this.failOnError));
         }
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3666

# What does this Pull Request do?

Fixes the default thread count calculation so that there will always be at least 1 reindex thread

# How should this be tested?

Run Fedora on a system that only as a single available processor and see that it still creates a reindex thread.

# Interested parties
@fcrepo/committers
