### PR TITLE
Add cache to FedoraToOcflIndex getMapping

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -121,10 +121,10 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.unsafe.write.enabled:false}")
     private boolean unsafeWriteEnabled;
 
-    @Value("${fcrepo.ocfl.id_map_cache.size:1024}")
+    @Value("${fcrepo.cache.db.ocfl.id_map.size.entries:1024}")
     private long fedoraToOcflCacheSize;
 
-    @Value("${fcrepo.ocfl.id_map_cache.timeout:30}")
+    @Value("${fcrepo.cache.db.ocfl.id_map.timeout.minutes:30}")
     private long fedoraToOcflCacheTimeout;
 
     private DigestAlgorithm FCREPO_DIGEST_ALGORITHM;

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -121,6 +121,12 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.unsafe.write.enabled:false}")
     private boolean unsafeWriteEnabled;
 
+    @Value("${fcrepo.ocfl.id_map_cache.size:1024}")
+    private long fedoraToOcflCacheSize;
+
+    @Value("${fcrepo.ocfl.id_map_cache.timeout:30}")
+    private long fedoraToOcflCacheTimeout;
+
     private DigestAlgorithm FCREPO_DIGEST_ALGORITHM;
 
     /**
@@ -468,5 +474,19 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public boolean isUnsafeWriteEnabled() {
         return unsafeWriteEnabled;
+    }
+
+    /**
+     * @return Size of the fedoraToOcflIndex cache.
+     */
+    public long getFedoraToOcflCacheSize() {
+        return fedoraToOcflCacheSize;
+    }
+
+    /**
+     * @return Time to cache expiration in minutes.
+     */
+    public long getFedoraToOcflCacheTimeout() {
+        return fedoraToOcflCacheTimeout;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -266,6 +266,7 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
             final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
             parameterSource.addValue("fedoraId", fedoraId.getResourceId());
             jdbcTemplate.update(DIRECT_DELETE_MAPPING, parameterSource);
+            this.mappingCache.invalidate(fedoraId.getResourceId());
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -43,12 +43,12 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  */
 public class DbFedoraToOcflObjectIndexTest {
 
-    private static final FedoraId RESOURCE_ID_1 = FedoraId.create("info:fedora/parent/child1");
-    private static final FedoraId RESOURCE_ID_2 = FedoraId.create("info:fedora/parent/child2");
-    private static final FedoraId RESOURCE_ID_3 = FedoraId.create("info:fedora/resource3");
-    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
-    private static final String OCFL_ID = "ocfl-id";
-    private static final String OCFL_ID_RESOURCE_3 = "ocfl-id-resource-3";
+    private FedoraId RESOURCE_ID_1;
+    private FedoraId RESOURCE_ID_2;
+    private FedoraId RESOURCE_ID_3;
+    private FedoraId ROOT_RESOURCE_ID;
+    private String OCFL_ID;
+    private String OCFL_ID_RESOURCE_3;
 
     private static DriverManagerDataSource dataSource;
     private static DbFedoraToOcflObjectIndex index;
@@ -75,6 +75,16 @@ public class DbFedoraToOcflObjectIndexTest {
         when(session.isCommitted()).thenReturn(false);
         when(session.isOpenLongRunning()).thenReturn(true);
         readOnlyTx = ReadOnlyTransaction.INSTANCE;
+        ROOT_RESOURCE_ID = FedoraId.create(getRandomUUID());
+        RESOURCE_ID_1 = ROOT_RESOURCE_ID.resolve(getRandomUUID());
+        RESOURCE_ID_2 = ROOT_RESOURCE_ID.resolve(getRandomUUID());
+        RESOURCE_ID_3 = FedoraId.create(getRandomUUID());
+        OCFL_ID = "ocfl-id-" + getRandomUUID();
+        OCFL_ID_RESOURCE_3 = "ocfl-id-resource-3-" + getRandomUUID();
+    }
+
+    private static String getRandomUUID() {
+        return UUID.randomUUID().toString();
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndexTest.java
@@ -20,11 +20,14 @@ package org.fcrepo.persistence.ocfl.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.UUID;
 
 import org.fcrepo.config.FlywayFactory;
+import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.ReadOnlyTransaction;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
@@ -56,13 +59,19 @@ public class DbFedoraToOcflObjectIndexTest {
     private Transaction session;
     private Transaction readOnlyTx;
 
+    private static OcflPropsConfig propsConfig;
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         dataSource = new DriverManagerDataSource();
         dataSource.setDriverClassName("org.h2.jdbcx.JdbcDataSource");
         dataSource.setUrl("jdbc:h2:mem:index;DB_CLOSE_DELAY=-1");
         FlywayFactory.create().setDataSource(dataSource).setDatabaseType("h2").getObject();
+        propsConfig = mock(OcflPropsConfig.class);
+        when(propsConfig.getFedoraToOcflCacheSize()).thenReturn(2L);
+        when(propsConfig.getFedoraToOcflCacheTimeout()).thenReturn(1L);
         index = new DbFedoraToOcflObjectIndex(dataSource);
+        setField(index, "ocflPropsConfig", propsConfig);
         index.setup();
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3712

Relies on: https://github.com/fcrepo/fcrepo-storage-ocfl/pull/39

# What does this Pull Request do?
Add a caffeine cache to the `DbFedoraToOcflIndex` for the `getMapping` calls.

# How should this be tested?

There should  be no functional difference, though I hope it is faster.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
