### PR TITLE
added field for specifying mime type in web console

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-node-actions.vsl
@@ -18,6 +18,12 @@
           <label for="update_file" class="control-label">File</label>
           <input type="file" id="update_file"/>
         </div>
+        <div class="form-group">
+          <label for="update_mime_type" class="control-label">
+            MIME Type
+          </label>
+          <input type="text" id="update_mime_type" placeholder="application/octet-stream" name="update_mime_type" class="form-control"/>
+        </div>
         <input type="submit" id="binary_update_content" class="btn btn-primary" value="Update">
       </form>
     #end
@@ -62,7 +68,14 @@
     </label>
     <input type="file" name="file" id="binary_payload"/>
     </div>
-    
+
+    <div id="binary_mime_type_container" class="form-group">
+      <label for="mime_type" class="control-label">
+          MIME Type
+       </label>
+       <input type="text" id="mime_type" placeholder="application/octet-stream" name="mime_type" class="form-control"/>
+    </div>
+
     <button id="btn_action_create" class="btn btn-primary">Add</button>
     <hr />
   </form>

--- a/fcrepo-webapp/src/main/webapp/static/css/common.css
+++ b/fcrepo-webapp/src/main/webapp/static/css/common.css
@@ -50,6 +50,10 @@ dd {
     display: none;
 }
 
+#binary_mime_type_container {
+    display: none;
+}
+
 #actions.visible-lg.in, #actions.visible-lg.collapsing, #actions.visible-md.in, #actions.visible-md.collapsing  {
     display: block !important;
 }

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -73,9 +73,14 @@
     if (mixin == 'binary') {
       const update_file = document.getElementById('binary_payload').files[0];
       const reader = new FileReader();
+
+      const mime_type = document.getElementById('mime_type').value
+          || update_file.type
+          || 'application/octet-stream';
+
       headers.push(['Content-Disposition', 'attachment; filename=\"' + update_file.name + '\"']);
       headers.push(['Link', '<http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"']);
-      headers.push(['Content-Type', update_file.type || 'application/octet-stream']);
+      headers.push(['Content-Type', mime_type]);
       reader.onload = function(e) {
           fn(method, url, headers, e.target.result);
       };
@@ -237,9 +242,13 @@
       const url = window.location.href.replace('fcr:metadata', '');
       const reader = new FileReader();
 
+      const mime_type = document.getElementById('update_mime_type').value
+          || update_file.type
+          || 'application/octet-stream';
+
       const headers = [
         ['Content-Disposition', 'attachment; filename=\"' + update_file.name + '\"'],
-        ['Content-Type', update_file.type]];
+        ['Content-Type', mime_type]];
 
       reader.onload = function(e) {
           http('PUT', url, headers, e.target.result, function(res) {
@@ -483,6 +492,7 @@
   ready(function() {
       listen('new_mixin', 'change', function(e) {
         document.getElementById('binary_payload_container').style.display = e.target.value == 'binary' ? 'block' : 'none';
+        document.getElementById('binary_mime_type_container').style.display = e.target.value == 'binary' ? 'block' : 'none';
         document.getElementById('turtle_payload_container').style.display = e.target.value == 'binary' ? 'none' : 'block';
 
       });

--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -264,6 +264,20 @@
   }
 
   /*
+   * Updates the mime type based on the file selected, or clears the type if the type is unknown
+   */
+  function updateMimeType(target, mimeInputId) {
+      const mime_input = document.getElementById(mimeInputId);
+      const file = target.files[0];
+
+      if (file != null && file.type != null) {
+          mime_input.value = file.type;
+      } else {
+          mime_input.value = '';
+      }
+  }
+
+  /*
    * Do the search
    */
   function doSearch(e) {
@@ -520,6 +534,13 @@
       listen('action_enable_version', 'submit', enableVersioning);
       listen('action_update_file', 'submit', updateFile);
       listen('action_search', 'submit', doSearch);
+
+      listen('update_file', 'change', function(e) {
+          updateMimeType(e.target, 'update_mime_type');
+      });
+      listen('binary_payload', 'change', function(e) {
+          updateMimeType(e.target, 'mime_type');
+      });
 
       const links = document.querySelectorAll('a[property][href*="' + location.host + '"],#childList a,.breadcrumb a,.version_link');
       for (var i = 0; i < links.length; ++i) {


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3741

# What does this Pull Request do?

1. Adds a field for specifying mime type when adding/updating binaries
2. Fixes bug where content type was being set to an empty string

Ideally, the type would be pre-populated with the existing mime type on update, but I don't know how to do that.

# How should this be tested?

Do the following for adding and updating binaries:

1. Open the console
2. Add/update a binary _without_ a file extension and _without_ a mime type, and see it default to `application/octet-stream`
3. Add/update a binary _with_ a file extension and _without_ a mime type and see it guess the mime type
4. Add/update a binary _without_ a file extension and _with_ a mime type and see it use the specified type

# Interested parties

@fcrepo/committers
