### PR TITLE
upgrade ocfl-java; add buffers to streams where needed

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ExternalContentHandler.java
@@ -32,6 +32,7 @@ import org.fcrepo.kernel.api.exception.ExternalContentAccessException;
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
 import javax.ws.rs.core.Link;
 
+import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -147,9 +148,9 @@ public class ExternalContentHandler implements ExternalContent {
         if (scheme != null) {
             try {
                 if (scheme.equals("file")) {
-                    return new FileInputStream(uri.getPath());
+                    return new BufferedInputStream(new FileInputStream(uri.getPath()));
                 } else if (scheme.equals("http") || scheme.equals("https")) {
-                    return uri.toURL().openStream();
+                    return new BufferedInputStream(uri.toURL().openStream());
                 }
             } catch (final IOException e) {
                 throw new ExternalContentAccessException("Failed to read external content from " + uri, e);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -32,6 +32,7 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -80,7 +81,8 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
     public InputStream getContent() {
         try {
             if (isProxy() || isRedirect()) {
-                return URI.create(getExternalURL()).toURL().openStream();
+                // non-external streams are already buffered
+                return new BufferedInputStream(URI.create(getExternalURL()).toURL().openStream());
             } else {
                 return getSession().getBinaryContent(getFedoraId().asResourceId(), getMementoDatetime());
             }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -45,6 +45,8 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Link;
+
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
@@ -110,7 +112,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             }
             if (!digest.isEmpty()) {
                 final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
-                        externalContent.fetchExternalContent(),
+                        new BufferedInputStream(externalContent.fetchExternalContent()),
                         digest,
                         Collections.emptyList());
                 multiDigestWrapper.checkFixity();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -46,7 +46,6 @@ import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Link;
 
-import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
@@ -112,7 +111,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
             }
             if (!digest.isEmpty()) {
                 final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
-                        new BufferedInputStream(externalContent.fetchExternalContent()),
+                        externalContent.fetchExternalContent(),
                         digest,
                         Collections.emptyList());
                 multiDigestWrapper.checkFixity();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+
+import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
@@ -90,7 +92,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                 }
                 if (!digests.isEmpty()) {
                     final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
-                            externalContent.fetchExternalContent(),
+                            new BufferedInputStream(externalContent.fetchExternalContent()),
                             digests,
                             Collections.emptyList());
                     multiDigestWrapper.checkFixity();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplaceBinariesServiceImpl.java
@@ -33,7 +33,6 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 
-import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
@@ -92,7 +91,7 @@ public class ReplaceBinariesServiceImpl extends AbstractService implements Repla
                 }
                 if (!digests.isEmpty()) {
                     final var multiDigestWrapper = new MultiDigestInputStreamWrapper(
-                            new BufferedInputStream(externalContent.fetchExternalContent()),
+                            externalContent.fetchExternalContent(),
                             digests,
                             Collections.emptyList());
                     multiDigestWrapper.checkFixity();

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/AbstractNonRdfSourcePersister.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 
+import java.io.BufferedInputStream;
 import java.util.Collections;
 
 import static org.fcrepo.kernel.api.operations.ResourceOperationType.CREATE;
@@ -97,7 +98,7 @@ abstract class AbstractNonRdfSourcePersister extends AbstractPersister {
                     Collections.emptyList());
             final var contentStream = multiDigestWrapper.getInputStream();
 
-            objectSession.writeResource(headers.asStorageHeaders(), contentStream);
+            objectSession.writeResource(headers.asStorageHeaders(), new BufferedInputStream(contentStream));
 
             // Verify that the content matches the provided digests
             if (!CollectionUtils.isEmpty(providedDigests)) {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
       (for scm, site-distribution, etc -->
     <project_name>fcrepo</project_name>
     <project_organization>fcrepo</project_organization>
-    <fcrepo-storage-ocfl.version>6.0.0</fcrepo-storage-ocfl.version>
+    <fcrepo-storage-ocfl.version>6.1.0-SNAPSHOT</fcrepo-storage-ocfl.version>
     <!-- Dependency version properties -->
     <activemq.version>5.16.2</activemq.version>
     <aws.version>2.16.72</aws.version>
@@ -32,7 +32,7 @@
     <commons-io.version>2.9.0</commons-io.version>
     <commons-lang.version>3.12.0</commons-lang.version>
     <narayana-jta.version>5.9.0.Final</narayana-jta.version>
-    <failsafe.version>2.4.0</failsafe.version>
+    <failsafe.version>2.4.3</failsafe.version>
     <flyway.version>7.9.1</flyway.version>
     <flyway.test.version>7.0.0</flyway.test.version>
     <guava.version>30.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <logback.version>1.2.3</logback.version>
     <micrometer.version>1.6.4</micrometer.version>
     <netty.version>4.1.63.Final</netty.version>
-    <ocfl-java.version>1.1.0</ocfl-java.version>
+    <ocfl-java.version>1.2.3</ocfl-java.version>
     <prometheus.version>0.9.0</prometheus.version>
     <reactivestrams.version>1.0.3</reactivestrams.version>
     <shiro.version>1.7.1</shiro.version>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3758

**This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/43**

# What does this Pull Request do?

Upgrades to the latest version of ocfl-java and adds buffers to a few input streams. The latest version of ocfl-java adds buffering to all input streams, including streams that are returned via the api. This will resolve a couple of buffering related bugs in this code base as well, and hopefully make it much faster on systems running on a NAS.

# How should this be tested?

No functional changes

# Interested parties
@fcrepo/committers