### PR TITLE
Async repository initialization

### DIFF
--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
@@ -15,9 +15,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Filter which blocks requests if the repository initialization is ongoing
  *
@@ -25,15 +22,12 @@ import org.slf4j.LoggerFactory;
  */
 public class RepositoryInitializationFilter implements Filter {
 
-    final Logger logger = LoggerFactory.getLogger(RepositoryInitializationFilter.class);
-
     @Inject
     private RepositoryInitializer initializer;
 
     @Override
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
         throws IOException, ServletException {
-        logger.info("Checking request for db init");
         if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
             throw new ServletException("Unable to handle non http request");
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
@@ -39,7 +39,7 @@ public class RepositoryInitializationFilter implements Filter {
         }
 
         final var httpResponse = (HttpServletResponse) response;
-        if (!initializer.isRebuildComplete()) {
+        if (!initializer.isInitializationComplete()) {
             httpResponse.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
             return;
         }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
@@ -35,7 +35,7 @@ public class RepositoryInitializationFilter implements Filter {
         throws IOException, ServletException {
         logger.info("Checking request for db init");
         if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
-            throw new ServletException("Unable to handle non-http request");
+            throw new ServletException("Unable to handle non http request");
         }
 
         final var httpResponse = (HttpServletResponse) response;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializationFilter.java
@@ -1,0 +1,49 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.persistence.ocfl;
+
+import java.io.IOException;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter which blocks requests if the repository initialization is ongoing
+ *
+ * @author mikejritter
+ */
+public class RepositoryInitializationFilter implements Filter {
+
+    final Logger logger = LoggerFactory.getLogger(RepositoryInitializationFilter.class);
+
+    @Inject
+    private RepositoryInitializer initializer;
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
+        throws IOException, ServletException {
+        logger.info("Checking request for db init");
+        if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+            throw new ServletException("Unable to handle non-http request");
+        }
+
+        final var httpResponse = (HttpServletResponse) response;
+        if (!initializer.isRebuildComplete()) {
+            httpResponse.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/RepositoryInitializer.java
@@ -64,7 +64,7 @@ public class RepositoryInitializer {
     @Inject
     private TransactionManager txManager;
 
-    private final AtomicBoolean rebuildComplete = new AtomicBoolean(false);
+    private final AtomicBoolean initializationComplete = new AtomicBoolean(false);
 
     // This is used in-place of @PostConstruct so that it is called _after_ the rest of context has been
     // completely initialized.
@@ -77,7 +77,7 @@ public class RepositoryInitializer {
             LOGGER.error("Failed to initialize repository", e);
             ((ConfigurableApplicationContext) event.getApplicationContext()).close();
         } finally {
-            rebuildComplete.set(true);
+            initializationComplete.set(true);
         }
     }
 
@@ -124,8 +124,8 @@ public class RepositoryInitializer {
         }
     }
 
-    public boolean isRebuildComplete() {
-        return rebuildComplete.get();
+    public boolean isInitializationComplete() {
+        return initializationComplete.get();
     }
 
 }

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -41,6 +42,7 @@ import com.google.common.eventbus.EventBus;
  * @author pwinckles
  */
 @Configuration
+@EnableAsync
 @EnableScheduling
 public class WebappConfig {
 

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -141,7 +141,7 @@ public class WebappConfig {
     }
 
     /**
-     * Filter to prevent http requests during reindexing
+     * Filter to prevent http requests during repo init
      *
      * @return the filter
      */

--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/WebappConfig.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
+import javax.servlet.Filter;
 
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.api.ExternalContentHandlerFactory;
@@ -21,6 +22,7 @@ import org.fcrepo.kernel.api.rdf.RdfNamespaceRegistry;
 
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.fcrepo.persistence.ocfl.RepositoryInitializationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -137,4 +139,15 @@ public class WebappConfig {
                 .expireAfterAccess(fedoraPropsConfig.getWebacCacheTimeout(), TimeUnit.MINUTES)
                 .maximumSize(fedoraPropsConfig.getWebacCacheSize()).build();
     }
+
+    /**
+     * Filter to prevent http requests during reindexing
+     *
+     * @return the filter
+     */
+    @Bean
+    public Filter repositoryInitializationFilter() {
+        return new RepositoryInitializationFilter();
+    }
+
 }

--- a/fcrepo-webapp/src/main/jetty-console/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/jetty-console/WEB-INF/web.xml
@@ -34,23 +34,33 @@
 
 	</servlet-mapping>
 
-    <servlet>
-        <servlet-name>prometheus</servlet-name>
-        <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>prometheus</servlet-name>
-        <url-pattern>/prometheus</url-pattern>
-    </servlet-mapping>
+  <servlet>
+      <servlet-name>prometheus</servlet-name>
+      <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+      <servlet-name>prometheus</servlet-name>
+      <url-pattern>/prometheus</url-pattern>
+  </servlet-mapping>
 
   <filter>
     <filter-name>ETagFilter</filter-name>
     <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>
   </filter>
 
+  <filter>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+  </filter>
+
   <filter-mapping>
     <filter-name>ETagFilter</filter-name>
     <url-pattern>/static/*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <url-pattern>/rest/*</url-pattern>
   </filter-mapping>
 
 </web-app>

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/no-auth-web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/no-auth-web.xml
@@ -34,23 +34,33 @@
 
 	</servlet-mapping>
 
-    <servlet>
-        <servlet-name>prometheus</servlet-name>
-        <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>prometheus</servlet-name>
-        <url-pattern>/prometheus</url-pattern>
-    </servlet-mapping>
+  <servlet>
+      <servlet-name>prometheus</servlet-name>
+      <servlet-class>org.fcrepo.http.commons.metrics.PrometheusMetricsServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+      <servlet-name>prometheus</servlet-name>
+      <url-pattern>/prometheus</url-pattern>
+  </servlet-mapping>
 
   <filter>
     <filter-name>ETagFilter</filter-name>
     <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>
   </filter>
 
+  <filter>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+  </filter>
+
   <filter-mapping>
     <filter-name>ETagFilter</filter-name>
     <url-pattern>/static/*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <url-pattern>/rest/*</url-pattern>
   </filter-mapping>
 
 </web-app>

--- a/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fcrepo-webapp/src/main/webapp/WEB-INF/web.xml
@@ -74,12 +74,22 @@
     <filter-class>org.springframework.web.filter.ShallowEtagHeaderFilter</filter-class>
   </filter>
 
+  <filter>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+  </filter>
+
   <!-- Make sure any request you want accessible to Shiro is filtered. /* catches all -->
   <!-- requests.  Usually this filter mapping is defined first (before all others) to -->
   <!-- ensure that Shiro works in subsequent filters in the filter chain:             -->
   <filter-mapping>
       <filter-name>shiroFilter</filter-name>
       <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter-mapping>
+    <filter-name>repositoryInitializationFilter</filter-name>
+    <url-pattern>/rest/*</url-pattern>
   </filter-mapping>
 
   <filter-mapping>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3735

# What does this Pull Request do?

This makes the RepositoryInitializer async and adds a filter to block requests on `/rest/` until initialization is complete.

# How should this be tested?

In order to test this I had the `RepositoryInitializer` sleep in `onApplicationEvent` in order to simulate a long rebuild and issued a GET on `/rest/` during the rebuild.

start fedora:
```
 mvn jetty:run -pl fcrepo-webapp -Dfcrepo.log=DEBUG
```
then issue a request on `/rest/` expecting a 503 to be returned:
```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest
```
also issue a request on `/prometheus` expecting it not to be caught by the filter:
```
curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/prometheus
```

# Additional Notes

Although the ticket mentions this for only the rebuild, I opted to go for the rest of the repository initialization as we would have had to block in the `RepositoryInitializer` until the rebuild completed. 

It would also be good to test this with a prometheus + grafana instance running, which is something I haven't gotten around to testing yet.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
