### PR TITLE
corrected slugs to be interpreted as url encoded strings

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -60,6 +60,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
@@ -594,6 +595,7 @@ public class FedoraLdp extends ContentExposingResource {
                                  @HeaderParam("Digest") final String digest)
             throws InvalidChecksumException, MalformedRdfException, UnsupportedAlgorithmException {
 
+        final var decodedSlug = slug != null ? URLDecoder.decode(slug, UTF_8) : null;
         final var transaction = transaction();
 
         try {
@@ -611,10 +613,10 @@ public class FedoraLdp extends ContentExposingResource {
             final String interactionModel = checkInteractionModel(links);
 
             final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
-            final FedoraId newFedoraId = mintNewPid(fedoraId, slug);
+            final FedoraId newFedoraId = mintNewPid(fedoraId, decodedSlug);
             final var providedContentType = getSimpleContentType(requestContentType);
 
-            LOGGER.info("POST to create resource with ID: {}, slug: {}", newFedoraId.getFullIdPath(), slug);
+            LOGGER.info("POST to create resource with ID: {}, slug: {}", newFedoraId.getFullIdPath(), decodedSlug);
 
             if (isBinary(interactionModel,
                     providedContentType,

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -71,6 +71,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
@@ -557,7 +559,7 @@ public abstract class AbstractResourceIT {
     private CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String... linkHeaders) {
         final HttpPost httpPost = postObjMethod("/");
         if (isNotEmpty(pid)) {
-            httpPost.addHeader("Slug", pid);
+            httpPost.addHeader("Slug", URLEncoder.encode(pid, StandardCharsets.UTF_8));
         }
 
         if (linkHeaders != null && linkHeaders.length > 0) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3668

# What does this Pull Request do?

* Changes the `Slug` header to be interpreted as a url-encoded string, allowing it to support unicode characters.

# How should this be tested?

The following does not work before this PR and works after.

```
echo "hello world" | curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/ -H'Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"' -H"Slug: %E2%98%9E%E2%98%95%E2%98%9C%E2%98%91" --data-binary @- -XPOST -v

curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/%E2%98%9E%E2%98%95%E2%98%9C%E2%98%91
```

# Interested parties

@fcrepo/committers
