### PR TITLE
add option to enable unsafe ocfl writing

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -118,6 +118,9 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.s3.db.enabled:true}")
     private boolean ocflS3DbEnabled;
 
+    @Value("${fcrepo.ocfl.unsafe.write.enabled:false}")
+    private boolean unsafeWriteEnabled;
+
     private DigestAlgorithm FCREPO_DIGEST_ALGORITHM;
 
     /**
@@ -455,5 +458,15 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public boolean isOcflS3DbEnabled() {
         return ocflS3DbEnabled;
+    }
+
+    /**
+     * When unsafe writes are enabled, the OCFL client does not calculate a digest for files that are added, and
+     * trusts the digest value that it's given. If this value is incorrect, the object will be corrupted.
+     *
+     * @return true if objects should be written to OCFL using an "unsafe" write
+     */
+    public boolean isUnsafeWriteEnabled() {
+        return unsafeWriteEnabled;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -100,7 +100,7 @@ public class OcflPersistenceConfig {
     public OcflObjectSessionFactory ocflObjectSessionFactory() throws IOException {
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
 
-        return new DefaultOcflObjectSessionFactory(repository(),
+        final var factory = new DefaultOcflObjectSessionFactory(repository(),
                 ocflPropsConfig.getFedoraOcflStaging(),
                 objectMapper,
                 resourceHeadersCache(),
@@ -108,6 +108,8 @@ public class OcflPersistenceConfig {
                 "Authored by Fedora 6",
                 "fedoraAdmin",
                 "info:fedora/fedoraAdmin");
+        factory.useUnsafeWrite(ocflPropsConfig.isUnsafeWriteEnabled());
+        return factory;
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.6.4</micrometer.version>
     <netty.version>4.1.59.Final</netty.version>
-    <ocfl-java.version>1.0.3</ocfl-java.version>
+    <ocfl-java.version>1.1.0</ocfl-java.version>
     <prometheus.version>0.9.0</prometheus.version>
     <reactivestrams.version>1.0.2</reactivestrams.version>
     <shiro.version>1.7.1</shiro.version>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3711

**This PR will not build until https://github.com/fcrepo/fcrepo-storage-ocfl/pull/38 is merged**

# What does this Pull Request do?

Adds an option for enabling unsafe OCFL writes. When this option is enabled, the OCFL client will not calculate a digest for files that are added to objects. This should be faster, but is less safe as the object will be corrupted if the digest is incorrect.

Set `fcrepo.ocfl.unsafe.write.enabled=true` to enable unsafe writes.

# How should this be tested?

Fedora should behave the same with or without this feature. It should be impossible to make Fedora create a bad object, including by intentionally giving it an incorrect digest like:

```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=type" -v -H "Content-Type: text/plain" -H"digest: sha-512=cb1a576f22e8e3e110611b616e3e2f5ce9bdb941" -X PUT --data-binary "testing"
```

# Interested parties
@fcrepo/committers
