### PR TITLE
fixed utf-8 support for filenames

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1966,6 +1966,28 @@ public class FedoraLdpIT extends AbstractResourceIT {
         // verifyContentDispositionFilename(location, filename1);
     }
 
+    @Test
+    public void testContentDispositionHeaderEncoding() throws ParseException, IOException {
+        final HttpPost method = postObjMethod();
+        final File img = new File("src/test/resources/test-objects/img.png");
+        final String filename = "浅顶软呢帽岩石.png";
+        final String filenamePart = "UTF-8''" + URLEncoder.encode(filename, UTF_8);
+        method.addHeader(CONTENT_TYPE, "application/png");
+        method.addHeader(CONTENT_DISPOSITION, "attachment; filename*=" + filenamePart);
+        method.setEntity(new FileEntity(img));
+        method.addHeader(LINK, NON_RDF_SOURCE_LINK_HEADER);
+
+        // Create a binary resource with content-disposition
+        final String location;
+        try (final CloseableHttpResponse response = execute(method)) {
+            assertEquals("Should be a 201 Created!", CREATED.getStatusCode(), getStatus(response));
+            location = getLocation(response);
+        }
+
+        // Retrieve the new resource and verify the content-disposition
+        verifyContentDispositionFilename(location, filenamePart);
+    }
+
     private void verifyContentDispositionFilename(final String location, final String filename)
             throws IOException, ParseException {
         final HttpHead head = new HttpHead(location);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1986,6 +1986,17 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
         // Retrieve the new resource and verify the content-disposition
         verifyContentDispositionFilename(location, filenamePart);
+
+        final HttpGet get = new HttpGet(location + "/" + FCR_METADATA);
+        try (final CloseableHttpResponse response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            try (final CloseableDataset dataset = getDataset(response)) {
+                final DatasetGraph graph = dataset.asDatasetGraph();
+                assertFalse(dataset.isEmpty());
+                assertTrue(graph.contains(ANY, createURI(location), HAS_ORIGINAL_NAME.asNode(),
+                        createLiteral(filename)));
+            }
+        }
     }
 
     private void verifyContentDispositionFilename(final String location, final String filename)


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3700

# What does this Pull Request do?

Allows users to specify filenames that contain non-ascii characters. This must be done in the form of `filename*=UTF-8''URL_ENCODED_NAME`.

# How should this be tested?

Create a resource with special characters:

```
curl -v -H'Link: <http://www.w3.org/ns/ldp#NonRDFSource>; rel="type"' --data-binary @README.md -H"Content-Disposition: attachment; filename*=UTF-8''%E6%B5%85%E9%A1%B6%E8%BD%AF%E5%91%A2%E5%B8%BD%E5%B2%A9%E7%9F%B3" -H"Content-type: text/plain" -XPOST http://localhost:8080/rest/ -ufedoraAdmin:fedoraAdmin
```

Check the headers:

```
curl -I -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/d788d515-4a6d-4f27-a005-6433f4a879a6
```

Check the binary description:

```
curl -v -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/d788d515-4a6d-4f27-a005-6433f4a879a6/fcr:metadata
```

Do the same for a resource without special characters, using the standard `filename=FILENAME`

# Interested parties
@fcrepo/committers
