### PR TITLE
keep tx alive while reindexing

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -326,6 +326,9 @@ public class MembershipServiceImpl implements MembershipService {
 
         // get all the members of the DC and index the history for each, accounting for changes to the DC
         fedoraResc.getChildren().forEach(member -> {
+            // must ensure the tx does not close before indexing is complete
+            tx.refresh();
+
             final var memberDeleted = member instanceof Tombstone;
             log.debug("Populating membership history for DirectContainer {}member {}",
                     memberDeleted ? "deleted " : "", member.getFedoraId());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
@@ -116,7 +116,11 @@ public class ReindexManager {
             for (final var worker : workers) {
                 worker.join();
             }
-            indexMembership();
+            if (failOnError && errorCount.get() == 0) {
+                indexMembership();
+            } else {
+                LOGGER.error("Reindex did not complete successfully");
+            }
         } catch (final Exception e) {
             LOGGER.error("Error while rebuilding index", e);
             stop();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexManager.java
@@ -116,7 +116,7 @@ public class ReindexManager {
             for (final var worker : workers) {
                 worker.join();
             }
-            if (failOnError && errorCount.get() == 0) {
+            if (!failOnError || errorCount.get() == 0) {
                 indexMembership();
             } else {
                 LOGGER.error("Reindex did not complete successfully");

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexService.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexService.java
@@ -222,6 +222,9 @@ public class ReindexService {
         try {
             int numResults;
             do {
+                // must ensure the tx does not close before indexing is complete
+                transaction.refresh();
+
                 final var params = new SearchParameters(fields, conditions, membershipPageSize,
                         offset, Condition.Field.FEDORA_ID, "asc", false);
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexService.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexService.java
@@ -222,9 +222,6 @@ public class ReindexService {
         try {
             int numResults;
             do {
-                // must ensure the tx does not close before indexing is complete
-                transaction.refresh();
-
                 final var params = new SearchParameters(fields, conditions, membershipPageSize,
                         offset, Condition.Field.FEDORA_ID, "asc", false);
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3750

# What does this Pull Request do?

Keeps the tx alive while reindexing membership

# How should this be tested?

Reindexing a large repo that uses membership should succeed when the membership indexing takes longer to complete than the tx timeout.

# Interested parties

@fcrepo/committers
