### PR TITLE
change snapshot repo to https to work with mvn 3.8

### DIFF
--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -705,7 +705,7 @@
   <repositories>
     <repository>
       <id>oss.sonatype.org-snapshot</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
**JIRA Ticket**: na

# What does this Pull Request do?

Changes the snapshot repo to https in an attempt to fix the build. Maven 3.8 only supports https

# How should this be tested?

The GH Actions build should work.

# Interested parties

@fcrepo/committers
