### PR TITLE
Display blank node triples in HTML UI

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/resource.vsl
+++ b/fcrepo-http-api/src/main/resources/views/resource.vsl
@@ -55,15 +55,16 @@
             <div class="panel-group" id="accordion">
             #foreach($subject in $model.listSubjects())
                 #if( $subject != $topic )
-                    <div class="panel panel-default" resource="$subject.getURI()">
-                        <div class="panel-heading collapsed" data-toggle="collapse" data-target="#$helpers.parameterize($subject.getURI())_triples" >
+                    #set( $subUri = #$helpers.getResourceId($subject) )
+                    <div class="panel panel-default" resource="$subUri">
+                        <div class="panel-heading collapsed" data-toggle="collapse" data-target="#$helpers.parameterize($subUri)_triples" >
                             #if( $subject.getURI() && $subject.getURI().startsWith("http") )
                                 <h3 class="ctitle panel-title"><a href="$subject.getURI()">$esc.html($helpers.getObjectTitle($rdf, $subject.asNode()))</a></h3>
                             #else
                                 <h3 class="ctitle panel-title">$esc.html($helpers.getObjectTitle($rdf, $subject.asNode()))</h3>
                             #end
                         </div>
-                        <div class="panel-collapse collapse"  id="$helpers.parameterize($subject.getURI())_triples">
+                        <div class="panel-collapse collapse"  id="$helpers.parameterize($subUri)_triples">
                             <div class="panel-body">
                                 #triples($subject.asNode())
                             </div>

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraHtmlIT.java
@@ -17,15 +17,18 @@
  */
 package org.fcrepo.integration.http.api;
 
+import static javax.ws.rs.core.HttpHeaders.ACCEPT;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static javax.ws.rs.core.HttpHeaders.ACCEPT;
 
 import java.io.IOException;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 import org.springframework.test.context.TestExecutionListeners;
@@ -110,6 +113,33 @@ public class FedoraHtmlIT extends AbstractResourceIT {
             final String html = EntityUtils.toString(response.getEntity());
             assertTrue(html, contains(html, "class=\"fcrepo_root\""));
         }
+    }
+
+    @Test
+    public void testGetBlankNodesInHtml() throws IOException {
+        final String blankNodeTtl = "@prefix test:  <info:fedora/test/> .\n" +
+                "@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .\n" +
+                "@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+                "@prefix fedora: <http://fedora.info/definitions/v4/repository#> .\n" +
+                "@prefix ldp:   <http://www.w3.org/ns/ldp#> .\n" +
+                "@prefix dc:    <http://purl.org/dc/elements/1.1/> .\n" +
+                "\n" +
+                "<> rdfs:label  \"dsa\" ;\n" +
+                "   test:test     _:b0 .\n" +
+                "\n" +
+                "_:b0 rdfs:label  \"r\" ;\n" +
+                "   dc:title    \"tq\" .";
+        final String pid = getRandomUniqueId();
+        final HttpPut putMethod = putObjMethod(pid, "text/turtle", blankNodeTtl);
+        assertEquals(CREATED.getStatusCode(), getStatus(putMethod));
+        // Can get as text/turtle
+        final HttpGet getTtl = getObjMethod(pid);
+        getTtl.addHeader(ACCEPT, "text/turtle");
+        assertEquals(OK.getStatusCode(), getStatus(getTtl));
+        // Can get with text/html
+        final HttpGet getHtml = getObjMethod(pid);
+        getHtml.addHeader(ACCEPT, "text/html");
+        assertEquals(OK.getStatusCode(), getStatus(getHtml));
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ViewHelpers.java
@@ -192,6 +192,26 @@ public class ViewHelpers {
     }
 
     /**
+     * Get the ID of a resource, this is the URI, blank node ID or just the local name. Used in resource.vsl
+     *
+     * @param res
+     *   The resource to get the ID for
+     * @return
+     *   The ID as a string.
+     */
+     public String getResourceId(final Resource res) {
+         if (res == null) {
+            return "";
+         } else if (res.isURIResource()) {
+            return res.getURI();
+         } else if (res.isAnon()) {
+            return res.getId().getLabelString();
+         } else {
+            return res.getLocalName();
+         }
+     }
+
+    /**
      * Determines whether the subject is writable
      * true if node is writable
      * @param graph the graph


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3773

# What does this Pull Request do?
When displaying triples in the HTML UI we expect the subject of all triples to be a URI. Blank nodes (while not recommended) are supported and don't have a URI in Jena.

This checks for the type of resource and finds something to use.

# How should this be tested?

Make a RDFResource with a blank node, get it with `Accept: text/turtle` and see the output. Get it with the HTML UI and get a 500 server error.
Pull in this PR and be able to see the blank node resource in the HTML UI.

There is a test as the first commit if you want to verify it fails before the actual fix.

# Interested parties
@fcrepo/committers
