### PR TITLE
Cache WebAC effectiveAcl locations and authorizations

### DIFF
--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.security.Principal;
 import java.util.Set;
@@ -31,9 +30,11 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Tests for {@link ContainerRolesPrincipalProvider}.
@@ -52,7 +53,7 @@ public class ContainerRolesPrincipalProviderTest {
      */
     @Before
     public void setUp() {
-        initMocks(this);
+        MockitoAnnotations.openMocks(this);
         provider = new ContainerRolesPrincipalProvider();
     }
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
@@ -22,17 +22,18 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
-
-import org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
-import javax.servlet.http.HttpServletRequest;
 
 import java.security.Principal;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 /**
  * @author daines
@@ -48,7 +49,7 @@ public class HttpHeaderPrincipalProviderTest {
 
     @Before
     public void setUp() {
-        initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         provider = new HttpHeaderPrincipalProvider();
     }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.auth.integration;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Strings;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -28,13 +30,19 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.Integer.parseInt;
+
+import org.fcrepo.kernel.api.auth.ACLHandle;
 
 /**
  * <p>Abstract AbstractResourceIT class.</p>
@@ -50,6 +58,15 @@ public abstract class AbstractResourceIT {
     @Before
     public void setLogger() {
         logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public Cache<String, Optional<ACLHandle>> authHandleCache() {
+            return Caffeine.newBuilder().weakValues().expireAfterAccess(10, TimeUnit.SECONDS)
+                    .maximumSize(10).build();
+        }
     }
 
     private static final int SERVER_PORT = parseInt(Objects.requireNonNullElse(

--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>javax.annotation-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- test gear -->
     <dependency>
       <groupId>org.fcrepo</groupId>

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/ACLHandleImpl.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/ACLHandleImpl.java
@@ -19,6 +19,8 @@ package org.fcrepo.auth.webac;
 
 import java.util.List;
 
+import org.fcrepo.kernel.api.auth.ACLHandle;
+import org.fcrepo.kernel.api.auth.WebACAuthorization;
 import org.fcrepo.kernel.api.models.FedoraResource;
 
 /**
@@ -26,20 +28,29 @@ import org.fcrepo.kernel.api.models.FedoraResource;
  *
  * @author ajs6f
  */
-public class ACLHandle {
+public class ACLHandleImpl implements ACLHandle {
 
-    public final FedoraResource resource;
+    private final FedoraResource resource;
 
-    public final List<WebACAuthorization> authorizations;
+    private final List<WebACAuthorization> authorizations;
     /**
      * Default constructor.
      *
      * @param resource the requested FedoraResource
      * @param authorizations any authorizations associated with the uri
      */
-    public ACLHandle(final FedoraResource resource, final List<WebACAuthorization> authorizations) {
+    public ACLHandleImpl(final FedoraResource resource, final List<WebACAuthorization> authorizations) {
         this.resource = resource;
         this.authorizations = authorizations;
     }
 
+    @Override
+    public FedoraResource getResource() {
+        return resource;
+    }
+
+    @Override
+    public List<WebACAuthorization> getAuthorizations() {
+        return authorizations;
+    }
 }

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationImpl.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACAuthorizationImpl.java
@@ -22,12 +22,14 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.fcrepo.kernel.api.auth.WebACAuthorization;
+
 /**
  * @author whikloj
  * @author acoburn
  * @since 2015-08-25
  */
-public class WebACAuthorization {
+public class WebACAuthorizationImpl implements WebACAuthorization {
 
     private final Set<String> agents = new HashSet<>();
 
@@ -54,9 +56,10 @@ public class WebACAuthorization {
      * @param agentGroups the acl:agentGroup values
      * @param defaults the acl:default values
      */
-    public WebACAuthorization(final Collection<String> agents, final Collection<String> agentClasses,
-            final Collection<URI> modes, final Collection<String> accessTo, final Collection<String> accessToClass,
-            final Collection<String> agentGroups, final Collection<String> defaults) {
+    public WebACAuthorizationImpl(final Collection<String> agents, final Collection<String> agentClasses,
+                                  final Collection<URI> modes, final Collection<String> accessTo,
+                                  final Collection<String> accessToClass, final Collection<String> agentGroups,
+                                  final Collection<String> defaults) {
         this.agents.addAll(agents);
         this.agentClasses.addAll(agentClasses);
         this.modes.addAll(modes);

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACAuthorizationTest.java
@@ -60,7 +60,7 @@ public class WebACAuthorizationTest {
         final List<String> accessGroups = Arrays.asList(ACCESS_GROUP1, ACCESS_GROUP2);
         final List<String> defaults = Collections.singletonList(DEFAULT_1);
 
-        final WebACAuthorization auth = new WebACAuthorization(agents, agentClasses,
+        final WebACAuthorizationImpl auth = new WebACAuthorizationImpl(agents, agentClasses,
                 modes, accessTo, accessToClass, accessGroups, defaults);
 
         assertEquals(2, auth.getAgents().size());
@@ -90,7 +90,7 @@ public class WebACAuthorizationTest {
         final Set<String> accessGroups = new HashSet<>(Arrays.asList(ACCESS_GROUP1, ACCESS_GROUP2));
         final Set<String> defaults = new HashSet<>(Collections.singletonList(DEFAULT_1));
 
-        final WebACAuthorization auth = new WebACAuthorization(agents, agentClasses,
+        final WebACAuthorizationImpl auth = new WebACAuthorizationImpl(agents, agentClasses,
                 modes, accessTo, accessToClass, accessGroups, defaults);
 
         assertEquals(2, auth.getAgents().size());

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -29,6 +29,7 @@ import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 
 import org.fcrepo.config.AuthPropsConfig;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceFactory;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
@@ -62,6 +64,9 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * @author acoburn
@@ -96,12 +101,16 @@ public class WebACRolesProviderTest {
 
     private AuthPropsConfig propsConfig;
 
+    private Cache<String, Optional<ACLHandle>> authHandleCache;
+
     @Before
     public void setUp() throws RepositoryException {
+        authHandleCache = Caffeine.newBuilder().build();
         propsConfig = new AuthPropsConfig();
         roleProvider = new WebACRolesProvider();
         setField(roleProvider, "resourceFactory", mockResourceFactory);
         setField(roleProvider, "authPropsConfig", propsConfig);
+        setField(roleProvider, "authHandleCache", authHandleCache);
 
         when(mockResource.getDescribedResource()).thenReturn(mockResource);
         when(mockResource.getDescription()).thenReturn(mockResource);

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -131,6 +131,12 @@ public class FedoraPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.cache.db.containment.timeout.minutes:10}")
     private long containmentCacheTimeout;
 
+    @Value("${fcrepo.cache.webac.acl.size.entries:1024}")
+    private long webacCacheSize;
+
+    @Value("${fcrepo.cache.webac.acl.timeout.minutes:10}")
+    private long webacCacheTimeout;
+
     @PostConstruct
     private void postConstruct() throws IOException {
         LOGGER.info("Fedora home: {}", fedoraHome);
@@ -335,5 +341,19 @@ public class FedoraPropsConfig extends BasePropsConfig {
      */
     public long getContainmentCacheTimeout() {
         return containmentCacheTimeout;
+    }
+
+    /**
+     * @return The number of entries in the WebAC effective ACL cache.
+     */
+    public long getWebacCacheSize() {
+        return webacCacheSize;
+    }
+
+    /**
+     * @return The number of minutes before items in the WebAC ACL cache expire.
+     */
+    public long getWebacCacheTimeout() {
+        return webacCacheTimeout;
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -17,6 +17,8 @@
  */
 package org.fcrepo.integration.http.api;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.base.Strings;
 
 import org.apache.http.Header;
@@ -54,9 +56,13 @@ import org.fcrepo.config.AuthPropsConfig;
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.fcrepo.http.commons.test.util.ContainerWrapper;
+import org.fcrepo.kernel.api.auth.ACLHandle;
+
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -79,6 +85,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -843,5 +850,17 @@ public abstract class AbstractResourceIT {
         Arrays.stream(aTriples).map(String::trim).sorted().toArray(unused -> aTriples);
         Arrays.stream(bTriples).map(String::trim).sorted().toArray(unused -> bTriples);
         assertArrayEquals(aTriples, bTriples);
+    }
+
+    /**
+     * Instantiation of the authentication handle cache for integration tests.
+     */
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public Cache<String, Optional<ACLHandle>> authHandleCache() {
+            return Caffeine.newBuilder().weakValues().expireAfterAccess(10, TimeUnit.SECONDS)
+                    .maximumSize(10).build();
+        }
     }
 }

--- a/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
+++ b/fcrepo-jms/src/test/java/org/fcrepo/integration/jms/observer/AbstractJmsIT.java
@@ -37,6 +37,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,7 @@ import org.fcrepo.event.serialization.JsonLDEventMessage;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -80,9 +82,13 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 /**
  * <p>
@@ -396,4 +402,15 @@ abstract class AbstractJmsIT implements MessageListener {
         }
     }
 
+    /**
+     * Instantiation of the authentication handle cache for integration tests.
+     */
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public Cache<String, Optional<ACLHandle>> authHandleCache() {
+            return Caffeine.newBuilder().weakValues().expireAfterAccess(10, TimeUnit.SECONDS)
+                    .maximumSize(10).build();
+        }
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/auth/ACLHandle.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/auth/ACLHandle.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.auth;
+
+import java.util.List;
+
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+/**
+ * Class to hold the authorizations from an ACL and the resource that has the ACL.
+ *
+ * @author whikloj
+ */
+public interface ACLHandle {
+
+    /**
+     * Get the resource that contains the ACL.
+     *
+     * @return the fedora resource
+     */
+    FedoraResource getResource();
+
+    /**
+     * Get the list of authorizations from the ACL.
+     *
+     * @return the authorizations
+     */
+    List<WebACAuthorization> getAuthorizations();
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/auth/WebACAuthorization.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/auth/WebACAuthorization.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.auth;
+
+import java.net.URI;
+import java.util.Set;
+
+/**
+ * @author whikloj
+ * @author acoburn
+ * @since 2015-08-25
+ */
+public interface WebACAuthorization {
+
+    /**
+     * Get the set of acl:agents, empty set if none.
+     *
+     * @return set of acl:agents
+     */
+    Set<String> getAgents();
+
+    /**
+     * Get the set of acl:agentClasses, empty set if none.
+     * 
+     * @return set of acl:agentClasses
+     */
+    Set<String> getAgentClasses();
+
+    /**
+     * Get the set of acl:modes, empty set if none.
+     *
+     * @return set of acl:modes
+     */
+    Set<URI> getModes();
+
+    /**
+     * Get the set of strings directly linked from this ACL, empty set if none.
+     *
+     * @return set of String
+     */
+    Set<String> getAccessToURIs();
+
+    /**
+     * Get the set of strings describing the rdf:types for this ACL, empty set if none.
+     *
+     * @return set of Strings
+     */
+    Set<String> getAccessToClassURIs();
+
+    /**
+     * Get the set of strings describing the agent groups for this ACL, empty set if none.
+     *
+     * @return set of Strings
+     */
+    Set<String> getAgentGroups();
+
+    /**
+     * Get the set of strings describing the defaults for this ACL, empty set if none.
+     *
+     * @return set of Strings
+     */
+    Set<String> getDefaults();
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -131,6 +131,9 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
                 // Flush ACL cache on any ACL creation/update/deletion.
                 authHandleCache.invalidateAll();
             }
+        } else {
+            // Flush ACL cache on any ACL creation/update/deletion.
+            authHandleCache.invalidateAll();
         }
 
         //delete/purge the resource itself

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractDeleteResourceService.java
@@ -19,11 +19,13 @@ package org.fcrepo.kernel.impl.services;
 
 import static java.lang.String.format;
 
-import javax.inject.Inject;
-
+import java.util.Optional;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
+
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -37,8 +39,11 @@ import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 /**
  * Shared delete/purge code.
@@ -53,6 +58,9 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
 
     @Inject
     protected PersistentStorageSessionManager psManager;
+
+    @Inject
+    private Cache<String, Optional<ACLHandle>> authHandleCache;
 
     /**
      * The starts the service, does initial checks and setups for processing.
@@ -120,6 +128,8 @@ abstract public class AbstractDeleteResourceService extends AbstractService {
             final FedoraResource acl = fedoraResource.getAcl();
             if (acl != null) {
                 doAction(tx, pSession, acl.getFedoraId(), userPrincipal);
+                // Flush ACL cache on any ACL creation/update/deletion.
+                authHandleCache.invalidateAll();
             }
         }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/DeleteResourceServiceImplTest.java
@@ -25,12 +25,14 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.inject.Inject;
 
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Binary;
@@ -48,6 +50,7 @@ import org.fcrepo.kernel.impl.operations.DeleteResourceOperationFactoryImpl;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.search.api.SearchIndex;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +62,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 /**
  * DeleteResourceServiceTest
@@ -120,6 +125,9 @@ public class DeleteResourceServiceImplTest {
     private ResourceHeaders descHeaders;
     @Mock
     private ResourceHeaders aclHeaders;
+
+    @Mock
+    private Cache<String, Optional<ACLHandle>> authHandleCache;
 
     @Captor
     private ArgumentCaptor<DeleteResourceOperation> operationCaptor;

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/PurgeResourceServiceImplTest.java
@@ -26,11 +26,13 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Binary;
@@ -56,6 +58,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.github.benmanes.caffeine.cache.Cache;
 
 /**
  * PurgeResourceServiceTest
@@ -111,6 +115,8 @@ public class PurgeResourceServiceImplTest {
     private ResourceHeaders descHeaders;
     @Mock
     private ResourceHeaders aclHeaders;
+    @Mock
+    private Cache<String, Optional<ACLHandle>> authHandleCache;
 
     @Captor
     private ArgumentCaptor<PurgeResourceOperation> operationCaptor;

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -23,6 +23,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import javax.inject.Inject;
+
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.api.ExternalContentHandlerFactory;
 import org.fcrepo.http.api.ExternalContentPathValidator;
@@ -53,6 +55,9 @@ import com.google.common.eventbus.EventBus;
 public class WebappConfig {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebappConfig.class);
+
+    @Inject
+    private FedoraPropsConfig fedoraPropsConfig;
 
     /**
      * Task scheduler used for cleaning up transactions
@@ -133,9 +138,15 @@ public class WebappConfig {
         return factory;
     }
 
+    /**
+     * Used to cache the effective ACL location and authorizations for a given resource.
+     *
+     * @return the cache
+     */
     @Bean
     public Cache<String, Optional<ACLHandle>> authHandleCache() {
-        return Caffeine.newBuilder().weakValues().expireAfterAccess(10, TimeUnit.SECONDS)
-                .maximumSize(100).build();
+        return Caffeine.newBuilder().weakValues()
+                .expireAfterAccess(fedoraPropsConfig.getWebacCacheTimeout(), TimeUnit.MINUTES)
+                .maximumSize(fedoraPropsConfig.getWebacCacheSize()).build();
     }
 }

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -18,12 +18,15 @@
 
 package org.fcrepo.webapp;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.api.ExternalContentHandlerFactory;
 import org.fcrepo.http.api.ExternalContentPathValidator;
+import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -35,6 +38,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
 
@@ -128,4 +133,9 @@ public class WebappConfig {
         return factory;
     }
 
+    @Bean
+    public Cache<String, Optional<ACLHandle>> authHandleCache() {
+        return Caffeine.newBuilder().weakValues().expireAfterAccess(10, TimeUnit.SECONDS)
+                .maximumSize(100).build();
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3322

# What does this Pull Request do?
It adds a cache to the WebAC layer which stores the resource that contains the ACL for the given target resource and list of all the authorizations in that ACL.

These authorizations are still processed against the target resource to filter for applicable authorizations (if any).

# How should this be tested?

This PR should have no functional difference and the performance implications are un-clear.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
