### PR TITLE
do not log normal tx rollbacks

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -114,6 +114,7 @@ public class TransactionImpl implements Transaction {
             log.error("Failed to commit transaction: {}", id, ex);
 
             // Rollback on commit failure
+            log.info("Rolling back transaction {}", id);
             rollback();
             throw new RepositoryRuntimeException("Failed to commit transaction " + id, ex);
         }
@@ -131,8 +132,6 @@ public class TransactionImpl implements Transaction {
         }
 
         failIfCommitted();
-
-        log.info("Rolling back transaction {}", id);
 
         updateState(TransactionState.ROLLINGBACK);
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3765

# What does this Pull Request do?

1. No longer logs exceptions that are rolled back as part of normal cleanup

# How should this be tested?

Execute a GET against Fedora, wait around for 5 minutes or so, and see that no rollback messages were logged.

# Interested parties
@fcrepo/committers
