### PR TITLE
upgrade to jena 4.2.0

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -94,7 +94,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFReader;
+import org.apache.jena.rdf.model.RDFReaderI;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.riot.Lang;
@@ -671,7 +671,7 @@ public class WebACFilter extends RequestContextFilter {
      */
     private URI getHasMemberFromRequest(final HttpServletRequest request) throws IOException {
         final String baseUri = request.getRequestURL().toString();
-        final RDFReader reader;
+        final RDFReaderI reader;
         final String contentType = request.getContentType();
         final Lang format = contentTypeToLang(contentType);
         final Model inputModel;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -82,7 +82,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -256,7 +255,7 @@ public class FedoraAcl extends ContentExposingResource {
     @GET
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
                 N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-                TURTLE_X, TEXT_HTML_WITH_CHARSET })
+                TEXT_HTML_WITH_CHARSET })
     public Response getResource()
             throws IOException, ItemNotFoundException {
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -21,6 +21,7 @@ import io.micrometer.core.annotation.Timed;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.shared.JenaException;
 
 import org.fcrepo.config.AuthPropsConfig;
@@ -339,7 +340,7 @@ public class FedoraAcl extends ContentExposingResource {
                 LOGGER.debug("Getting root authorization from file: {}", customRootAcl);
 
                 try (final var stream = new BufferedInputStream(Files.newInputStream(customRootAcl))) {
-                    RDFDataMgr.read(model, stream, baseUri, null);
+                    RDFDataMgr.read(model, stream, baseUri, RDFLanguages.pathnameToLang(customRootAcl.toString()));
                 }
 
                 return model;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -57,6 +57,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -336,10 +338,12 @@ public class FedoraAcl extends ContentExposingResource {
             try {
                 LOGGER.debug("Getting root authorization from file: {}", customRootAcl);
 
-                RDFDataMgr.read(model, customRootAcl.toString(), baseUri, null);
+                try (final var stream = new BufferedInputStream(Files.newInputStream(customRootAcl))) {
+                    RDFDataMgr.read(model, stream, baseUri, null);
+                }
 
                 return model;
-            } catch (final JenaException ex) {
+            } catch (final JenaException | IOException ex) {
                 throw new RuntimeException("Error parsing the default root ACL " + customRootAcl + ".", ex);
             }
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraFixity.java
@@ -27,7 +27,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -105,7 +104,7 @@ public class FedoraFixity extends ContentExposingResource {
     @GET
     @HtmlTemplate(value = "fcr:fixity")
     @Produces({TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8", N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET,
-            RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET, TURTLE_X, TEXT_HTML_WITH_CHARSET, "*/*"})
+            RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET, TEXT_HTML_WITH_CHARSET, "*/*"})
     public RdfNamespacedStream getDatastreamFixity() {
 
         if (!(resource() instanceof Binary)) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -45,7 +45,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_TYPE;
 import static org.fcrepo.http.commons.domain.RDFMediaType.APPLICATION_OCTET_STREAM_TYPE;
 
@@ -184,7 +183,7 @@ public class FedoraLdp extends ContentExposingResource {
     @HEAD
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
         N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-        TURTLE_X, TEXT_HTML_WITH_CHARSET })
+        TEXT_HTML_WITH_CHARSET })
     public Response head() throws UnsupportedAlgorithmException {
         LOGGER.info("HEAD for: {}", externalPath);
 
@@ -251,7 +250,7 @@ public class FedoraLdp extends ContentExposingResource {
     @GET
     @Produces({TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-            TURTLE_X, TEXT_HTML_WITH_CHARSET})
+            TEXT_HTML_WITH_CHARSET})
     public Response getResource(@HeaderParam("Range") final String rangeValue)
             throws IOException, UnsupportedAlgorithmException {
 
@@ -610,7 +609,7 @@ public class FedoraLdp extends ContentExposingResource {
     @Consumes({MediaType.APPLICATION_OCTET_STREAM + ";qs=1.000", WILDCARD})
     @Produces({TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
             N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-            TURTLE_X, TEXT_HTML_WITH_CHARSET, "*/*"})
+            TEXT_HTML_WITH_CHARSET, "*/*"})
     public Response createObject(@HeaderParam(CONTENT_DISPOSITION) final String contentDispositionRaw,
                                  @HeaderParam(CONTENT_TYPE) final MediaType requestContentType,
                                  @HeaderParam("Slug") final String slug,

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -69,7 +69,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_HTML_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_WITH_CHARSET;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -178,7 +177,7 @@ public class FedoraVersioning extends ContentExposingResource {
     @HtmlTemplate(value = "fcr:versions")
     @Produces({ TURTLE_WITH_CHARSET + ";qs=1.0", JSON_LD + ";qs=0.8",
         N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES, TEXT_PLAIN_WITH_CHARSET,
-        TURTLE_X, TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT })
+        TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT })
     public Response getVersionList(@HeaderParam("Accept") final String acceptValue) throws IOException {
 
         final FedoraResource theTimeMap = resource().getTimeMap();

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/RDFMediaType.java
@@ -24,7 +24,6 @@ import static org.apache.jena.riot.WebContent.contentTypeN3Alt2;
 import static org.apache.jena.riot.WebContent.contentTypeNTriples;
 import static org.apache.jena.riot.WebContent.contentTypeRDFXML;
 import static org.apache.jena.riot.WebContent.contentTypeTurtle;
-import static org.apache.jena.riot.WebContent.contentTypeTurtleAlt2;
 
 import java.util.List;
 
@@ -60,10 +59,6 @@ public abstract class RDFMediaType extends MediaType {
 
     public static final String TURTLE_WITH_CHARSET = TURTLE + CHARSET_UTF8;
 
-    public static final String TURTLE_X = contentTypeTurtleAlt2;
-
-    public static final MediaType TURTLE_X_TYPE = typeFromString(TURTLE_X);
-
     public static final String RDF_XML = contentTypeRDFXML;
 
     public static final MediaType RDF_XML_TYPE = typeFromString(RDF_XML);
@@ -84,11 +79,11 @@ public abstract class RDFMediaType extends MediaType {
 
     public static final List<Variant> POSSIBLE_RDF_VARIANTS = mediaTypes(
             RDF_XML_TYPE, TURTLE_TYPE, N3_TYPE, N3_ALT2_TYPE, NTRIPLES_TYPE,
-            TEXT_PLAIN_TYPE, TURTLE_X_TYPE, JSON_LD_TYPE).add().build();
+            TEXT_PLAIN_TYPE, JSON_LD_TYPE).add().build();
 
     public static final String[] POSSIBLE_RDF_RESPONSE_VARIANTS_STRING = {
         TURTLE_WITH_CHARSET, N3_WITH_CHARSET, N3_ALT2_WITH_CHARSET, RDF_XML, NTRIPLES,
-        TEXT_PLAIN_WITH_CHARSET, TURTLE_X, JSON_LD };
+        TEXT_PLAIN_WITH_CHARSET, JSON_LD };
 
     private static MediaType typeFromString(final String type) {
         return new MediaType(type.split("/")[0], type.split("/")[1]);

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/RdfStreamProvider.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/RdfStreamProvider.java
@@ -25,7 +25,6 @@ import static org.fcrepo.http.commons.domain.RDFMediaType.N3_ALT2;
 import static org.fcrepo.http.commons.domain.RDFMediaType.NTRIPLES;
 import static org.fcrepo.http.commons.domain.RDFMediaType.RDF_XML;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE_X;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.OutputStream;
@@ -47,7 +46,7 @@ import org.slf4j.Logger;
  * @since Nov 19, 2013
  */
 @Provider
-@Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, TURTLE_X, JSON_LD})
+@Produces({TURTLE, N3, N3_ALT2, RDF_XML, NTRIPLES, TEXT_PLAIN, JSON_LD})
 public class RdfStreamProvider implements MessageBodyWriter<RdfNamespacedStream> {
 
     private static final Logger LOGGER = getLogger(RdfStreamProvider.class);

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <jaxb.impl.version>2.3.1</jaxb.impl.version>
     <jackson2.version>2.12.3</jackson2.version>
     <jboss-logging.version>3.4.2.Final</jboss-logging.version>
-    <jena.version>3.17.0</jena.version>
+    <jena.version>4.2.0</jena.version>
     <jersey.version>2.34</jersey.version>
     <jetty.version>9.4.34.v20201102</jetty.version>
     <jgroups.version>5.1.7.Final</jgroups.version>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3767

# What does this Pull Request do?

Upgrades Jena to 4.2.0. This includes removing the mime type `application/x-turtle` because it was removed from Jena (https://issues.apache.org/jira/browse/JENA-2076)

# How should this be tested?

Everything should still work the same, but Fedora will no longer accept `application/x-turtle`

# Interested parties
@fcrepo/committers
