### PR TITLE
Suppress events on rebuild.

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ReadOnlyTransaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ReadOnlyTransaction.java
@@ -142,4 +142,9 @@ public class ReadOnlyTransaction implements Transaction {
     public void setUserAgent(final String userAgent) {
         // no-op
     }
+
+    @Override
+    public void suppressEvents() {
+        // no-op
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/Transaction.java
@@ -156,4 +156,9 @@ public interface Transaction {
      */
     void setUserAgent(final String userAgent);
 
+    /**
+     * After invoking, any accumulated events will be suppressed.
+     */
+    void suppressEvents();
+
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -100,7 +100,10 @@ public class TransactionImpl implements Transaction {
             updateState(TransactionState.COMMITTED);
             if (!this.suppressEvents) {
                 this.getEventAccumulator().emitEvents(this, baseUri, userAgent);
+            } else {
+                this.getEventAccumulator().clearEvents(this);
             }
+
             releaseLocks();
             log.debug("Committed transaction {}", id);
         } catch (final Exception ex) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionImpl.java
@@ -25,7 +25,6 @@ import org.fcrepo.kernel.api.services.MembershipService;
 import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.persistence.api.PersistentStorageSession;
 import org.fcrepo.search.api.SearchIndex;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +56,8 @@ public class TransactionImpl implements Transaction {
     private final Duration sessionTimeout;
 
     private final Phaser operationPhaser;
+
+    private boolean suppressEvents = false;
 
     protected TransactionImpl(final String id,
                               final TransactionManagerImpl txManager,
@@ -97,7 +98,9 @@ public class TransactionImpl implements Transaction {
             }
 
             updateState(TransactionState.COMMITTED);
-            this.getEventAccumulator().emitEvents(this, baseUri, userAgent);
+            if (!this.suppressEvents) {
+                this.getEventAccumulator().emitEvents(this, baseUri, userAgent);
+            }
             releaseLocks();
             log.debug("Committed transaction {}", id);
         } catch (final Exception ex) {
@@ -289,6 +292,11 @@ public class TransactionImpl implements Transaction {
     @Override
     public void setUserAgent(final String userAgent) {
         this.userAgent = userAgent;
+    }
+
+    @Override
+    public void suppressEvents() {
+        this.suppressEvents = true;
     }
 
     private void doCommitShortLived() {

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionImplTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Stopwatch;
 import org.fcrepo.common.db.DbTransactionExecutor;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.cache.UserTypesCache;
@@ -38,8 +39,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import com.google.common.base.Stopwatch;
 
 /**
  * <p>
@@ -299,5 +298,20 @@ public class TransactionImplTest {
         verify(psSession).rollback();
         verify(containmentIndex).rollbackTransaction(testTx);
         verify(eventAccumulator).clearEvents(testTx);
+    }
+
+    @Test
+    public void testSuppressEvents() {
+        testTx.suppressEvents();
+        testTx.commit();
+        verify(eventAccumulator, times(0))
+                .emitEvents(testTx, null, null);
+    }
+
+    @Test
+    public void testNoEventSuppression() {
+        testTx.commit();
+        verify(eventAccumulator, times(1))
+                .emitEvents(testTx, null, null);
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexWorker.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/ReindexWorker.java
@@ -94,6 +94,7 @@ public class ReindexWorker implements Runnable {
                 }
 
                 final Transaction tx = txManager.create();
+                tx.suppressEvents();
                 tx.setShortLived(true);
                 if (stopwatch.elapsed(TimeUnit.SECONDS) > REPORTING_INTERVAL_SECS) {
                     manager.updateComplete(completed, errors);


### PR DESCRIPTION
**Suppress events on rebuild.**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3792
* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR causes Fedora to suppress all events during the rebuild process.  Prior to this change,  object creation events were not being generated on rebuild since they are recorded during creation of the ocfl resource.  As a result only events that involve index updates (such as inbound reference updates) were being generated.  Since event generation is connected to the request (from which the base url is resolved) this was causing the NPE symptom since rebuild make use of the fcrepo.jms.baseUrl property.  

Since we neither want to require the use of fcrepo.jms.baseUrl nor generate a subset of repo events, the most straightforward solution I believe is to simply suppress all events for now during rebuild.

# How should this be tested?
1. fire up fedora
2. Do the following

```
curl -X PUT -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test1"
curl -X PUT -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test2"

curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test1" -X PATCH -H "Content-Type: application/sparql-update" --data "INSERT DATA { <> <http://relation/pointat> <http://localhost:8080/rest/test2>. }"

curl -u fedoraAdmin:fedoraAdmin "http://localhost:8080/rest/test2" -X PATCH -H "Content-Type: application/sparql-update" --data "INSERT DATA { <> <http://relation/pointat> <http://localhost:8080/rest/test1>. }"
```
3. delete everything but ocfl-root in your data directory
4. restart fedora and validate that it comes up without the NPE.


A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
