### PR TITLE
FCREPO-3752: Altering the external content URL does not update the binary metadata's last-modified date

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/RdfSourceOperationFactory.java
@@ -54,4 +54,16 @@ public interface RdfSourceOperationFactory extends ResourceOperationFactory {
     RdfSourceOperationBuilder updateBuilder(Transaction transaction, FedoraId rescId,
                                             final ServerManagedPropsMode serverManagedPropsMode);
 
+    /**
+     * Get a builder for an operation to update server managed properties of an RDF source
+     *
+     * @param transaction the transaction
+     * @param resourceId id of the resource targeted by the operation
+     * @param serverManagedPropsMode server managed props mode
+     * @return new builder
+     */
+    RdfSourceOperationBuilder updateManagedHeadersBuilder(Transaction transaction,
+                                                          FedoraId resourceId,
+                                                          ServerManagedPropsMode serverManagedPropsMode);
+
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperationType.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/operations/ResourceOperationType.java
@@ -24,5 +24,5 @@ package org.fcrepo.kernel.api.operations;
  * @author bbpennel
  */
 public enum ResourceOperationType {
-    UPDATE, CREATE, DELETE, PURGE, FOLLOW, REINDEX
+    UPDATE, UPDATE_HEADERS, CREATE, DELETE, PURGE, FOLLOW, REINDEX
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
@@ -73,6 +73,7 @@ public class ResourceOperationEventBuilder implements EventBuilder {
             case CREATE:
                 return EventType.RESOURCE_CREATION;
             case UPDATE:
+            case UPDATE_HEADERS:
                 return EventType.RESOURCE_MODIFICATION;
             case DELETE:
                 return EventType.RESOURCE_DELETION;

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/RdfSourceOperationFactoryImpl.java
@@ -49,4 +49,11 @@ public class RdfSourceOperationFactoryImpl implements RdfSourceOperationFactory 
         return new UpdateRdfSourceOperationBuilder(transaction, rescId, serverManagedPropsMode);
     }
 
+    @Override
+    public RdfSourceOperationBuilder updateManagedHeadersBuilder(final Transaction transaction,
+                                                                 final FedoraId resourceId,
+                                                                 final ServerManagedPropsMode serverManagedPropsMode) {
+        return new UpdateRdfHeadersOperationBuilder(transaction, resourceId, serverManagedPropsMode);
+    }
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperation.java
@@ -28,6 +28,7 @@ import org.fcrepo.kernel.api.operations.ResourceOperationType;
 /**
  * Operation for updating headers of an RDFSource
  *
+ * @author mikejritter
  */
 public class UpdateRdfHeadersOperation extends AbstractRdfSourceOperation {
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperation.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.operations;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE_HEADERS;
+
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.ResourceOperationType;
+
+/**
+ * Operation for updating headers of an RDFSource
+ *
+ */
+public class UpdateRdfHeadersOperation extends AbstractRdfSourceOperation {
+
+    protected UpdateRdfHeadersOperation(final Transaction transaction, final FedoraId resourceId) {
+        super(transaction, resourceId, null);
+    }
+
+    @Override
+    public RdfStream getTriples() {
+        throw new UnsupportedOperationException("UpdateRdfHeadersOperation has no triples");
+    }
+
+    @Override
+    public ResourceOperationType getType() {
+        return UPDATE_HEADERS;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
@@ -26,6 +26,7 @@ import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 /**
  * Builder for operations to update RDF Source headers
  *
+ * @author mikejritter
  */
 public class UpdateRdfHeadersOperationBuilder extends AbstractRdfSourceOperationBuilder {
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
@@ -38,8 +38,8 @@ public class UpdateRdfHeadersOperationBuilder extends AbstractRdfSourceOperation
      * @param serverManagedPropsMode server managed properties mode
      */
     public UpdateRdfHeadersOperationBuilder(final Transaction transaction,
-                                               final FedoraId resourceId,
-                                               final ServerManagedPropsMode serverManagedPropsMode) {
+                                            final FedoraId resourceId,
+                                            final ServerManagedPropsMode serverManagedPropsMode) {
         super(transaction, resourceId, null, serverManagedPropsMode);
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/UpdateRdfHeadersOperationBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.impl.operations;
+
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.config.ServerManagedPropsMode;
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+
+/**
+ * Builder for operations to update RDF Source headers
+ *
+ */
+public class UpdateRdfHeadersOperationBuilder extends AbstractRdfSourceOperationBuilder {
+
+    /**
+     * Constructor
+     *
+     * @param transaction the transaction
+     * @param resourceId the fedora identifier
+     * @param serverManagedPropsMode server managed properties mode
+     */
+    public UpdateRdfHeadersOperationBuilder(final Transaction transaction,
+                                               final FedoraId resourceId,
+                                               final ServerManagedPropsMode serverManagedPropsMode) {
+        super(transaction, resourceId, null, serverManagedPropsMode);
+    }
+
+    @Override
+    public RdfSourceOperation build() {
+        final var operation = new UpdateRdfHeadersOperation(transaction, resourceId.asBaseId());
+        operation.setUserPrincipal(userPrincipal);
+        operation.setCreatedBy(createdBy);
+        operation.setCreatedDate(createdDate);
+        operation.setLastModifiedBy(lastModifiedBy);
+        operation.setLastModifiedDate(lastModifiedDate);
+        return operation;
+    }
+
+    @Override
+    public UpdateRdfHeadersOperationBuilder relaxedProperties(final Model model) {
+        super.relaxedProperties(model);
+        return this;
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -113,7 +113,6 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
     private void updateBinaryHeaders(final Transaction tx,
                                      final PersistentStorageSession pSession,
                                      final ResourceOperation operation) {
-        // tx.lockResource(operation.getResourceId());
         pSession.persist(operation);
         recordEvent(tx, operation.getResourceId(), operation);
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -37,6 +37,8 @@ import javax.inject.Inject;
 
 import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 
+import java.util.Optional;
+
 /**
  * This class mediates update operations between the kernel and persistent storage layers
  * @author bseeger
@@ -56,7 +58,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                         final FedoraId fedoraId,
                         final Model inputModel) throws MalformedRdfException {
         try {
-            final PersistentStorageSession pSession = this.psManager.getSession(tx);
+            final PersistentStorageSession pSession = psManager.getSession(tx);
 
             final var headers = pSession.getHeaders(fedoraId, null);
             final var interactionModel = headers.getInteractionModel();
@@ -64,12 +66,31 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
             ensureValidDirectContainer(fedoraId, interactionModel, inputModel);
             ensureValidACLAuthorization(inputModel);
 
-            final ResourceOperation updateOp = factory.updateBuilder(tx, fedoraId,
-                    fedoraPropsConfig.getServerManagedPropsMode())
-                .relaxedProperties(inputModel)
-                .userPrincipal(userPrincipal)
-                .triples(fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel))
-                .build();
+            final var rdfStream = fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel);
+            final var serverManagedMode = fedoraPropsConfig.getServerManagedPropsMode();
+
+            // create 2 updates -- one for the properties coming in and one for and server managed properties
+            final ResourceOperation primaryOp;
+            final Optional<ResourceOperation> secondaryOp;
+            if (fedoraId.isDescription()) {
+                primaryOp = factory.updateBuilder(tx, fedoraId, serverManagedMode)
+                                   .userPrincipal(userPrincipal)
+                                   .triples(rdfStream)
+                                   .build();
+
+                // we need to use the description id until we write the headers in order to resolve properties
+                secondaryOp = Optional.of(factory.updateManagedHeadersBuilder(tx, fedoraId, serverManagedMode)
+                                                 .relaxedProperties(inputModel)
+                                                 .userPrincipal(userPrincipal)
+                                                 .build());
+            } else {
+                primaryOp = factory.updateBuilder(tx, fedoraId, serverManagedMode)
+                                   .relaxedProperties(inputModel)
+                                   .userPrincipal(userPrincipal)
+                                   .triples(rdfStream)
+                                   .build();
+                secondaryOp = Optional.empty();
+            }
 
             lockArchivalGroupResource(tx, pSession, fedoraId);
             tx.lockResource(fedoraId);
@@ -77,14 +98,23 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
                 tx.lockResource(fedoraId.asBaseId());
             }
 
-            pSession.persist(updateOp);
+            pSession.persist(primaryOp);
             updateReferences(tx, fedoraId, userPrincipal, inputModel);
             membershipService.resourceModified(tx, fedoraId);
             searchIndex.addUpdateIndex(tx, pSession.getHeaders(fedoraId, null));
-            recordEvent(tx, fedoraId, updateOp);
+            recordEvent(tx, fedoraId, primaryOp);
+            secondaryOp.ifPresent(operation -> updateBinaryHeaders(tx, pSession, operation));
         } catch (final PersistentStorageException ex) {
             throw new RepositoryRuntimeException(String.format("failed to replace resource %s",
                     fedoraId), ex);
         }
+    }
+
+    private void updateBinaryHeaders(final Transaction tx,
+                                     final PersistentStorageSession pSession,
+                                     final ResourceOperation operation) {
+        tx.lockResource(operation.getResourceId());
+        pSession.persist(operation);
+        recordEvent(tx, operation.getResourceId(), operation);
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -113,7 +113,7 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
     private void updateBinaryHeaders(final Transaction tx,
                                      final PersistentStorageSession pSession,
                                      final ResourceOperation operation) {
-        tx.lockResource(operation.getResourceId());
+        // tx.lockResource(operation.getResourceId());
         pSession.persist(operation);
         recordEvent(tx, operation.getResourceId(), operation);
     }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -168,7 +168,7 @@ public class ReplacePropertiesServiceImplTest {
 
         service.perform(tx, USER_PRINCIPAL, descId, model);
         verify(tx).lockResource(agId);
-        verify(tx, times(2)).lockResource(binaryId);
+        verify(tx).lockResource(binaryId);
         verify(tx).lockResource(descId);
         verify(pSession, times(2)).persist(operationCaptor.capture());
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -22,11 +22,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.time.Instant;
+import java.util.List;
 
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.config.ServerManagedPropsMode;
@@ -37,6 +39,7 @@ import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
 import org.fcrepo.kernel.api.operations.RdfSourceOperationFactory;
 import org.fcrepo.kernel.api.services.MembershipService;
 import org.fcrepo.kernel.api.services.ReferenceService;
@@ -104,7 +107,7 @@ public class ReplacePropertiesServiceImplTest {
     private RdfSourceOperationFactory factory;
 
     @Captor
-    private ArgumentCaptor<UpdateRdfSourceOperation> operationCaptor;
+    private ArgumentCaptor<RdfSourceOperation> operationCaptor;
 
     private FedoraPropsConfig propsConfig;
 
@@ -165,10 +168,20 @@ public class ReplacePropertiesServiceImplTest {
 
         service.perform(tx, USER_PRINCIPAL, descId, model);
         verify(tx).lockResource(agId);
-        verify(tx).lockResource(binaryId);
+        verify(tx, times(2)).lockResource(binaryId);
         verify(tx).lockResource(descId);
-        verify(pSession).persist(operationCaptor.capture());
-        assertEquals(descId, operationCaptor.getValue().getResourceId());
+        verify(pSession, times(2)).persist(operationCaptor.capture());
+
+        final var updateOp = getOperation(operationCaptor.getAllValues(), UpdateRdfSourceOperation.class);
+        assertEquals(descId, updateOp.getResourceId());
+    }
+
+    private <T extends RdfSourceOperation> T getOperation(final List<RdfSourceOperation> ops, final Class<T> clazz) {
+        return ops.stream()
+            .filter(clazz::isInstance)
+            .findFirst()
+            .map(clazz::cast)
+            .orElseThrow();
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -145,6 +145,7 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
         //load the persister list if empty
         persisterList.add(new CreateRdfSourcePersister(this.fedoraOcflIndex));
         persisterList.add(new UpdateRdfSourcePersister(this.fedoraOcflIndex));
+        persisterList.add(new UpdateRdfHeadersPersister(this.fedoraOcflIndex));
         persisterList.add(new CreateNonRdfSourcePersister(this.fedoraOcflIndex));
         persisterList.add(new UpdateNonRdfSourcePersister(this.fedoraOcflIndex));
         persisterList.add(new DeleteResourcePersister(this.fedoraOcflIndex));

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE_HEADERS;
+
+
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.kernel.api.operations.ResourceOperation;
+import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
+import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
+import org.fcrepo.storage.ocfl.OcflObjectSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements the persistence of the headers for an RDFSource to bring in new system managed properties
+ *
+ * @since 6.0.0
+ */
+public class UpdateRdfHeadersPersister extends AbstractRdfSourcePersister {
+
+    private static final Logger log = LoggerFactory.getLogger(UpdateRdfSourcePersister.class);
+
+    /**
+     * Constructor
+     *
+     * @param fedoraOcflIndex the FedoraToOcflObjectIndex
+     */
+    public UpdateRdfHeadersPersister(final FedoraToOcflObjectIndex fedoraOcflIndex) {
+        super(RdfSourceOperation.class, UPDATE_HEADERS, fedoraOcflIndex);
+    }
+
+    @Override
+    public void persist(OcflPersistentStorageSession session, ResourceOperation operation)
+        throws PersistentStorageException {
+        final var resourceId = operation.getResourceId();
+        log.info("persisting {} headers to {}", resourceId, session);
+
+        final var fedoraOcflMapping = getMapping(operation.getTransaction(), resourceId);
+        final var ocflId = fedoraOcflMapping.getOcflObjectId();
+        final OcflObjectSession objSession = session.findOrCreateSession(ocflId);
+
+        // unlike with normal updates we don't want to clear the digests/content-size, just the server managed headers
+        // in the event the server managed mode is strict, all values will be null
+        final var headers = new ResourceHeadersAdapter(objSession.readHeaders(resourceId.getResourceId()));
+
+        final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
+        final var createdDate = rdfSourceOp.getCreatedDate();
+        final var lastModifiedDate = rdfSourceOp.getLastModifiedDate();
+        final var createdBy = rdfSourceOp.getCreatedBy();
+        final var lastModifiedBy = rdfSourceOp.getLastModifiedBy();
+        if (createdDate != null) {
+            headers.setCreatedDate(createdDate);
+        }
+        if (lastModifiedDate != null) {
+            headers.setLastModifiedDate(lastModifiedDate);
+        }
+        if (createdBy != null) {
+            headers.setCreatedBy(createdBy);
+        }
+        if (lastModifiedBy != null) {
+            headers.setLastModifiedBy(lastModifiedBy);
+        }
+
+        objSession.writeHeaders(headers.asStorageHeaders());
+    }
+
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
@@ -51,7 +51,7 @@ public class UpdateRdfHeadersPersister extends AbstractRdfSourcePersister {
     public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
         throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
-        log.info("persisting {} headers to {}", resourceId, session);
+        log.debug("persisting {} headers to {}", resourceId, session);
 
         final var fedoraOcflMapping = getMapping(operation.getTransaction(), resourceId);
         final var ocflId = fedoraOcflMapping.getOcflObjectId();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersister.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class implements the persistence of the headers for an RDFSource to bring in new system managed properties
  *
+ * @author mikejritter
  * @since 6.0.0
  */
 public class UpdateRdfHeadersPersister extends AbstractRdfSourcePersister {
@@ -47,7 +48,7 @@ public class UpdateRdfHeadersPersister extends AbstractRdfSourcePersister {
     }
 
     @Override
-    public void persist(OcflPersistentStorageSession session, ResourceOperation operation)
+    public void persist(final OcflPersistentStorageSession session, final ResourceOperation operation)
         throws PersistentStorageException {
         final var resourceId = operation.getResourceId();
         log.info("persisting {} headers to {}", resourceId, session);
@@ -60,7 +61,7 @@ public class UpdateRdfHeadersPersister extends AbstractRdfSourcePersister {
         // in the event the server managed mode is strict, all values will be null
         final var headers = new ResourceHeadersAdapter(objSession.readHeaders(resourceId.getResourceId()));
 
-        final RdfSourceOperation rdfSourceOp = (RdfSourceOperation)operation;
+        final RdfSourceOperation rdfSourceOp = (RdfSourceOperation) operation;
         final var createdDate = rdfSourceOp.getCreatedDate();
         final var lastModifiedDate = rdfSourceOp.getLastModifiedDate();
         final var createdBy = rdfSourceOp.getCreatedBy();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersisterTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/UpdateRdfHeadersPersisterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.persistence.ocfl.impl;
+
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.operations.ResourceOperationType.UPDATE_HEADERS;
+import static org.fcrepo.persistence.common.ResourceHeaderUtils.newResourceHeaders;
+import static org.fcrepo.persistence.common.ResourceHeaderUtils.touchCreationHeaders;
+import static org.fcrepo.persistence.common.ResourceHeaderUtils.touchModificationHeaders;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.operations.NonRdfSourceOperation;
+import org.fcrepo.kernel.api.operations.RdfSourceOperation;
+import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
+import org.fcrepo.storage.ocfl.OcflObjectSession;
+import org.fcrepo.storage.ocfl.ResourceHeaders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author mikejritter
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateRdfHeadersPersisterTest {
+    private static final FedoraId RESOURCE_ID = FedoraId.create("info:fedora/parent/child");
+    private static final FedoraId ROOT_RESOURCE_ID = FedoraId.create("info:fedora/parent");
+    private static final String USER_PRINCIPAL = "fedoraUser";
+
+    @Mock
+    private RdfSourceOperation operation;
+
+    @Mock
+    private OcflObjectSession session;
+
+    @Mock
+    private FedoraOcflMapping mapping;
+
+    @Mock
+    private FedoraToOcflObjectIndex index;
+
+    @Mock
+    private OcflPersistentStorageSession psSession;
+
+    @Captor
+    private ArgumentCaptor<ResourceHeaders> headersCaptor;
+
+    private UpdateRdfHeadersPersister persister;
+
+    @Mock
+    private Transaction transaction;
+
+    @Before
+    public void setup() throws Exception {
+        operation = mock(RdfSourceOperation.class);
+
+        when(psSession.findOrCreateSession(anyString())).thenReturn(session);
+        when(index.getMapping(eq(transaction), any())).thenReturn(mapping);
+        when(operation.getType()).thenReturn(UPDATE_HEADERS);
+        when(operation.getTransaction()).thenReturn(transaction);
+
+        persister = new UpdateRdfHeadersPersister(index);
+    }
+
+    @Test
+    public void testHandle() {
+        assertTrue(persister.handle(operation));
+        final NonRdfSourceOperation badOperation = mock(NonRdfSourceOperation.class);
+        assertFalse(persister.handle(badOperation));
+    }
+
+    @Test
+    public void testPersistHeaders() {
+        final var now = Instant.now();
+        final var user = "some-user";
+        final var objectId = "object-id";
+
+        when(operation.getResourceId()).thenReturn(RESOURCE_ID);
+        when(mapping.getOcflObjectId()).thenReturn(objectId);
+
+        // setup headers
+        final var headers = newResourceHeaders(ROOT_RESOURCE_ID, RESOURCE_ID, BASIC_CONTAINER.toString());
+        touchCreationHeaders(headers, USER_PRINCIPAL);
+        touchModificationHeaders(headers, USER_PRINCIPAL);
+        when(session.readHeaders(anyString())).thenReturn(new ResourceHeadersAdapter(headers).asStorageHeaders());
+
+        when(operation.getCreatedDate()).thenReturn(now);
+        when(operation.getLastModifiedDate()).thenReturn(now);
+        when(operation.getCreatedBy()).thenReturn(user);
+        when(operation.getLastModifiedBy()).thenReturn(user);
+
+        persister.persist(psSession, operation);
+
+        verify(session).writeHeaders(headersCaptor.capture());
+
+        final var resultHeaders = headersCaptor.getValue();
+        assertEquals(now, resultHeaders.getCreatedDate());
+        assertEquals(now, resultHeaders.getLastModifiedDate());
+        assertEquals(user, resultHeaders.getCreatedBy());
+        assertEquals(user, resultHeaders.getLastModifiedBy());
+    }
+
+}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3752

# What does this Pull Request do?

This updates the metadata handling for server managed properties to be applied to the binary headers rather than the binary description. This allows for the ManagedPropertiesService to resolve all managed properties from the binary.

# Changes

* Create a new operation for updating only the binary headers
* Create a new persister for updating the binary headers
* When updating a description, create two operations for managed and unmanaged properties
* Resolve managed properties from the Binary when possible

# How should this be tested?

There are two things to test here - the binary metadata being pulled from the correct source and that updates to server managed properties are done to the correct file.

## Binary Metadata

* Start fedora
* Create a binary
  ```
  curl -X PUT -H "Content-Type: text/plain" --data "somedata" -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"" --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1 
  ```
* Get the metadata
  ```
  curl --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary/fcr:metadata
  ```
* Do a second put over top of the binary
  ```
  curl -X PUT -H "Content-Type: text/plain" --data "somemoredata" -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"" --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/test1 
  ```
* Check that the metadata is updated properly

## Server Managed Properties

* Start fedora with relaxed properties mode
* Create a binary
  ```
  curl -X PUT -H "Content-Type: text/plain" --data "somedata" -H "Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel=\"type\"" --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary 
  ```
* Get the metadata for the binary and see that it matches what is the in the binary headers
  ```
  curl --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary/fcr:metadata
  ```
* Update the server managed properties on the binary
  ```
  curl -X PATCH --data "PREFIX fedora: <http://fedora.info/definitions/v4/repository#>
  INSERT {
      <> fedora:createdDate "2021-08-26T15:04:43.517Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
      fedora:lastModified "2021-08-26T15:04:43.517Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
  }
  WHERE  { }" -H "Content-Type: application/sparql-update" --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/descupdate/fcr:metadata 
  ```
* Get the metadata for the binary and see that it matches the update + what is the in the v2 binary headers
  ```
  curl --user fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary/fcr:metadata
  ```

# Interested parties
@fcrepo/committers
