### PR TITLE
allow unicode chars by default

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -59,9 +59,6 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_JMS_DESTINATION_NAME = "fcrepo.jms.destination.name";
     public static final String FCREPO_JMS_ENABLED = "fcrepo.jms.enabled";
     private static final String FCREPO_EVENT_THREADS = "fcrepo.event.threads";
-    private static final String FCREPO_PATH_ALLOW_NON_ASCII = "fcrepo.path.allow.non-ascii";
-    private static final String FCREPO_PATH_ALLOW_BACKSLASH = "fcrepo.path.allow.backslash";
-    private static final String FCREPO_PATH_ALLOW_SEMICOLON = "fcrepo.path.allow.semicolon";
 
     private static final String DATA_DIR_DEFAULT_VALUE = "data";
     private static final String LOG_DIR_DEFAULT_VALUE = "logs";
@@ -128,15 +125,6 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${" + FCREPO_EVENT_THREADS + ":1}")
     private int eventBusThreads;
-
-    @Value("${" + FCREPO_PATH_ALLOW_NON_ASCII + ":true}")
-    private boolean pathAllowNonAscii;
-
-    @Value("${" + FCREPO_PATH_ALLOW_BACKSLASH + ":true}")
-    private boolean pathAllowBackslash;
-
-    @Value("${" + FCREPO_PATH_ALLOW_SEMICOLON + ":true}")
-    private boolean pathAllowSemicolon;
 
     @PostConstruct
     private void postConstruct() throws IOException {
@@ -330,24 +318,4 @@ public class FedoraPropsConfig extends BasePropsConfig {
         return eventBusThreads;
     }
 
-    /**
-     * @return indicates if non-ascii chars should be allowed in URL paths
-     */
-    public boolean isPathAllowNonAscii() {
-        return pathAllowNonAscii;
-    }
-
-    /**
-     * @return indicates if backslash chars should be allowed in URL paths
-     */
-    public boolean isPathAllowBackslash() {
-        return pathAllowBackslash;
-    }
-
-    /**
-     * @return indicates if semicolon chars should be allowed in URL paths
-     */
-    public boolean isPathAllowSemicolon() {
-        return pathAllowSemicolon;
-    }
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -59,6 +59,9 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_JMS_DESTINATION_NAME = "fcrepo.jms.destination.name";
     public static final String FCREPO_JMS_ENABLED = "fcrepo.jms.enabled";
     private static final String FCREPO_EVENT_THREADS = "fcrepo.event.threads";
+    private static final String FCREPO_PATH_ALLOW_NON_ASCII = "fcrepo.path.allow.non-ascii";
+    private static final String FCREPO_PATH_ALLOW_BACKSLASH = "fcrepo.path.allow.backslash";
+    private static final String FCREPO_PATH_ALLOW_SEMICOLON = "fcrepo.path.allow.semicolon";
 
     private static final String DATA_DIR_DEFAULT_VALUE = "data";
     private static final String LOG_DIR_DEFAULT_VALUE = "logs";
@@ -125,6 +128,15 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${" + FCREPO_EVENT_THREADS + ":1}")
     private int eventBusThreads;
+
+    @Value("${" + FCREPO_PATH_ALLOW_NON_ASCII + ":true}")
+    private boolean pathAllowNonAscii;
+
+    @Value("${" + FCREPO_PATH_ALLOW_BACKSLASH + ":true}")
+    private boolean pathAllowBackslash;
+
+    @Value("${" + FCREPO_PATH_ALLOW_SEMICOLON + ":true}")
+    private boolean pathAllowSemicolon;
 
     @PostConstruct
     private void postConstruct() throws IOException {
@@ -316,5 +328,26 @@ public class FedoraPropsConfig extends BasePropsConfig {
             return 1;
         }
         return eventBusThreads;
+    }
+
+    /**
+     * @return indicates if non-ascii chars should be allowed in URL paths
+     */
+    public boolean isPathAllowNonAscii() {
+        return pathAllowNonAscii;
+    }
+
+    /**
+     * @return indicates if backslash chars should be allowed in URL paths
+     */
+    public boolean isPathAllowBackslash() {
+        return pathAllowBackslash;
+    }
+
+    /**
+     * @return indicates if semicolon chars should be allowed in URL paths
+     */
+    public boolean isPathAllowSemicolon() {
+        return pathAllowSemicolon;
     }
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -317,5 +317,4 @@ public class FedoraPropsConfig extends BasePropsConfig {
         }
         return eventBusThreads;
     }
