### PR TITLE
make binaries non-retryable

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -686,6 +686,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                                                        final HttpServletResponse servletResponse,
                                                        final FedoraResource resource,
                                                        final Transaction transaction) {
+        // The resource must be locked prior to applying pre-conditions for the optimistic locking to be effective
+        transaction.lockResource(resource.getFedoraId());
         evaluateRequestPreconditions(request, servletResponse, resource, transaction, false);
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraBaseResource.java
@@ -142,4 +142,19 @@ abstract public class FedoraBaseResource extends AbstractResource {
         }
     }
 
+    /**
+     * Executes the runnable within a DB transaction. The block is NOT retried on MySQL deadlock exceptions.
+     * If the runnable throws an exception, then the Fedora transaction is marked as failed.
+     *
+     * @param action the code to execute
+     */
+    protected void doInDbTx(final Runnable action) {
+        try {
+            dbTransactionExecutor.doInTx(action);
+        } catch (RuntimeException e) {
+            transaction().fail();
+            throw e;
+        }
+    }
+
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -344,11 +344,11 @@ public class FedoraLdp extends ContentExposingResource {
                 METHOD_NOT_ALLOWED);
         }
 
-        evaluateRequestPreconditions(request, servletResponse, resource(), transaction());
-
         LOGGER.info("Delete resource '{}'", externalPath);
 
         try {
+            evaluateRequestPreconditions(request, servletResponse, resource(), transaction());
+
             doInDbTxWithRetry(() -> {
                 deleteResourceService.perform(transaction(), resource(), getUserPrincipal());
                 transaction().commitIfShortLived();

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -441,7 +441,6 @@ public class FedoraLdp extends ContentExposingResource {
 
             final var created = new AtomicBoolean(false);
 
-            doInDbTxWithRetry(() -> {
                 if ((resourceExists && resource() instanceof Binary) ||
                         (!resourceExists && isBinary(interactionModel,
                                 providedContentType,
@@ -457,49 +456,52 @@ public class FedoraLdp extends ContentExposingResource {
                     final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
                     final long contentSize = contentDisposition == null ? -1L : contentDisposition.getSize();
 
-                    if (resourceExists) {
-                        replaceBinariesService.perform(transaction,
-                                getUserPrincipal(),
-                                fedoraId,
-                                originalFileName,
-                                contentType,
-                                checksums,
-                                requestBodyStream,
-                                contentSize,
-                                extContent);
-                    } else {
-                        createResourceService.perform(transaction,
-                                getUserPrincipal(),
-                                fedoraId,
-                                contentType,
-                                originalFileName,
-                                contentSize,
-                                links,
-                                checksums,
-                                requestBodyStream,
-                                extContent);
-                        created.set(true);
-                    }
+                    doInDbTx(() -> {
+                        if (resourceExists) {
+                            replaceBinariesService.perform(transaction,
+                                    getUserPrincipal(),
+                                    fedoraId,
+                                    originalFileName,
+                                    contentType,
+                                    checksums,
+                                    requestBodyStream,
+                                    contentSize,
+                                    extContent);
+                        } else {
+                            createResourceService.perform(transaction,
+                                    getUserPrincipal(),
+                                    fedoraId,
+                                    contentType,
+                                    originalFileName,
+                                    contentSize,
+                                    links,
+                                    checksums,
+                                    requestBodyStream,
+                                    extContent);
+                            created.set(true);
+                        }
+                        transaction.commitIfShortLived();
+                    });
                 } else {
                     final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;
                     final Model model = httpRdfService.bodyToInternalModel(fedoraId, requestBodyStream,
                             contentType, identifierConverter(), hasLenientPreferHeader());
 
-                    if (resourceExists) {
-                        replacePropertiesService.perform(transaction,
-                                getUserPrincipal(),
-                                fedoraId,
-                                model);
-                    } else {
-                        createResourceService.perform(transaction, getUserPrincipal(), fedoraId, links, model);
-                        created.set(true);
-                    }
+                    doInDbTxWithRetry(() -> {
+                        if (resourceExists) {
+                            replacePropertiesService.perform(transaction,
+                                    getUserPrincipal(),
+                                    fedoraId,
+                                    model);
+                        } else {
+                            createResourceService.perform(transaction, getUserPrincipal(), fedoraId, links, model);
+                            created.set(true);
+                        }
+                        transaction.commitIfShortLived();
+                    });
                 }
 
-                // TODO: How to generate a response.
-                LOGGER.debug("Finished creating resource with path: {}", externalPath());
-                transaction.commitIfShortLived();
-            });
+            LOGGER.debug("Finished creating resource with path: {}", externalPath());
 
             return createUpdateResponse(getFedoraResource(transaction, fedoraId), created.get());
         } finally {
@@ -635,20 +637,20 @@ public class FedoraLdp extends ContentExposingResource {
 
             LOGGER.info("POST to create resource with ID: {}, slug: {}", newFedoraId.getFullIdPath(), decodedSlug);
 
-            doInDbTxWithRetry(() -> {
-                if (isBinary(interactionModel,
-                        providedContentType,
-                        requestBodyStream != null && providedContentType != null,
-                        extContent != null)) {
-                    ensureArchivalGroupHeaderNotPresentForBinaries(links);
+            if (isBinary(interactionModel,
+                    providedContentType,
+                    requestBodyStream != null && providedContentType != null,
+                    extContent != null)) {
+                ensureArchivalGroupHeaderNotPresentForBinaries(links);
 
-                    final Collection<URI> checksums = parseDigestHeader(digest);
-                    final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
-                    final var binaryType = requestContentType != null ?
-                            requestContentType : DEFAULT_NON_RDF_CONTENT_TYPE;
-                    final var contentType = extContent == null ? binaryType.toString() : extContent.getContentType();
-                    final long contentSize = contentDisposition == null ? -1L : contentDisposition.getSize();
+                final Collection<URI> checksums = parseDigestHeader(digest);
+                final String originalFileName = contentDisposition != null ? contentDisposition.getFileName() : "";
+                final var binaryType = requestContentType != null ?
+                        requestContentType : DEFAULT_NON_RDF_CONTENT_TYPE;
+                final var contentType = extContent == null ? binaryType.toString() : extContent.getContentType();
+                final long contentSize = contentDisposition == null ? -1L : contentDisposition.getSize();
 
+                doInDbTx(() -> {
                     createResourceService.perform(transaction,
                             getUserPrincipal(),
                             newFedoraId,
@@ -659,19 +661,26 @@ public class FedoraLdp extends ContentExposingResource {
                             checksums,
                             requestBodyStream,
                             extContent);
-                } else {
-                    final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;
-                    final Model model = httpRdfService.bodyToInternalModel(newFedoraId, requestBodyStream,
-                            contentType, identifierConverter(), hasLenientPreferHeader());
+
+                    transaction.commitIfShortLived();
+                });
+            } else {
+                final var contentType = requestContentType != null ? requestContentType : DEFAULT_RDF_CONTENT_TYPE;
+                final Model model = httpRdfService.bodyToInternalModel(newFedoraId, requestBodyStream,
+                        contentType, identifierConverter(), hasLenientPreferHeader());
+
+                doInDbTxWithRetry(() -> {
                     createResourceService.perform(transaction,
                             getUserPrincipal(),
                             newFedoraId,
                             links,
                             model);
-                }
-                LOGGER.debug("Finished creating resource with path: {}", externalPath());
-                transaction.commitIfShortLived();
-            });
+
+                    transaction.commitIfShortLived();
+                });
+            }
+
+            LOGGER.debug("Finished creating resource with path: {}", externalPath());
 
             try {
                 final var resource = getFedoraResource(transaction, newFedoraId);


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3728

# What does this Pull Request do?

When a MySQL deadlock occurs, Fedora retries the request. However, if the initial attempt consumed the request's input stream, the retry will fail. This PR fixes this problem by:

1. Moving the logic that parses RDF outside of the retryable block so that the stream is only read once
2. Makes non-RDF requests non-retryable

# How should this be tested?

The concurrency itest that was flapping should flap no more

# Interested parties

@fcrepo/committers
