### PR TITLE
expose properties for customizing the s3 endpoint

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -115,6 +115,9 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${" + FCREPO_PERSISTENCE_ALGORITHM + ":sha512}")
     private String FCREPO_DIGEST_ALGORITHM_VALUE;
 
+    @Value("${fcrepo.ocfl.s3.db.enabled:true}")
+    private boolean ocflS3DbEnabled;
+
     private DigestAlgorithm FCREPO_DIGEST_ALGORITHM;
 
     /**
@@ -445,5 +448,12 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public boolean isPathStyleAccessEnabled() {
         return pathStyleAccessEnabled;
+    }
+
+    /**
+     * @return true if the ocfl client should be configured to use a database when storing objects in S3
+     */
+    public boolean isOcflS3DbEnabled() {
+        return ocflS3DbEnabled;
     }
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -82,6 +82,12 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.aws.region:}")
     private String awsRegion;
 
+    @Value("${fcrepo.s3.endpoint:}")
+    private String s3Endpoint;
+
+    @Value("${fcrepo.s3.path.style.access:false}")
+    private boolean pathStyleAccessEnabled;
+
     @Value("${" + FCREPO_OCFL_S3_BUCKET + ":}")
     private String ocflS3Bucket;
 
@@ -425,5 +431,19 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public DigestAlgorithm getDefaultDigestAlgorithm() {
         return FCREPO_DIGEST_ALGORITHM;
+    }
+
+    /**
+     * @return an optional custom s3 endpoint or null
+     */
+    public String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    /**
+     * @return true if path style S3 access should be used
+     */
+    public boolean isPathStyleAccessEnabled() {
+        return pathStyleAccessEnabled;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -21,6 +21,7 @@ import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.create
 import static org.fcrepo.persistence.ocfl.impl.OcflPersistentStorageUtils.createS3Repository;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
@@ -126,6 +127,14 @@ public class OcflPersistenceConfig {
 
         if (StringUtils.isNotBlank(ocflPropsConfig.getAwsRegion())) {
             builder.region(Region.of(ocflPropsConfig.getAwsRegion()));
+        }
+
+        if (StringUtils.isNotBlank(ocflPropsConfig.getS3Endpoint())) {
+            builder.endpointOverride(URI.create(ocflPropsConfig.getS3Endpoint()));
+        }
+
+        if (ocflPropsConfig.isPathStyleAccessEnabled()) {
+            builder.serviceConfiguration(config -> config.pathStyleAccessEnabled(true));
         }
 
         if (StringUtils.isNoneBlank(ocflPropsConfig.getAwsAccessKey(), ocflPropsConfig.getAwsSecretKey())) {

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -88,7 +88,8 @@ public class OcflPersistenceConfig {
                     ocflPropsConfig.getOcflS3Bucket(),
                     ocflPropsConfig.getOcflS3Prefix(),
                     ocflPropsConfig.getOcflTemp(),
-                    ocflPropsConfig.getDefaultDigestAlgorithm());
+                    ocflPropsConfig.getDefaultDigestAlgorithm(),
+                    ocflPropsConfig.isOcflS3DbEnabled());
         } else {
             return createFilesystemRepository(ocflPropsConfig.getOcflRepoRoot(), ocflPropsConfig.getOcflTemp(),
                     ocflPropsConfig.getDefaultDigestAlgorithm());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -113,6 +113,7 @@ public class OcflPersistentStorageUtils {
      * @param prefix the prefix within the bucket to store objects under
      * @param ocflWorkDir the local directory to stage objects in
      * @param algorithm the algorithm for the OCFL repository
+     * @param withDb true if the ocfl client should use a db
      * @return the repository
      */
     public static MutableOcflRepository createS3Repository(final DataSource dataSource,
@@ -120,7 +121,8 @@ public class OcflPersistentStorageUtils {
                                                            final String bucket,
                                                            final String prefix,
                                                            final Path ocflWorkDir,
-                                                           final org.fcrepo.config.DigestAlgorithm algorithm)
+                                                           final org.fcrepo.config.DigestAlgorithm algorithm,
+                                                           final boolean withDb)
             throws IOException {
         Files.createDirectories(ocflWorkDir);
 
@@ -134,8 +136,12 @@ public class OcflPersistentStorageUtils {
 
         return createRepository(ocflWorkDir, builder -> {
             builder.contentPathConstraints(ContentPathConstraints.cloud())
-                    .objectDetailsDb(db -> db.dataSource(dataSource))
                     .storage(storage);
+
+            if (withDb) {
+                builder.objectDetailsDb(db -> db.dataSource(dataSource));
+            }
+
         }, algorithm);
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageUtils.java
@@ -134,7 +134,6 @@ public class OcflPersistentStorageUtils {
 
         return createRepository(ocflWorkDir, builder -> {
             builder.contentPathConstraints(ContentPathConstraints.cloud())
-                    .objectLock(lock -> lock.dataSource(dataSource))
                     .objectDetailsDb(db -> db.dataSource(dataSource))
                     .storage(storage);
         }, algorithm);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/FCREPO-3690

# What does this Pull Request do?

Exposes two new properties for customizing the S3 endpoint:

1. `fcrepo.s3.endpoint`: URL of a non-aws s3 endpoint
2. `fcrepo.s3.path.style.access`: Set to `true` if your endpoint needs path style access

# How should this be tested?

Running Fedora against a non-aws endpoint should work if you start Fedora [configured to use s3](https://wiki.lyrasis.org/display/FEDORA6x/Amazon+S3), set `fcrepo.s3.endpoint` to the custom endpoint, and it should work.

# Interested parties

@fcrepo/committers
