### PR TITLE
Don't allow POSTing to non-existant resource

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -619,6 +619,11 @@ public class FedoraLdp extends ContentExposingResource {
             final String interactionModel = checkInteractionModel(links);
 
             final FedoraId fedoraId = identifierConverter().pathToInternalId(externalPath());
+            // If the resource doesn't exist and it's not a ghost node, throw an exception.
+            // Ghost node checking is done further down in the code and returns a 400 Bad Request error.
+            if (!doesResourceExist(transaction, fedoraId, false) && !isGhostNode(transaction, fedoraId)) {
+                throw new PathNotFoundRuntimeException(String.format("Path %s not found", fedoraId.getFullIdPath()));
+            }
             final FedoraId newFedoraId = mintNewPid(fedoraId, decodedSlug);
             final var providedContentType = getSimpleContentType(requestContentType);
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -259,6 +259,8 @@ public class FedoraLdpTest {
     public void setUp() {
         testObj = spy(new FedoraLdp(path));
 
+        when(resourceHelper.doesResourceExist(any(Transaction.class), eq(pathId), eq(false))).thenReturn(true);
+
         mockResponse = new MockHttpServletResponse();
 
         final HttpRdfService httpRdfService = new HttpRdfService();

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -366,7 +366,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testCreateBinaryAsArchivalGroupWithPostFails() throws Exception {
         final var id = getRandomUniqueId();
-        final var postMethod = postObjMethod(id);
+        final var postMethod = postObjMethod();
+        postMethod.setHeader("Slug", id);
         postMethod.setEntity(new StringEntity("test"));
         postMethod.addHeader("Link", ARCHIVAL_GROUP_LINK_HEADER);
         postMethod.addHeader("Link", NON_RDF_SOURCE_LINK_HEADER);
@@ -4586,6 +4587,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testLongIdentifier1() throws IOException {
         final String url = genLongUrl(serverAddress,476);
+        final HttpPut putMethod = new HttpPut(url);
+        assertEquals(CREATED.getStatusCode(), getStatus(putMethod));
         final HttpPost postMethod = new HttpPost(url);
         postMethod.setHeader("Slug", getRandomUniqueId());
         try (final CloseableHttpResponse response = execute(postMethod)) {
@@ -4596,6 +4599,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testLongIdentifier2() throws IOException {
         final String url = genLongUrl(serverAddress,477);
+        final HttpPut putMethod = new HttpPut(url);
+        assertEquals(CREATED.getStatusCode(), getStatus(putMethod));
         final HttpPost postMethod = new HttpPost(url);
         postMethod.setHeader("Slug", getRandomUniqueId());
         try (final CloseableHttpResponse response = execute(postMethod)) {
@@ -4713,6 +4718,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(new HttpGet(location))) {
             assertEquals(SC_OK, response.getStatusLine().getStatusCode());
         }
+    }
+
+    @Test
+    public void postToNonexistantResourceFails() throws IOException {
+        final var id = getRandomUniqueId();
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(getObjMethod(id)));
+        assertEquals(NOT_FOUND.getStatusCode(), getStatus(postObjMethod(id)));
     }
 
     private void assertIdStringConstraint(final String id) throws IOException {

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/PathNotFoundRuntimeException.java
@@ -33,4 +33,12 @@ public class PathNotFoundRuntimeException extends RepositoryRuntimeException {
     public PathNotFoundRuntimeException(final String message, final Throwable rootCause) {
         super(message, rootCause);
     }
+
+    /**
+     * Create a PathNotFoundException directly.
+     * @param message the original message.
+     */
+    public PathNotFoundRuntimeException(final String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3714

# What does this Pull Request do?

Currently if you try to POST to a URI that does not exist, Fedora appends the Slug to the provided URI and creates it as huge long URI.

See the attached ticket for differences from Fedora 5 behaviour.

# How should this be tested?

Before the PR
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/bob      
HTTP/1.1 404 Not Found
Date: Thu, 06 May 2021 16:36:07 GMT
Set-Cookie: JSESSIONID=node02dgglis27umjisgjghf2yj951.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 05-May-2021 16:36:07 GMT; SameSite=lax
Content-Type: text/turtle;charset=utf-8
Content-Length: 53
Server: Jetty(9.4.34.v20201102)

Error: Resource /test/bob not found%                                                                                                                  

> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/bob -XPOST
HTTP/1.1 201 Created
Date: Thu, 06 May 2021 16:36:13 GMT
Set-Cookie: JSESSIONID=node01riuxicl0u3ou1crany59zdy0o2.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 05-May-2021 16:36:13 GMT; SameSite=lax
ETag: W/"3337687282E5435097D71BF3A0C6CBAA"
X-State-Token: 9B455CBCF8F70EEC4F8F91DF63382597
Last-Modified: Thu, 06 May 2021 16:36:13 GMT
Link: <http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb>; rel="timegate"
Link: <http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb>; rel="original"
Link: <http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb/fcr:versions>; rel="timemap"
Link: <http://www.w3.org/ns/ldp#BasicContainer>; rel="type"
Link: <http://www.w3.org/ns/ldp#Resource>; rel="type"
Link: <http://fedora.info/definitions/v4/repository#Resource>; rel="type"
Link: <http://mementoweb.org/ns#OriginalResource>; rel="type"
Link: <http://mementoweb.org/ns#TimeGate>; rel="type"
Link: <http://www.w3.org/ns/ldp#RDFSource>; rel="type"
Link: <http://www.w3.org/ns/ldp#Container>; rel="type"
Link: <http://fedora.info/definitions/v4/repository#Container>; rel="type"
Link: <http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb/fcr:acl>; rel="acl"
Location: http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb
Content-Type: text/plain
Content-Length: 72
Server: Jetty(9.4.34.v20201102)

http://localhost:8080/rest/test/bob/8af39b5c-26dd-4053-91f1-5f59f2aa56bb%
```

After the PR
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/bob      
HTTP/1.1 404 Not Found
Date: Thu, 06 May 2021 18:44:03 GMT
Set-Cookie: JSESSIONID=node01b7unya5k5wm9l1chis6uqfo60.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 05-May-2021 18:44:03 GMT; SameSite=lax
Content-Type: text/turtle;charset=utf-8
Content-Length: 35
Server: Jetty(9.4.34.v20201102)

Error: Resource /test/bob not found%

> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test/bob -XPOST
HTTP/1.1 404 Not Found
Date: Thu, 06 May 2021 18:44:28 GMT
Set-Cookie: JSESSIONID=node017dnai3oysp251qwr1vn5sul4g1.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 05-May-2021 18:44:28 GMT; SameSite=lax
Content-Type: text/turtle;charset=utf-8
Content-Length: 31
Server: Jetty(9.4.34.v20201102)

Error: Path /test/bob not found%
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
