### PR TITLE
improve message when resource not found

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -223,7 +223,8 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         try {
             return fedoraOcflIndex.getMapping(transaction, identifier);
         } catch (final FedoraOcflMappingNotFoundException e) {
-            throw new PersistentItemNotFoundException(String.format("Resource %s not found", identifier), e);
+            throw new PersistentItemNotFoundException(String.format("Resource %s not found",
+                    identifier.getFullIdPath()), e);
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -223,7 +223,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         try {
             return fedoraOcflIndex.getMapping(transaction, identifier);
         } catch (final FedoraOcflMappingNotFoundException e) {
-            throw new PersistentItemNotFoundException(e.getMessage());
+            throw new PersistentItemNotFoundException(String.format("Resource %s not found", identifier), e);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3652

# What does this Pull Request do?

Changes the error message that's returned when a resource isn't found to be more user friendly

# How should this be tested?

Attempt to get a resource that does not exist and see a message like:

> Error: Resource /test2 not found

# Interested parties
@fcrepo/committers
