### PR TITLE
add user rdf types cache

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -131,6 +131,12 @@ public class FedoraPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.cache.db.containment.timeout.minutes:10}")
     private long containmentCacheTimeout;
 
+    @Value("${fcrepo.cache.types.size.entries:1024}")
+    private long userTypesCacheSize;
+
+    @Value("${fcrepo.cache.types.timeout.minutes:10}")
+    private long userTypesCacheTimeout;
+
     @Value("${fcrepo.cache.webac.acl.size.entries:1024}")
     private long webacCacheSize;
 
@@ -341,6 +347,20 @@ public class FedoraPropsConfig extends BasePropsConfig {
      */
     public long getContainmentCacheTimeout() {
         return containmentCacheTimeout;
+    }
+
+    /**
+     * @return The number of entries in the user types cache.
+     */
+    public long getUserTypesCacheSize() {
+        return userTypesCacheSize;
+    }
+
+    /**
+     * @return The number of minutes before items in the user types cache expire.
+     */
+    public long getUserTypesCacheTimeout() {
+        return userTypesCacheTimeout;
     }
 
     /**

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -357,10 +357,24 @@ public class FedoraPropsConfig extends BasePropsConfig {
     }
 
     /**
+     * @param userTypesCacheSize user types cache size
+     */
+    public void setUserTypesCacheSize(final long userTypesCacheSize) {
+        this.userTypesCacheSize = userTypesCacheSize;
+    }
+
+    /**
      * @return The number of minutes before items in the user types cache expire.
      */
     public long getUserTypesCacheTimeout() {
         return userTypesCacheTimeout;
+    }
+
+    /**
+     * @param userTypesCacheTimeout user types cache timeout
+     */
+    public void setUserTypesCacheTimeout(final long userTypesCacheTimeout) {
+        this.userTypesCacheTimeout = userTypesCacheTimeout;
     }
 
     /**

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-configs</artifactId>
-      <version>6.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/cache/UserTypesCache.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/cache/UserTypesCache.java
@@ -25,23 +25,64 @@ import java.util.function.Supplier;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 
-// TODO docs
+/**
+ * Cache of user RDF types. This cache has two levels. Types are cached at the session level as well as globally.
+ * This is necessary to support long-running transactions that can span multiple requests.
+ *
+ * @author pwinckles
+ */
 public interface UserTypesCache {
 
+    /**
+     * Gets the user RDF types for the specified resource from the cache. First, the session's cache is checked.
+     * If the types were not found, then the global cache is checked. If not in either cache, then the rdfProvider
+     * is called to load the resource's RDF from which the types are parsed, cached, and returned.
+     *
+     * This method should NOT be called on binary resources.
+     *
+     * @param resourceId the id of the resource
+     * @param sessionId the id of the current session
+     * @param rdfProvider the provider that is called, if needed, to load the resource's rdf
+     * @return the resource's user RDF types
+     */
     List<URI> getUserTypes(final FedoraId resourceId,
                            final String sessionId,
                            final Supplier<RdfStream> rdfProvider);
 
+    /**
+     * Extracts the user RDF types from the RDF and caches them in the session level cache.
+     *
+     * @param resourceId the id of the resource
+     * @param rdf the resource's RDF
+     * @param sessionId the session to cache the types in
+     */
     void cacheUserTypes(final FedoraId resourceId,
                         final RdfStream rdf,
                         final String sessionId);
 
+    /**
+     * Caches the user RDF types in the session level cache.
+     *
+     * @param resourceId the id of the resource
+     * @param userTypes the resource's types
+     * @param sessionId the session to cache the types in
+     */
     void cacheUserTypes(final FedoraId resourceId,
                         final List<URI> userTypes,
                         final String sessionId);
 
+    /**
+     * Merges the session level cache into the global cache.
+     *
+     * @param sessionId the id of the session to merge
+     */
     void mergeSessionCache(final String sessionId);
 
+    /**
+     * Drops a session level cache without merging it into the global cache.
+     *
+     * @param sessionId the id of the session cache to drop
+     */
     void dropSessionCache(final String sessionId);
 
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/cache/UserTypesCache.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/cache/UserTypesCache.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.api.cache;
+
+import java.net.URI;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
+// TODO docs
+public interface UserTypesCache {
+
+    List<URI> getUserTypes(final FedoraId resourceId,
+                           final String sessionId,
+                           final Supplier<RdfStream> rdfProvider);
+
+    void cacheUserTypes(final FedoraId resourceId,
+                        final RdfStream rdf,
+                        final String sessionId);
+
+    void cacheUserTypes(final FedoraId resourceId,
+                        final List<URI> userTypes,
+                        final String sessionId);
+
+    void mergeSessionCache(final String sessionId);
+
+    void dropSessionCache(final String sessionId);
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/models/FedoraResource.java
@@ -64,6 +64,13 @@ public interface FedoraResource {
     FedoraResource getParent() throws PathNotFoundException;
 
     /**
+     * Get the FedoraId of this resource's parent
+     *
+     * @return the parent resource's id
+     */
+    FedoraId getParentId();
+
+    /**
      * Get the children of this resource
      * @return a stream of Fedora resources
      */

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -22,6 +22,7 @@ import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
 import org.fcrepo.kernel.api.lock.ResourceLockManager;
@@ -84,6 +85,9 @@ public class TransactionManagerImpl implements TransactionManager {
 
     @Inject
     private DbTransactionExecutor dbTransactionExecutor;
+
+    @Inject
+    private UserTypesCache userTypesCache;
 
     TransactionManagerImpl() {
         transactions = new ConcurrentHashMap<>();
@@ -186,6 +190,10 @@ public class TransactionManagerImpl implements TransactionManager {
 
     protected ResourceLockManager getResourceLockManager() {
         return resourceLockManager;
+    }
+
+    protected UserTypesCache getUserTypesCache() {
+        return userTypesCache;
     }
 
     public DbTransactionExecutor getDbTransactionExecutor() {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.ReadOnlyTransaction;
 import org.fcrepo.kernel.api.cache.UserTypesCache;
@@ -50,11 +51,10 @@ public class UserTypesCacheImpl implements UserTypesCache {
     private final Cache<FedoraId, List<URI>> globalCache;
     private final Map<String, Cache<FedoraId, List<URI>>> sessionCaches;
 
-    public UserTypesCacheImpl() {
+    public UserTypesCacheImpl(final FedoraPropsConfig config) {
         this.globalCache = Caffeine.newBuilder()
-                // TODO config
-                .maximumSize(1024)
-                .expireAfterAccess(15, TimeUnit.MINUTES)
+                .maximumSize(config.getUserTypesCacheSize())
+                .expireAfterAccess(config.getUserTypesCacheTimeout(), TimeUnit.MINUTES)
                 .build();
         this.sessionCaches = new ConcurrentHashMap<>();
     }
@@ -130,9 +130,7 @@ public class UserTypesCacheImpl implements UserTypesCache {
     private Cache<FedoraId, List<URI>> getSessionCache(final String sessionId) {
         return sessionCaches.computeIfAbsent(sessionId, k -> {
             return Caffeine.newBuilder()
-                    // TODO config
                     .maximumSize(1024)
-                    .expireAfterAccess(15, TimeUnit.MINUTES)
                     .build();
         });
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
@@ -26,14 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.ReadOnlyTransaction;
 import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
-import org.fcrepo.persistence.api.PersistentStorageSession;
 
 import org.apache.jena.graph.Triple;
 import org.springframework.stereotype.Component;
@@ -41,7 +39,11 @@ import org.springframework.stereotype.Component;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
-// TODO docs
+/**
+ * Default UserTypesCache implementation
+ *
+ * @author pwinckles
+ */
 @Component
 public class UserTypesCacheImpl implements UserTypesCache {
 
@@ -57,13 +59,15 @@ public class UserTypesCacheImpl implements UserTypesCache {
         this.sessionCaches = new ConcurrentHashMap<>();
     }
 
-    // TODO note that this must only be called on rdf resources
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public List<URI> getUserTypes(final FedoraId resourceId,
                                   final String sessionId,
                                   final Supplier<RdfStream> rdfProvider) {
         if (isNotReadOnlySession(sessionId)) {
-            var sessionCache = getSessionCache(sessionId);
+            final var sessionCache = getSessionCache(sessionId);
 
             return sessionCache.get(resourceId, k -> {
                 return globalCache.get(resourceId, k2 -> {
@@ -77,6 +81,9 @@ public class UserTypesCacheImpl implements UserTypesCache {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void cacheUserTypes(final FedoraId resourceId,
                                final RdfStream rdf,
@@ -86,6 +93,9 @@ public class UserTypesCacheImpl implements UserTypesCache {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void cacheUserTypes(final FedoraId resourceId,
                                final List<URI> userTypes,
@@ -95,15 +105,21 @@ public class UserTypesCacheImpl implements UserTypesCache {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void mergeSessionCache(final String sessionId) {
         if (isNotReadOnlySession(sessionId)) {
-            var sessionCache = getSessionCache(sessionId);
+            final var sessionCache = getSessionCache(sessionId);
             globalCache.putAll(sessionCache.asMap());
             dropSessionCache(sessionId);
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void dropSessionCache(final String sessionId) {
         if (isNotReadOnlySession(sessionId)) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImpl.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.cache;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.jena.vocabulary.RDF.type;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.ReadOnlyTransaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.persistence.api.PersistentStorageSession;
+
+import org.apache.jena.graph.Triple;
+import org.springframework.stereotype.Component;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+// TODO docs
+@Component
+public class UserTypesCacheImpl implements UserTypesCache {
+
+    private final Cache<FedoraId, List<URI>> globalCache;
+    private final Map<String, Cache<FedoraId, List<URI>>> sessionCaches;
+
+    public UserTypesCacheImpl() {
+        this.globalCache = Caffeine.newBuilder()
+                // TODO config
+                .maximumSize(1024)
+                .expireAfterAccess(15, TimeUnit.MINUTES)
+                .build();
+        this.sessionCaches = new ConcurrentHashMap<>();
+    }
+
+    // TODO note that this must only be called on rdf resources
+    @Override
+    public List<URI> getUserTypes(final FedoraId resourceId,
+                                  final String sessionId,
+                                  final Supplier<RdfStream> rdfProvider) {
+        if (isNotReadOnlySession(sessionId)) {
+            var sessionCache = getSessionCache(sessionId);
+
+            return sessionCache.get(resourceId, k -> {
+                return globalCache.get(resourceId, k2 -> {
+                    return extractRdfTypes(rdfProvider.get());
+                });
+            });
+        } else {
+            return globalCache.get(resourceId, k -> {
+                return extractRdfTypes(rdfProvider.get());
+            });
+        }
+    }
+
+    @Override
+    public void cacheUserTypes(final FedoraId resourceId,
+                               final RdfStream rdf,
+                               final String sessionId) {
+        if (isNotReadOnlySession(sessionId)) {
+            getSessionCache(sessionId).put(resourceId, extractRdfTypes(rdf));
+        }
+    }
+
+    @Override
+    public void cacheUserTypes(final FedoraId resourceId,
+                               final List<URI> userTypes,
+                               final String sessionId) {
+        if (isNotReadOnlySession(sessionId)) {
+            getSessionCache(sessionId).put(resourceId, userTypes);
+        }
+    }
+
+    @Override
+    public void mergeSessionCache(final String sessionId) {
+        if (isNotReadOnlySession(sessionId)) {
+            var sessionCache = getSessionCache(sessionId);
+            globalCache.putAll(sessionCache.asMap());
+            dropSessionCache(sessionId);
+        }
+    }
+
+    @Override
+    public void dropSessionCache(final String sessionId) {
+        if (isNotReadOnlySession(sessionId)) {
+            sessionCaches.remove(sessionId);
+        }
+    }
+
+    private Cache<FedoraId, List<URI>> getSessionCache(final String sessionId) {
+        return sessionCaches.computeIfAbsent(sessionId, k -> {
+            return Caffeine.newBuilder()
+                    // TODO config
+                    .maximumSize(1024)
+                    .expireAfterAccess(15, TimeUnit.MINUTES)
+                    .build();
+        });
+    }
+
+    private List<URI> extractRdfTypes(final RdfStream rdf) {
+        return rdf.filter(t -> t.predicateMatches(type.asNode()))
+                .map(Triple::getObject)
+                .map(t -> URI.create(t.toString()))
+                .collect(toList());
+    }
+
+    private boolean isNotReadOnlySession(final String sessionId) {
+        return !ReadOnlyTransaction.READ_ONLY_TX_ID.equals(sessionId);
+    }
+}

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -72,6 +72,7 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
      * @param transaction transaction
      * @param pSessionManager session manager
      * @param resourceFactory resource factory
+     * @param userTypesCache the user types cache
      */
     public BinaryImpl(final FedoraId fedoraID,
                       final Transaction transaction,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/BinaryImpl.java
@@ -19,6 +19,7 @@ package org.fcrepo.kernel.impl.models;
 
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
@@ -72,9 +73,12 @@ public class BinaryImpl extends FedoraResourceImpl implements Binary {
      * @param pSessionManager session manager
      * @param resourceFactory resource factory
      */
-    public BinaryImpl(final FedoraId fedoraID, final Transaction transaction,
-                      final PersistentStorageSessionManager pSessionManager, final ResourceFactory resourceFactory) {
-        super(fedoraID, transaction, pSessionManager, resourceFactory);
+    public BinaryImpl(final FedoraId fedoraID,
+                      final Transaction transaction,
+                      final PersistentStorageSessionManager pSessionManager,
+                      final ResourceFactory resourceFactory,
+                      final UserTypesCache userTypesCache) {
+        super(fedoraID, transaction, pSessionManager, resourceFactory, userTypesCache);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.models;
 
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.Container;
 import org.fcrepo.kernel.api.models.FedoraResource;
@@ -52,9 +53,12 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
      * @param pSessionManager session manager
      * @param resourceFactory resource factory
      */
-    public ContainerImpl(final FedoraId fedoraID, final Transaction transaction,
-                         final PersistentStorageSessionManager pSessionManager, final ResourceFactory resourceFactory) {
-        super(fedoraID, transaction, pSessionManager, resourceFactory);
+    public ContainerImpl(final FedoraId fedoraID,
+                         final Transaction transaction,
+                         final PersistentStorageSessionManager pSessionManager,
+                         final ResourceFactory resourceFactory,
+                         final UserTypesCache userTypesCache) {
+        super(fedoraID, transaction, pSessionManager, resourceFactory, userTypesCache);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ContainerImpl.java
@@ -52,6 +52,7 @@ public class ContainerImpl extends FedoraResourceImpl implements Container {
      * @param transaction transaction
      * @param pSessionManager session manager
      * @param resourceFactory resource factory
+     * @param userTypesCache the user types cache
      */
     public ContainerImpl(final FedoraId fedoraID,
                          final Transaction transaction,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -54,6 +54,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
      * @param transaction transaction
      * @param pSessionManager session manager
      * @param resourceFactory resource factory
+     * @param userTypesCache the user types cache
      */
     public NonRdfSourceDescriptionImpl(final FedoraId fedoraID,
                                        final Transaction transaction,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -21,6 +21,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -55,10 +56,11 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
      * @param resourceFactory resource factory
      */
     public NonRdfSourceDescriptionImpl(final FedoraId fedoraID,
-            final Transaction transaction,
-            final PersistentStorageSessionManager pSessionManager,
-            final ResourceFactory resourceFactory) {
-        super(fedoraID, transaction, pSessionManager, resourceFactory);
+                                       final Transaction transaction,
+                                       final PersistentStorageSessionManager pSessionManager,
+                                       final ResourceFactory resourceFactory,
+                                       final UserTypesCache userTypesCache) {
+        super(fedoraID, transaction, pSessionManager, resourceFactory, userTypesCache);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/ResourceFactoryImpl.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
@@ -68,6 +69,9 @@ public class ResourceFactoryImpl implements ResourceFactory {
     @Autowired
     @Qualifier("containmentIndex")
     private ContainmentIndex containmentIndex;
+
+    @Inject
+    private UserTypesCache userTypesCache;
 
     @Override
     public FedoraResource getResource(final Transaction transaction, final FedoraId fedoraID)
@@ -146,14 +150,15 @@ public class ResourceFactoryImpl implements ResourceFactory {
                     FedoraId.class,
                     Transaction.class,
                     PersistentStorageSessionManager.class,
-                    ResourceFactory.class);
+                    ResourceFactory.class,
+                    UserTypesCache.class);
 
             // If identifier is to a TimeMap we need to avoid creating a original resource with a Timemap FedoraId
             final var instantiationId = identifier.isTimemap() ?
                     FedoraId.create(identifier.getResourceId()) : identifier;
 
             final var rescImpl = constructor.newInstance(instantiationId, transaction,
-                    persistentStorageSessionManager, this);
+                    persistentStorageSessionManager, this, userTypesCache);
             populateResourceHeaders(rescImpl, headers, versionDateTime);
 
             if (headers.isDeleted()) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TimeMapImpl.java
@@ -81,7 +81,8 @@ public class TimeMapImpl extends FedoraResourceImpl implements TimeMap {
             final Transaction transaction,
             final PersistentStorageSessionManager pSessionManager,
             final ResourceFactory resourceFactory) {
-        super(originalResource.getFedoraId().asTimemap(), transaction, pSessionManager, resourceFactory);
+        super(originalResource.getFedoraId().asTimemap(), transaction,
+                pSessionManager, resourceFactory, null);
 
         this.originalResource = originalResource;
         setCreatedBy(originalResource.getCreatedBy());

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/TombstoneImpl.java
@@ -37,10 +37,12 @@ public class TombstoneImpl extends FedoraResourceImpl implements Tombstone {
 
     private FedoraResource originalResource;
 
-    protected TombstoneImpl(final FedoraId fedoraID, final Transaction transaction,
+    protected TombstoneImpl(final FedoraId fedoraID,
+                            final Transaction transaction,
                             final PersistentStorageSessionManager pSessionManager,
-                            final ResourceFactory resourceFactory, final FedoraResource original) {
-        super(fedoraID, transaction, pSessionManager, resourceFactory);
+                            final ResourceFactory resourceFactory,
+                            final FedoraResource original) {
+        super(fedoraID, transaction, pSessionManager, resourceFactory, null);
         this.originalResource = original;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -18,6 +18,7 @@
 package org.fcrepo.kernel.impl.models;
 
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -40,9 +41,12 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
      * @param pSessionManager a session manager
      * @param resourceFactory a resource factory instance.
      */
-    public WebacAclImpl(final FedoraId fedoraID, final Transaction transaction,
-                        final PersistentStorageSessionManager pSessionManager, final ResourceFactory resourceFactory) {
-        super(fedoraID, transaction, pSessionManager, resourceFactory);
+    public WebacAclImpl(final FedoraId fedoraID,
+                        final Transaction transaction,
+                        final PersistentStorageSessionManager pSessionManager,
+                        final ResourceFactory resourceFactory,
+                        final UserTypesCache userTypesCache) {
+        super(fedoraID, transaction, pSessionManager, resourceFactory, userTypesCache);
     }
 
     @Override

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/WebacAclImpl.java
@@ -40,6 +40,7 @@ public class WebacAclImpl extends ContainerImpl implements WebacAcl {
      * @param transaction the current transactionId
      * @param pSessionManager a session manager
      * @param resourceFactory a resource factory instance.
+     * @param userTypesCache the user types cache
      */
     public WebacAclImpl(final FedoraId fedoraID,
                         final Transaction transaction,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/AbstractService.java
@@ -27,6 +27,7 @@ import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.ACLAuthorizationConstraintViolationException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
@@ -104,6 +105,9 @@ public abstract class AbstractService {
 
     @Inject
     protected FedoraPropsConfig fedoraPropsConfig;
+
+    @Inject
+    protected UserTypesCache userTypesCache;
 
     /**
      * Utility to determine the correct interaction model from elements of a request.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImpl.java
@@ -166,6 +166,7 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
 
         try {
             pSession.persist(createOp);
+            userTypesCache.cacheUserTypes(descId, Collections.emptyList(), pSession.getId());
         } catch (final PersistentStorageException exc) {
             throw new RepositoryRuntimeException(String.format("failed to create description %s", descId), exc);
         }
@@ -205,6 +206,9 @@ public class CreateResourceServiceImpl extends AbstractService implements Create
         } catch (final PersistentStorageException exc) {
             throw new RepositoryRuntimeException(String.format("failed to create resource %s", fedoraId), exc);
         }
+
+        userTypesCache.cacheUserTypes(fedoraId,
+                fromModel(model.getResource(fedoraId.getFullId()).asNode(), model), pSession.getId());
 
         updateReferences(tx, fedoraId, userPrincipal, model);
         addToContainmentIndex(tx, parentId, fedoraId);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -469,11 +469,12 @@ public class MembershipServiceImpl implements MembershipService {
         if (!(fedoraResc instanceof Container)) {
             return null;
         }
-        if (fedoraResc.hasType(RdfLexicon.INDIRECT_CONTAINER.getURI())) {
+
+        if (RdfLexicon.INDIRECT_CONTAINER.getURI().equals(fedoraResc.getInteractionModel())) {
             return ContainerType.Indirect;
         }
 
-        if (fedoraResc.hasType(RdfLexicon.DIRECT_CONTAINER.getURI())) {
+        if (RdfLexicon.DIRECT_CONTAINER.getURI().equals(fedoraResc.getInteractionModel())) {
             return ContainerType.Direct;
         }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -87,6 +87,10 @@ public class MembershipServiceImpl implements MembershipService {
             return;
         }
 
+        if (isChildOfRoot(fedoraResc)) {
+            return;
+        }
+
         final var parentResc = getParentResource(fedoraResc);
         final var containerProperties = new DirectContainerProperties(parentResc);
 
@@ -110,6 +114,10 @@ public class MembershipServiceImpl implements MembershipService {
             } else {
                 modifyDCOnDemandVersioning(tx, fedoraResc);
             }
+        }
+
+        if (isChildOfRoot(fedoraResc)) {
+            return;
         }
 
         final var parentResc = getParentResource(fedoraResc);
@@ -258,6 +266,10 @@ public class MembershipServiceImpl implements MembershipService {
         if (resourceContainerType != null) {
             log.debug("Ending membership for deleted Direct/IndirectContainer {} in {}", fedoraId, transaction);
             indexManager.endMembershipForSource(transaction, fedoraId, fedoraResc.getLastModifiedDate());
+        }
+
+        if (isChildOfRoot(fedoraResc)) {
+            return;
         }
 
         // delete child of DirectContainer, clear from tx and end existing
@@ -471,6 +483,10 @@ public class MembershipServiceImpl implements MembershipService {
     @Override
     public Instant getLastUpdatedTimestamp(final Transaction transaction, final FedoraId fedoraId) {
         return indexManager.getLastUpdated(transaction, fedoraId);
+    }
+
+    private boolean isChildOfRoot(final FedoraResource resource) {
+        return resource.getParentId().isRepositoryRoot();
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -99,6 +99,10 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
             }
 
             pSession.persist(primaryOp);
+
+            userTypesCache.cacheUserTypes(fedoraId,
+                    fromModel(inputModel.getResource(fedoraId.getFullId()).asNode(), inputModel), pSession.getId());
+
             updateReferences(tx, fedoraId, userPrincipal, inputModel);
             membershipService.resourceModified(tx, fedoraId);
             searchIndex.addUpdateIndex(tx, pSession.getHeaders(fedoraId, null));

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.fcrepo.common.db.DbTransactionExecutor;
 import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.lock.ResourceLockManager;
@@ -91,6 +92,9 @@ public class TransactionImplTest {
     @Mock
     private ResourceLockManager resourceLockManager;
 
+    @Mock
+    private UserTypesCache userTypesCache;
+
     @Before
     public void setUp() {
         testTx = new TransactionImpl("123", txManager, Duration.ofMillis(180000));
@@ -103,6 +107,7 @@ public class TransactionImplTest {
         when(txManager.getSearchIndex()).thenReturn(this.searchIndex);
         when(txManager.getDbTransactionExecutor()).thenReturn(new DbTransactionExecutor());
         when(txManager.getResourceLockManager()).thenReturn(resourceLockManager);
+        when(txManager.getUserTypesCache()).thenReturn(userTypesCache);
     }
 
     @Test

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import org.fcrepo.common.db.DbTransactionExecutor;
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
 import org.fcrepo.kernel.api.exception.TransactionNotFoundException;
 import org.fcrepo.kernel.api.lock.ResourceLockManager;
@@ -87,6 +88,9 @@ public class TransactionManagerImplTest {
     @Mock
     private ResourceLockManager resourceLockManager;
 
+    @Mock
+    private UserTypesCache userTypesCache;
+
     private FedoraPropsConfig fedoraPropsConfig;
 
     @Before
@@ -104,6 +108,7 @@ public class TransactionManagerImplTest {
         setField(testTxManager, "dbTransactionExecutor", new DbTransactionExecutor());
         setField(testTxManager, "fedoraPropsConfig", fedoraPropsConfig);
         setField(testTxManager, "resourceLockManager", resourceLockManager);
+        setField(testTxManager, "userTypesCache", userTypesCache);
         testTx = (TransactionImpl) testTxManager.create();
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/cache/UserTypesCacheImplTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.kernel.impl.cache;
+
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.riot.RDFFormat.NTRIPLES;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.kernel.api.RdfStream;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFDataMgr;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author pwinckles
+ */
+public class UserTypesCacheImplTest {
+
+    private static final URI ANIMAL_TYPE = URI.create("http://example.org/#Animal");
+    private static final URI CAT_TYPE = URI.create("http://example.org/#Cat");
+
+    private UserTypesCacheImpl cache;
+
+    private FedoraId fedoraId;
+
+    private String sessionId;
+
+    private String sessionId2;
+
+    @Before
+    public void setup() {
+        final var props = new FedoraPropsConfig();
+        props.setUserTypesCacheSize(1024);
+        props.setUserTypesCacheTimeout(10);
+        cache = new UserTypesCacheImpl(props);
+
+        fedoraId = FedoraId.create(UUID.randomUUID().toString());
+        sessionId = UUID.randomUUID().toString();
+        sessionId2 = UUID.randomUUID().toString();
+    }
+
+    @Test
+    public void loadTriplesWhenNotCached() {
+        final var types = cache.getUserTypes(fedoraId, sessionId, rdfSupplier(ANIMAL_TYPE, CAT_TYPE));
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE, CAT_TYPE));
+    }
+
+    @Test
+    public void loadFromCacheWhenCached() {
+        cache.getUserTypes(fedoraId, sessionId, rdfSupplier(ANIMAL_TYPE, CAT_TYPE));
+
+        final var types = cache.getUserTypes(fedoraId, sessionId, noCallSupplier());
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE, CAT_TYPE));
+    }
+
+    @Test
+    public void manuallyCachedTypesAreOnlyAvailableInSession() {
+        cache.cacheUserTypes(fedoraId, List.of(ANIMAL_TYPE), sessionId);
+
+        var types = cache.getUserTypes(fedoraId, sessionId, noCallSupplier());
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE));
+
+        types = cache.getUserTypes(fedoraId, sessionId2, rdfSupplier(ANIMAL_TYPE, CAT_TYPE));
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE, CAT_TYPE));
+    }
+
+    @Test
+    public void mergeCacheMakesTypesGloballyAvailable() {
+        cache.cacheUserTypes(fedoraId, List.of(ANIMAL_TYPE), sessionId);
+        cache.mergeSessionCache(sessionId);
+
+        final var types = cache.getUserTypes(fedoraId, sessionId2, noCallSupplier());
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE));
+    }
+
+    @Test
+    public void droppingCacheRemovesSessionCache() {
+        cache.cacheUserTypes(fedoraId, List.of(ANIMAL_TYPE), sessionId);
+
+        var types = cache.getUserTypes(fedoraId, sessionId, noCallSupplier());
+        assertThat(types, containsInAnyOrder(ANIMAL_TYPE));
+
+        cache.dropSessionCache(sessionId);
+
+        types = cache.getUserTypes(fedoraId, sessionId, rdfSupplier(CAT_TYPE));
+        assertThat(types, containsInAnyOrder(CAT_TYPE));
+    }
+
+    private Supplier<RdfStream> noCallSupplier() {
+        return () -> {
+            throw new RuntimeException("Should not be called");
+        };
+    }
+
+    private Supplier<RdfStream> rdfSupplier(final URI... types) {
+        return () -> createRdfStream(types);
+    }
+
+    private RdfStream createRdfStream(final URI... types) {
+        final var builder = new StringBuilder();
+
+        for (final var type : types) {
+            builder.append("<> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <").append(type).append(">.\n");
+        }
+
+        final Model model = createDefaultModel();
+        RDFDataMgr.read(model, IOUtils.toInputStream(builder.toString(), StandardCharsets.UTF_8), NTRIPLES.getLang());
+        return DefaultRdfStream.fromModel(createURI(fedoraId.getFullId()), model);
+    }
+
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/ContainerImplTest.java
@@ -73,7 +73,7 @@ public class ContainerImplTest {
 
         when(resourceFactory.getChildren(transaction, fedoraId)).thenReturn(childrenStream);
 
-        final Container container = new ContainerImpl(fedoraId, transaction, sessionManager, resourceFactory);
+        final Container container = new ContainerImpl(fedoraId, transaction, sessionManager, resourceFactory, null);
 
         final var resultStream = container.getChildren();
         final var childrenList = resultStream.collect(Collectors.toList());

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/FedoraResourceImplTest.java
@@ -158,7 +158,7 @@ public class FedoraResourceImplTest {
 
         when(transaction.isShortLived()).thenReturn(true);
 
-        final var resource = new FedoraResourceImpl(FEDORA_ID, transaction, sessionManager, resourceFactory);
+        final var resource = new FedoraResourceImpl(FEDORA_ID, transaction, sessionManager, resourceFactory, null);
         resource.setInteractionModel(BASIC_CONTAINER.toString());
         resource.setIsArchivalGroup(false);
         final var resourceTypes = resource.getTypes();
@@ -181,7 +181,7 @@ public class FedoraResourceImplTest {
         final var userStream = fromModel(subject.asNode(), userModel);
 
         final var description = new NonRdfSourceDescriptionImpl(descriptionFedoraId, null, sessionManager,
-                resourceFactory);
+                resourceFactory, null);
 
         when(resourceFactory.getResource(any(Transaction.class), eq(descriptionFedoraId))).thenReturn(description);
         when(sessionManager.getReadOnlySession()).thenReturn(psSession);
@@ -199,7 +199,7 @@ public class FedoraResourceImplTest {
 
         when(transaction.isShortLived()).thenReturn(true);
 
-        final var resource = new BinaryImpl(FEDORA_ID, transaction, sessionManager, resourceFactory);
+        final var resource = new BinaryImpl(FEDORA_ID, transaction, sessionManager, resourceFactory, null);
         resource.setInteractionModel(NON_RDF_SOURCE.toString());
         resource.setIsArchivalGroup(false);
         final var resourceTypes = resource.getTypes();
@@ -214,7 +214,7 @@ public class FedoraResourceImplTest {
 
     @Test
     public void testGetChildren() {
-        final var resource = new FedoraResourceImpl(FEDORA_ID, null, sessionManager, resourceFactory);
+        final var resource = new FedoraResourceImpl(FEDORA_ID, null, sessionManager, resourceFactory, null);
         assertEquals(0, resource.getChildren().count());
     }
 
@@ -227,7 +227,8 @@ public class FedoraResourceImplTest {
     }
 
     private FedoraResource resourceWithMockedTimeMap() {
-        final var resource = spy(new FedoraResourceImpl(FEDORA_ID, null, sessionManager, resourceFactory));
+        final var resource = spy(new FedoraResourceImpl(FEDORA_ID, null, sessionManager,
+                resourceFactory, null));
         doReturn(timeMap).when(resource).getTimeMap();
         return resource;
     }
@@ -235,7 +236,7 @@ public class FedoraResourceImplTest {
     private FedoraResource memento(final String id, final Instant instant) {
         final String mementoTime = VersionService.MEMENTO_LABEL_FORMATTER.format(instant);
         final FedoraId fedoraID = FedoraId.create(id, FCR_VERSIONS, mementoTime);
-        final var memento = new FedoraResourceImpl(fedoraID, null, sessionManager, resourceFactory);
+        final var memento = new FedoraResourceImpl(fedoraID, null, sessionManager, resourceFactory, null);
         memento.setIsMemento(true);
         memento.setMementoDatetime(instant);
         return memento;

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/models/TimeMapImplTest.java
@@ -196,7 +196,7 @@ public class TimeMapImplTest {
 
     private FedoraResource createParent(final String id) {
         final var fedoraId = FedoraId.create(id);
-        final var parent = new ContainerImpl(fedoraId, transaction, sessionManager, resourceFactory);
+        final var parent = new ContainerImpl(fedoraId, transaction, sessionManager, resourceFactory, null);
 
         parent.setCreatedBy("createdBy");
         parent.setCreatedDate(Instant.now());

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/CreateResourceServiceImplTest.java
@@ -57,6 +57,7 @@ import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.config.ServerManagedPropsMode;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.InteractionModelViolationException;
 import org.fcrepo.kernel.api.exception.RequestWithAclLinkHeaderException;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
@@ -157,6 +158,9 @@ public class CreateResourceServiceImplTest {
     @Mock
     private EventAccumulator eventAccumulator;
 
+    @Mock
+    private UserTypesCache userTypesCache;
+
     @InjectMocks
     private CreateResourceServiceImpl createResourceService;
 
@@ -196,6 +200,7 @@ public class CreateResourceServiceImplTest {
         setField(createResourceService, "referenceService", referenceService);
         setField(createResourceService, "membershipService", membershipService);
         setField(createResourceService, "fedoraPropsConfig", propsConfig);
+        setField(createResourceService, "userTypesCache", userTypesCache);
         propsConfig.setServerManagedPropsMode(ServerManagedPropsMode.STRICT);
         when(psManager.getSession(ArgumentMatchers.any())).thenReturn(psSession);
         transaction = TestTransactionHelper.mockTransaction(TX_ID, false);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImplTest.java
@@ -36,6 +36,7 @@ import org.fcrepo.kernel.api.RdfCollectors;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.models.ResourceHeaders;
 import org.fcrepo.kernel.api.observer.EventAccumulator;
@@ -98,6 +99,9 @@ public class ReplacePropertiesServiceImplTest {
     @Mock
     private ResourceHeaders headers;
 
+    @Mock
+    private UserTypesCache userTypesCache;
+
     @InjectMocks
     private UpdateRdfSourceOperation operation;
 
@@ -127,6 +131,7 @@ public class ReplacePropertiesServiceImplTest {
         setField(service, "membershipService", membershipService);
         setField(service, "searchIndex", searchIndex);
         setField(service, "fedoraPropsConfig", propsConfig);
+        setField(service, "userTypesCache", userTypesCache);
         propsConfig.setServerManagedPropsMode(ServerManagedPropsMode.STRICT);
         when(psManager.getSession(any(Transaction.class))).thenReturn(pSession);
         when(pSession.getHeaders(any(FedoraId.class), nullable(Instant.class))).thenReturn(headers);

--- a/fcrepo-kernel-impl/src/test/resources/membershipServiceTest.xml
+++ b/fcrepo-kernel-impl/src/test/resources/membershipServiceTest.xml
@@ -55,4 +55,7 @@
     
     <bean id="membershipService" class="org.fcrepo.kernel.impl.services.MembershipServiceImpl">
     </bean>
+
+    <bean id="userTypesCache" class="org.fcrepo.kernel.impl.cache.UserTypesCacheImpl">
+    </bean>
 </beans>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSession.java
@@ -234,6 +234,8 @@ public class OcflPersistentStorageSession implements PersistentStorageSession {
             throws PersistentStorageException {
         ensureCommitNotStarted();
 
+        LOGGER.debug("Getting triples for {} at {}", identifier, version);
+
         try (final InputStream is = getBinaryContent(identifier, version)) {
             final Model model = createDefaultModel();
             RDFDataMgr.read(model, is, OcflPersistentStorageUtils.getRdfFormat().getLang());


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3732

# What does this Pull Request do?

Adds a cache for user rdf types so that they do not need to be repeatedly loaded from disk.

# How should this be tested?

Everything should work the same as before except triples should never be loaded from disk when creating or updating resources. I added a new debug log that will log every time a resource's triples are loaded. If you enable debug logging you should be able to confirm that the triples are no longer read when creating resources.

Key things to look at:

1. Triples are not read when creating/updating any resource
2. Updating resources in transactions works and does not bleed outside the tx

# Interested parties
@fcrepo/committers
