### PR TITLE
apply preconditions on long-running transactions

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -702,7 +702,6 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             // Force cache revalidation if in a transaction
             servletResponse.addHeader(CACHE_CONTROL, "must-revalidate");
             servletResponse.addHeader(CACHE_CONTROL, "max-age=0");
-            return;
         }
 
         final EntityTag etag;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3729

# What does this Pull Request do?

Applies preconditions to long-running transactions the same as short-lived.

# How should this be tested?

Execute a PUT in a long-running tx with `If-Match` set to a bogus value and see the request rejected. Execute with the correct value and see the request accepted.

# Interested parties

@fcrepo/committers
