### PR TITLE
Add support for multi-architecture docker builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,5 @@ jobs:
         run: |
           FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
           cd fcrepo-docker
-          echo "building docker container"
-          ./build.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war
-          echo "push image to dockerhub"
-          ./push.sh latest ${FCREPO_VERSION}
+          echo "build and push image to dockerhub"
+          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war latest ${FCREPO_VERSION}


### PR DESCRIPTION
**Add support for multi-architecture docker builds.**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3734

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

BE SURE TO MERGE https://github.com/fcrepo-exts/fcrepo-docker/pull/14 BEFORE MERGING THIS PR.


# What does this Pull Request do?
This PR merely references the new fcrepo-docker docker build and push script.
# How should this be tested?
I tested the fcrepo-docker changes locally.  We won't really know if everything is working until this PR is merged and we can verify whether or not the multi architecture image was published to dockerhub.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