-
 }

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
@@ -33,11 +33,13 @@ import org.fcrepo.auth.webac.WebACAuthorizingRealm;
 import org.fcrepo.auth.webac.WebACFilter;
 import org.fcrepo.config.AuthPropsConfig;
 import org.fcrepo.config.ConditionOnPropertyTrue;
+import org.fcrepo.config.FedoraPropsConfig;
 
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.spring.LifecycleBeanPostProcessor;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
+import org.apache.shiro.web.filter.InvalidRequestFilter;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.slf4j.Logger;
@@ -184,6 +186,22 @@ public class AuthConfig {
     @Order(2)
     public Filter webACFilter() {
         return new WebACFilter();
+    }
+
+    /**
+     * Shiro's filter that rejects invalid requests. Can be configured to reject requests containing specific characters
+     *
+     * @param propsConfig config props
+     * @return invalid request filter
+     */
+    @Bean
+    @Order(6)
+    public Filter invalidRequest(final FedoraPropsConfig propsConfig) {
+        final var filter = new InvalidRequestFilter();
+        filter.setBlockNonAscii(!propsConfig.isPathAllowNonAscii());
+        filter.setBlockBackslash(!propsConfig.isPathAllowBackslash());
+        filter.setBlockBackslash(!propsConfig.isPathAllowSemicolon());
+        return filter;
     }
 
     /**

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
@@ -33,7 +33,6 @@ import org.fcrepo.auth.webac.WebACAuthorizingRealm;
 import org.fcrepo.auth.webac.WebACFilter;
 import org.fcrepo.config.AuthPropsConfig;
 import org.fcrepo.config.ConditionOnPropertyTrue;
-import org.fcrepo.config.FedoraPropsConfig;
 
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.realm.AuthorizingRealm;
@@ -189,18 +188,17 @@ public class AuthConfig {
     }
 
     /**
-     * Shiro's filter that rejects invalid requests. Can be configured to reject requests containing specific characters
+     * Shiro's filter for rejecting invalid requests
      *
-     * @param propsConfig config props
      * @return invalid request filter
      */
     @Bean
     @Order(6)
-    public Filter invalidRequest(final FedoraPropsConfig propsConfig) {
+    public Filter invalidRequest() {
         final var filter = new InvalidRequestFilter();
-        filter.setBlockNonAscii(!propsConfig.isPathAllowNonAscii());
-        filter.setBlockBackslash(!propsConfig.isPathAllowBackslash());
-        filter.setBlockBackslash(!propsConfig.isPathAllowSemicolon());
+        filter.setBlockNonAscii(false);
+        filter.setBlockBackslash(false);
+        filter.setBlockSemicolon(false);
         return filter;
     }
 

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -180,4 +180,17 @@ public class SanityCheckIT {
         final HttpGet getLink = new HttpGet(linkURI);
         executeAndVerify(getLink, SC_OK);
     }
+
+    @Test
+    public void testUnicodeCharsAllowed() throws Exception {
+        final var id = "ÅŤéșţ!";
+        final var url = serverAddress + "/" + id;
+
+        final HttpPut put = new HttpPut(url);
+        put.setEntity(new StringEntity("testing"));
+        put.setHeader(CONTENT_TYPE, "text/plain");
+        executeAndVerify(put, SC_CREATED);
+
+        executeAndVerify(new HttpGet(url), SC_OK);
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3667

# What does this Pull Request do?

* Non-ASCII, `\`, and `:` are no longer blocked

# How should this be tested?

Try creating a resource containing unicode chars before and after this PR.

# Interested parties
@fcrepo/committers
