### PR TITLE
update to use root resource id cache

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -103,7 +103,8 @@ public class OcflPersistenceConfig {
         final var factory = new DefaultOcflObjectSessionFactory(repository(),
                 ocflPropsConfig.getFedoraOcflStaging(),
                 objectMapper,
-                resourceHeadersCache(),
+                createCache("resourceHeadersCache"),
+                createCache("rootIdCache"),
                 commitType(),
                 "Authored by Fedora 6",
                 "fedoraAdmin",
@@ -150,7 +151,7 @@ public class OcflPersistenceConfig {
         return builder.build();
     }
 
-    private Cache<String, ResourceHeaders> resourceHeadersCache() {
+    private <K, V> Cache<K, V> createCache(final String metricName) {
         if (ocflPropsConfig.isResourceHeadersCacheEnabled()) {
             final var builder = Caffeine.newBuilder();
 
@@ -164,7 +165,7 @@ public class OcflPersistenceConfig {
                     .build();
 
             if (metricsConfig.isMetricsEnabled()) {
-                CaffeineCacheMetrics.monitor(meterRegistry, cache, "resourceHeadersCache");
+                CaffeineCacheMetrics.monitor(meterRegistry, cache, metricName);
             }
 
             return new CaffeineCache<>(cache);

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
@@ -133,7 +133,8 @@ public class AbstractReindexerTest {
 
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
         ocflObjectSessionFactory = new DefaultOcflObjectSessionFactory(repository,
-                tempFolder.newFolder().toPath(), objectMapper, new NoOpCache<>(), CommitType.NEW_VERSION,
+                tempFolder.newFolder().toPath(), objectMapper, new NoOpCache<>(), new NoOpCache<>(),
+                CommitType.NEW_VERSION,
                 "Fedora 6 test", "fedoraAdmin", "info:fedora/fedoraAdmin");
 
         persistentStorageSessionManager = new OcflPersistentSessionManager();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -163,6 +163,7 @@ public class OcflPersistentStorageSessionTest {
         objectSessionFactory = new DefaultOcflObjectSessionFactory(repository, stagingDir,
                 objectMapper,
                 new NoOpCache<>(),
+                new NoOpCache<>(),
                 CommitType.NEW_VERSION,
                 "Fedora 6 test", "fedoraAdmin", "info:fedora/fedoraAdmin");
         session = createSession(index, objectSessionFactory);


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3693

**Depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/42**

# What does this Pull Request do?

Wires in the new root resource id cache.

# How should this be tested?

Everything should work the same as before. It should be slightly faster, but it's unclear if it'd be that noticeable, especially when using a local disk.

# Interested parties

@fcrepo/committers
