### PR TITLE
fix binary desc mementos to return historic binary attributes

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -72,7 +72,10 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     @Override
     public FedoraResource getDescribedResource() {
         // Get a FedoraId for the binary
-        final FedoraId describedId = FedoraId.create(this.getFedoraId().getBaseId());
+        FedoraId describedId = getFedoraId().asBaseId();
+        if (getFedoraId().isMemento()) {
+            describedId = describedId.asMemento(getFedoraId().getMementoInstant());
+        }
         try {
             return this.resourceFactory.getResource(transaction, describedId);
         } catch (final PathNotFoundException e) {


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3785

**Note** This PR depends on https://github.com/fcrepo/fcrepo-storage-ocfl/pull/46

# What does this Pull Request do?

Fixes binary description mementos to return historic binary attributes, instead of the attributes from the most recent version.

# How should this be tested?

1. Create a binary resource
2. Get the binary description
3. Update the binary resource, changing name, content, or both
4. Get the binary description memento and verify it matches the original values

# Interested parties

@fcrepo/committers
