### PR TITLE
Create automatic version when deleting a resource in a manual versioned repository

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersister.java
@@ -21,6 +21,8 @@ import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.common.ResourceHeaderUtils;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
+import org.fcrepo.storage.ocfl.CommitType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,9 @@ class DeleteResourcePersister extends AbstractPersister {
             ResourceHeaderUtils.touchModificationHeaders(headers, operation.getUserPrincipal());
 
             objectSession.deleteContentFile(new ResourceHeadersAdapter(headers).asStorageHeaders());
+            if (headers.getArchivalGroupId() == null) {
+                objectSession.commitType(CommitType.NEW_VERSION);
+            }
         } catch (final RuntimeException e) {
             throw new PersistentStorageException(
                     String.format("Failed to delete resource content for %s", resourceId), e);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/DeleteResourcePersisterIT.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/integration/persistence/ocfl/impl/DeleteResourcePersisterIT.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.integration.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.fcrepo.config.ServerManagedPropsMode;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.DeleteResourceOperationFactory;
+import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+import org.fcrepo.persistence.ocfl.impl.OcflPersistentSessionManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import edu.wisc.library.ocfl.api.model.ObjectVersionId;
+
+/**
+ * Test delete resource persister for stamping versions of deleted resources in manually versioned repository.
+ * @author whikloj
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/spring-test/manual-versioning-config.xml")
+public class DeleteResourcePersisterIT {
+
+    @Autowired
+    private OcflPersistentSessionManager sessionManager;
+
+    @Autowired
+    private RdfSourceOperationFactory rdfSourceOpFactory;
+
+    @Autowired
+    private DeleteResourceOperationFactory deleteResourceOpFactory;
+
+    @Autowired
+    private MutableOcflRepository ocflRepository;
+
+    private FedoraId rescId;
+
+    @Before
+    public void setup() {
+        rescId = FedoraId.create(UUID.randomUUID().toString());
+    }
+
+    @Test
+    public void testDeleteAgResource() {
+        final PersistentStorageSession storageSession1 = startWriteSession();
+        // Create an AG resource.
+        final var agOp = rdfSourceOpFactory
+                .createBuilder(rescId, BASIC_CONTAINER.getURI(), ServerManagedPropsMode.STRICT)
+                .archivalGroup(true)
+                .parentId(FedoraId.getRepositoryRootId())
+                .build();
+        storageSession1.persist(agOp);
+        storageSession1.prepare();
+        storageSession1.commit();
+
+        // Assert it exists
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert it has a mutable head.
+        assertTrue(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+
+        // In a new session delete it
+        final PersistentStorageSession storageSession2 = startWriteSession();
+        final var deleteOp = deleteResourceOpFactory
+                .deleteBuilder(rescId)
+                .build();
+        storageSession2.persist(deleteOp);
+        storageSession2.prepare();
+        storageSession2.commit();
+
+        // Assert it still exists.
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert it is committed.
+        assertFalse(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+    }
+
+    @Test
+    public void testDeleteResourceInAg() {
+        final String childResourceId = UUID.randomUUID().toString();
+        final FedoraId childId = rescId.resolve(childResourceId);
+        final PersistentStorageSession storageSession1 = startWriteSession();
+        // Create an AG resource.
+        final var agOp = rdfSourceOpFactory
+                .createBuilder(rescId, BASIC_CONTAINER.getURI(), ServerManagedPropsMode.STRICT)
+                .archivalGroup(true)
+                .parentId(FedoraId.getRepositoryRootId())
+                .build();
+        storageSession1.persist(agOp);
+        storageSession1.prepare();
+        storageSession1.commit();
+
+        // Assert it exists
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert it has a mutable head.
+        assertTrue(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+
+        final PersistentStorageSession storageSession2 = startWriteSession();
+
+        // Create a resource in the AG
+        final var agChild = rdfSourceOpFactory
+                .createBuilder(childId, BASIC_CONTAINER.getURI(), ServerManagedPropsMode.STRICT)
+                .parentId(rescId)
+                .build();
+        storageSession2.persist(agChild);
+        storageSession2.prepare();
+        storageSession2.commit();
+
+        // Assert the child exists
+        final var child = ocflRepository.getObject(ObjectVersionId.head(rescId.getResourceId()));
+        assertTrue(child.containsFile(childResourceId + "/fcr-container.nt"));
+        // Assert the resource still has a mutable head.
+        assertTrue(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+
+        // In a new session delete the child resource.
+        final PersistentStorageSession storageSession3 = startWriteSession();
+        final var deleteOp = deleteResourceOpFactory
+                .deleteBuilder(childId)
+                .build();
+        storageSession3.persist(deleteOp);
+        storageSession3.prepare();
+        storageSession3.commit();
+
+        // Assert the AG resource still exists.
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert the child file is now gone.
+        final var child2 = ocflRepository.getObject(ObjectVersionId.head(rescId.getResourceId()));
+        assertFalse(child2.containsFile(childResourceId + "/fcr-container.nt"));
+        // Assert the AG resource still has a mutable head.
+        assertTrue(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+    }
+
+    @Test
+    public void testDeleteAtomicResource() {
+        final PersistentStorageSession storageSession1 = startWriteSession();
+        // Create an atomic resource.
+        final var op = rdfSourceOpFactory
+                .createBuilder(rescId, BASIC_CONTAINER.getURI(), ServerManagedPropsMode.RELAXED)
+                .parentId(FedoraId.getRepositoryRootId())
+                .build();
+        storageSession1.persist(op);
+        storageSession1.prepare();
+        storageSession1.commit();
+
+        // Assert it exists.
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert it has a mutable head.
+        assertTrue(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+
+        // In a new session delete it
+        final PersistentStorageSession storageSession2 = startWriteSession();
+        final var deleteOp = deleteResourceOpFactory
+                .deleteBuilder(rescId)
+                .build();
+        storageSession2.persist(deleteOp);
+        storageSession2.prepare();
+        storageSession2.commit();
+
+        // Assert it still exist.
+        assertTrue(ocflRepository.containsObject(rescId.getResourceId()));
+        // Assert it is committed.
+        assertFalse(ocflRepository.hasStagedChanges(rescId.getResourceId()));
+    }
+
+    private PersistentStorageSession startWriteSession() {
+        return sessionManager.getSession(UUID.randomUUID().toString());
+    }
+}

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DeleteResourcePersisterTest.java
@@ -22,6 +22,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraOcflMappingNotFoundException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
+import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.OcflObjectSession;
 import org.fcrepo.storage.ocfl.ResourceHeaders;
 import org.fcrepo.storage.ocfl.exception.NotFoundException;
@@ -44,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,6 +97,7 @@ public class DeleteResourcePersisterTest {
                 parentId,
                 resourceId,
                 NON_RDF_SOURCE.toString());
+        headers.setArchivalGroupId(parentId);
         touchCreationHeaders(headers, null);
         touchModificationHeaders(headers, null);
 
@@ -109,6 +112,7 @@ public class DeleteResourcePersisterTest {
         persister.persist(psSession, operation);
 
         verify(session).deleteContentFile(headersCaptor.capture());
+        verify(session, never()).commitType(CommitType.NEW_VERSION);
 
         final var deleteHeaders = headersCaptor.getValue();
         assertEquals(resourceId.toString(), deleteHeaders.getId());
@@ -137,6 +141,7 @@ public class DeleteResourcePersisterTest {
         persister.persist(psSession, operation);
 
         verify(session).deleteContentFile(headersCaptor.capture());
+        verify(session).commitType(CommitType.NEW_VERSION);
 
         final var deleteHeaders = headersCaptor.getValue();
         assertEquals(resourceId.toString(), deleteHeaders.getId());

--- a/fcrepo-persistence-ocfl/src/test/resources/manual_versioning.properties
+++ b/fcrepo-persistence-ocfl/src/test/resources/manual_versioning.properties
@@ -1,0 +1,5 @@
+# Set the Fedora home location for tests
+fcrepo.home=target/fcrepo-home
+fcrepo.resource-header-cache.enable=false
+# Disable autoversioning
+fcrepo.autoversioning.enabled=false

--- a/fcrepo-persistence-ocfl/src/test/resources/spring-test/manual-versioning-config.xml
+++ b/fcrepo-persistence-ocfl/src/test/resources/spring-test/manual-versioning-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:task="http://www.springframework.org/schema/task"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
+    http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <context:annotation-config/>
+  <context:property-placeholder location="classpath:manual_versioning.properties"/>
+  <context:component-scan base-package="org.fcrepo.config"/>
+  <context:component-scan base-package="org.fcrepo.persistence.ocfl.impl"/>
+  <context:component-scan base-package="org.fcrepo.kernel.impl.operations" />
+  
+  <bean id="containmentIndex" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.ContainmentIndex" />
+  </bean>
+
+  <bean id="searchIndex" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.search.api.SearchIndex" />
+  </bean>
+
+  <bean id="referenceService" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.services.ReferenceService" />
+  </bean>
+  
+  <bean id="membershipService" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.services.MembershipService" />
+  </bean>
+  
+  <bean id="transactionManager" class="org.mockito.Mockito" factory-method="mock">
+    <constructor-arg value="org.fcrepo.kernel.api.TransactionManager" />
+  </bean>
+
+</beans>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3289

# What does this Pull Request do?
Forces a new version to be generated when you delete an atomic resource or an Archival Group (but not a part of an Archival Group)

# How should this be tested?

Start a manually versioned repository.
Create a resource.
Delete the resource.
Investigate the OCFL on disk to see that the only version in the OCFL object has the object as not deleted.
Pull in this PR and repeat.
See that now the object will have a second version persisting the changes to the header's sidecar file.

# Interested parties
@fcrepo/committers
