### PR TITLE
Make a query param to change content-disposition from attachment to inline

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -428,7 +428,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
                 final var uri = new URI(identifierConverter().toExternalId(agFedoraId.getFullId()));
                 final var link = buildLink(uri, "archival-group");
                 servletResponse.addHeader(LINK, link);
-            } catch (URISyntaxException e) {
+            } catch (final URISyntaxException e) {
                 throw new BadRequestException(e);
             }
         });
@@ -590,15 +590,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource instanceof Binary) {
             final Binary binary = (Binary)resource;
 
-            final var dispositionBuilder = ContentDisposition.builder("attachment")
-                    .size(binary.getContentSize());
-
-            if (binary.getCreatedDate() != null) {
-                dispositionBuilder.creationDate(binary.getCreatedDate().atZone(ZoneOffset.UTC));
-            }
-            if (binary.getLastModifiedDate() != null) {
-                dispositionBuilder.modificationDate(binary.getLastModifiedDate().atZone(ZoneOffset.UTC));
-            }
+            final var dispositionBuilder = ContentDisposition.inline();
 
             if (StringUtils.isNotBlank(binary.getFilename())) {
                 if (ISO_8859_1_ENCODER.canEncode(binary.getFilename())) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -409,7 +409,7 @@ public class FedoraLdpTest {
     public void testHead() throws Exception {
         setResource(FedoraResource.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
@@ -423,7 +423,7 @@ public class FedoraLdpTest {
     public void testHeadWithArchivalGroup() {
         setResourceWithArchivalGroup(FedoraResource.class, FedoraId.create(FEDORA_ID_PREFIX));
         when(mockRequest.getMethod()).thenReturn("HEAD");
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
@@ -441,7 +441,7 @@ public class FedoraLdpTest {
     public void testHeadWithObject() throws Exception {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
         assertTrue("Should advertise Accept-Patch flavors", mockResponse.containsHeader(
@@ -452,7 +452,7 @@ public class FedoraLdpTest {
     public void testHeadWithDefaultContainer() throws Exception {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPBasicContainer();
     }
@@ -467,17 +467,17 @@ public class FedoraLdpTest {
         final FedoraResource resource = setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
         when(resource.hasType(BASIC_CONTAINER.toString())).thenReturn(true);
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPBasicContainer();
     }
 
     @Test
     public void testHeadWithDirectContainer() throws Exception {
-        final FedoraResource resource = setResource(Container.class);
+        setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
         typeList.add(URI.create(DIRECT_CONTAINER.toString()));
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPDirectContainer();
     }
@@ -489,10 +489,10 @@ public class FedoraLdpTest {
 
     @Test
     public void testHeadWithIndirectContainer() throws Exception {
-        final FedoraResource resource = setResource(Container.class);
+        setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("HEAD");
         typeList.add(URI.create(INDIRECT_CONTAINER.toString()));
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPIndirectContainer();
     }
@@ -509,7 +509,7 @@ public class FedoraLdpTest {
         when(mockResource.getDescription()).thenReturn(mockNonRdfSourceDescription);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getMimeType()).thenReturn("image/jpeg");
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertContentLengthGreaterThan0(mockResponse.getHeader(CONTENT_LENGTH));
         assertShouldBeAnLDPNonRDFSource();
@@ -555,7 +555,7 @@ public class FedoraLdpTest {
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
         when(mockResource.getExternalURL()).thenReturn(url);
         when(mockResource.getExternalURI()).thenReturn(URI.create(url));
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
         assertEquals(new URI(url), actual.getLocation());
         assertShouldBeAnLDPNonRDFSource();
@@ -570,7 +570,7 @@ public class FedoraLdpTest {
         when(mockRequest.getMethod()).thenReturn("HEAD");
         when(mockResource.getDescribedResource()).thenReturn(mockBinary);
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
-        final Response actual = testObj.head();
+        final Response actual = testObj.head(false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP RDFSource",
             mockResponse.getHeaders(LINK).contains(buildLink(RDF_SOURCE.getURI(), "type")));
@@ -643,7 +643,7 @@ public class FedoraLdpTest {
         setField(testObj, "externalPath", path);
         when(mockRequest.getMethod()).thenReturn("GET");
         when(resourceFactory.getResource((Transaction)any(), any(FedoraId.class))).thenReturn(resource);
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should have a Link header", mockResponse.containsHeader(LINK));
         assertTrue("Should have an Allow header", mockResponse.containsHeader("Allow"));
@@ -662,7 +662,7 @@ public class FedoraLdpTest {
     public void testGetWithObject() throws Exception {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertTrue("Should advertise Accept-Post flavors", mockResponse.containsHeader("Accept-Post"));
         assertShouldAdvertiseAcceptPatchFlavors();
@@ -671,7 +671,7 @@ public class FedoraLdpTest {
             final Model model = entity.stream.collect(toModel());
             final List<String> rdfNodes = model.listObjects().mapWith(RDFNode::toString).toList();
             assertTrue("Expected RDF contexts missing", rdfNodes.containsAll(ImmutableSet.of(
-                    "LDP_CONTAINMENT", "PROPERTIES", "SERVER_MANAGED")));
+                    "LDP_CONTAINMENT", "PROPERTIES", "SERVER_MANAGED", "LDP_MEMBERSHIP")));
             // TODO: Above list is missing LDP_MEMBERSHIP - https://jira.lyrasis.org/browse/FCREPO-3165
         }
     }
@@ -681,7 +681,7 @@ public class FedoraLdpTest {
     public void testGetWithBasicContainer() throws Exception {
         final FedoraResource resource = setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPBasicContainer();
     }
@@ -691,7 +691,7 @@ public class FedoraLdpTest {
         final FedoraResource resource = setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
         typeList.add(URI.create(DIRECT_CONTAINER.toString()));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPDirectContainer();
     }
@@ -701,7 +701,7 @@ public class FedoraLdpTest {
         final FedoraResource resource = setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
         typeList.add(URI.create(INDIRECT_CONTAINER.toString()));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPIndirectContainer();
     }
@@ -712,7 +712,7 @@ public class FedoraLdpTest {
         setResource(Container.class);
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer", new MultiPrefer("return=minimal"));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         try (final RdfNamespacedStream entity = (RdfNamespacedStream) actual.getEntity()) {
@@ -811,7 +811,7 @@ public class FedoraLdpTest {
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + PREFER_CONTAINMENT + "\""));
-        final Response actual = testObj.getResource( null);
+        final Response actual = testObj.getResource( null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         try (final RdfNamespacedStream entity = (RdfNamespacedStream) actual.getEntity()) {
@@ -829,7 +829,7 @@ public class FedoraLdpTest {
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer",
                 new MultiPrefer("return=representation; omit=\"" + PREFER_MEMBERSHIP + "\""));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         try (final RdfNamespacedStream entity = (RdfNamespacedStream) actual.getEntity()) {
@@ -853,7 +853,7 @@ public class FedoraLdpTest {
         setResourceWithTriples(Container.class, triples);
         when(mockRequest.getMethod()).thenReturn("GET");
         setField(testObj, "prefer", new MultiPrefer("return=representation; include=\"" + INBOUND_REFERENCES + "\""));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         try (final RdfNamespacedStream entity = (RdfNamespacedStream) actual.getEntity()) {
@@ -874,7 +874,7 @@ public class FedoraLdpTest {
         when(mockResource.getMimeType()).thenReturn("text/plain");
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
         when(mockResource.getOriginalResource()).thenReturn(mockResource);
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
         assertShouldBeAnLDPNonRDFSource();
         assertShouldNotAdvertiseAcceptPatchFlavors();
@@ -901,7 +901,7 @@ public class FedoraLdpTest {
         when(mockResource.getExternalURI()).thenReturn(URI.create(url));
         when(mockResource.getExternalURL()).thenReturn(url);
         when(mockResource.getContent()).thenReturn(toInputStream("xyz", UTF_8));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(TEMPORARY_REDIRECT.getStatusCode(), actual.getStatus());
         assertTrue("Should be an LDP NonRDFSource", mockResponse.getHeaders(LINK).contains("<" +
                 NON_RDF_SOURCE + ">; rel=\"type\""));
@@ -949,7 +949,7 @@ public class FedoraLdpTest {
         when(mockBinary.getTriples())
             .thenReturn(new DefaultRdfStream(createURI("mockBinary"), of(new Triple
                     (createURI("mockBinary"), createURI("called"), createURI("child:properties")))));
-        final Response actual = testObj.getResource(null);
+        final Response actual = testObj.getResource(null, false);
         assertEquals(OK.getStatusCode(), actual.getStatus());
 
         assertTrue("Should be an LDP RDFSource",

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -672,7 +672,6 @@ public class FedoraLdpTest {
             final List<String> rdfNodes = model.listObjects().mapWith(RDFNode::toString).toList();
             assertTrue("Expected RDF contexts missing", rdfNodes.containsAll(ImmutableSet.of(
                     "LDP_CONTAINMENT", "PROPERTIES", "SERVER_MANAGED", "LDP_MEMBERSHIP")));
-            // TODO: Above list is missing LDP_MEMBERSHIP - https://jira.lyrasis.org/browse/FCREPO-3165
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -247,7 +247,11 @@ public abstract class AbstractResourceIT {
     }
 
     protected static HttpGet getDSMethod(final String pid, final String ds) {
-        return new HttpGet(serverAddress + pid + "/" + ds);
+        return getDSMethod(pid, ds, false);
+    }
+
+    protected static HttpGet getDSMethod(final String pid, final String ds, final boolean inline) {
+        return new HttpGet(serverAddress + pid + "/" + ds + (inline ? "?inline=true" : ""));
     }
 
     protected static HttpGet getDSDescMethod(final String pid, final String ds) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -340,7 +340,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             assertContentType(response, "image/jpeg");
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("attachment", disposition.getType());
+            assertEquals("inline", disposition.getType());
         }
     }
 
@@ -367,7 +367,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             assertEquals("bytes", response.getFirstHeader("Accept-Ranges").getValue());
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("attachment", disposition.getType());
+            assertEquals("inline", disposition.getType());
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/ExternalContentHandlerIT.java
@@ -317,17 +317,24 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
     }
 
     @Test
-    public void testHeadExternalDatastreamRedirectForHttpUri() throws Exception {
+    public void testHeadExternalDatastreamRedirectForHttpUriAttachment() throws Exception {
+        testHeadExternalDatastreamRedirectForHttpUri(false);
+    }
 
+    @Test
+    public void testHeadExternalDatastreamRedirectForHttpUriInline() throws Exception {
+        testHeadExternalDatastreamRedirectForHttpUri(true);
+    }
+
+    private void testHeadExternalDatastreamRedirectForHttpUri(final boolean inline) throws Exception {
         final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
-
         final String id = getRandomUniqueId();
         final HttpPut put = putObjMethod(id);
         put.addHeader(LINK, getExternalContentLinkHeader(externalLocation, "redirect", "image/jpeg"));
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
         // Configure HEAD request to NOT follow redirects
-        final HttpHead headObjMethod = headObjMethod(id);
+        final HttpHead headObjMethod = headObjMethod(id + (inline ? "?inline=true" : ""));
         final RequestConfig.Builder requestConfig = RequestConfig.custom();
         requestConfig.setRedirectsEnabled(false);
         headObjMethod.setConfig(requestConfig.build());
@@ -340,13 +347,25 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             assertContentType(response, "image/jpeg");
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("inline", disposition.getType());
+            if (inline) {
+                assertEquals("inline", disposition.getType());
+            } else {
+                assertEquals("attachment", disposition.getType());
+            }
         }
     }
 
     @Test
-    public void testGetExternalDatastreamForHttpUri() throws Exception {
+    public void testGetExternalDatastreamForHttpUriInline() throws Exception {
+        testGetExternalDatastreamForHttpUri(true);
+    }
 
+    @Test
+    public void testGetExternalDatastreamForHttpUriAttachment() throws Exception {
+        testGetExternalDatastreamForHttpUri(false);
+    }
+
+    private void testGetExternalDatastreamForHttpUri(final boolean inline) throws Exception {
         final String externalLocation = createHttpResource(TEST_BINARY_CONTENT);
 
         final String id = getRandomUniqueId();
@@ -355,7 +374,7 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
         assertEquals(CREATED.getStatusCode(), getStatus(put));
 
         // Configure HEAD request to NOT follow redirects
-        final HttpGet getObjMethod = getObjMethod(id);
+        final HttpGet getObjMethod = getObjMethod(id + (inline ? "?inline=true" : ""));
         final RequestConfig.Builder requestConfig = RequestConfig.custom();
         requestConfig.setRedirectsEnabled(false);
         getObjMethod.setConfig(requestConfig.build());
@@ -367,7 +386,11 @@ public class ExternalContentHandlerIT extends AbstractResourceIT {
             assertEquals("bytes", response.getFirstHeader("Accept-Ranges").getValue());
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("inline", disposition.getType());
+            if (inline) {
+                assertEquals("inline", disposition.getType());
+            } else {
+                assertEquals("attachment", disposition.getType());
+            }
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -511,7 +511,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals("bytes", response.getFirstHeader("Accept-Ranges").getValue());
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("attachment", disposition.getType());
+            assertEquals("inline", disposition.getType());
         }
     }
 
@@ -2186,7 +2186,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertEquals("bytes", response.getFirstHeader("Accept-Ranges").getValue());
             final ContentDisposition disposition =
                     new ContentDisposition(response.getFirstHeader(CONTENT_DISPOSITION).getValue());
-            assertEquals("attachment", disposition.getType());
+            assertEquals("inline", disposition.getType());
 
             final Collection<String> links = getLinkHeaders(response);
             final String describedByHeader =


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3791 & https://fedora-repository.atlassian.net/browse/FCREPO-1843

# What does this Pull Request do?
Adds a query parameter `inline`, that if set to `true` will result in the Content-Disposition being set to `inline`. Otherwise it remains `attachment`

This is also changed for HEAD requests, mementos and external content.

# How should this be tested?

Add a binary to a repository using main. 
GET the binary
* Through the HTML UI, see that pressing the "Download Content" button causes a save file dialog
* Through curl see the `Content-Disposition: attachment; size=79; creation-date="Wed, 24 Nov 2021 14:52:17 GMT"; modification-date="Wed, 24 Nov 2021 14:52:17 GMT"` header

Pull in this PR
GET the binary
* Through the HTML UI you cannot easily see this behaviour but if you go to a binary (which actually takes you to the description), remove `/fcr:metadata` and add `?inline=true` you will immediately gets the content.
* Through curl also add `?inline=true` and see the `Content-Disposition: inline; size=79; creation-date="Wed, 24 Nov 2021 14:52:17 GMT"; modification-date="Wed, 24 Nov 2021 14:52:17 GMT"` header (might have to do a HEAD if you use an image as your binary)

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
