### PR TITLE
Fix itest reset

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -162,7 +162,11 @@ public abstract class AbstractResourceIT {
     public void setLogger() throws InterruptedException {
         // must wait for the repo to be initialized
         final var initializer = getBean(RepositoryInitializer.class);
+        int i = 0;
         while (!initializer.isInitializationComplete()) {
+            if (++i > 6000) {
+                throw new RuntimeException("Repository failed to initialize");
+            }
             TimeUnit.MILLISECONDS.sleep(10);
         }
         logger = getLogger(this.getClass());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -46,6 +46,7 @@ import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.fcrepo.http.commons.test.util.ContainerWrapper;
 import org.fcrepo.kernel.api.auth.ACLHandle;
 
+import org.fcrepo.persistence.ocfl.RepositoryInitializer;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -158,7 +159,12 @@ public abstract class AbstractResourceIT {
     }
 
     @Before
-    public void setLogger() {
+    public void setLogger() throws InterruptedException {
+        // must wait for the repo to be initialized
+        final var initializer = getBean(RepositoryInitializer.class);
+        while (!initializer.isInitializationComplete()) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
         logger = getLogger(this.getClass());
         propsConfig = getBean(FedoraPropsConfig.class);
         authPropsConfig = getBean(AuthPropsConfig.class);

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TestIsolationExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TestIsolationExecutionListener.java
@@ -5,19 +5,18 @@
  */
 package org.fcrepo.integration.http.api;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import org.apache.commons.io.FileUtils;
 import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.persistence.ocfl.RepositoryInitializer;
-
-import org.apache.commons.io.FileUtils;
 import org.flywaydb.core.Flyway;
 import org.springframework.test.context.TestContext;
 
-import edu.wisc.library.ocfl.api.MutableOcflRepository;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Listener that baselines the DB and OCFL repo between every test.
@@ -28,10 +27,16 @@ import edu.wisc.library.ocfl.api.MutableOcflRepository;
 public class TestIsolationExecutionListener extends BaseTestExecutionListener {
 
     @Override
-    public void afterTestMethod(final TestContext testContext) throws Exception {
+    public void beforeTestMethod(final TestContext testContext) throws Exception {
         final var ocflRepo = getBean(testContext, MutableOcflRepository.class);
         final var ocflConfig = getBean(testContext, OcflPropsConfig.class);
         final var flyway = getBean(testContext, Flyway.class);
+        final var initializer = getBean(testContext, RepositoryInitializer.class);
+
+        // must wait for the initialization to finish
+        while (!initializer.isInitializationComplete()) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
 
         flyway.clean();
         flyway.migrate();
@@ -63,7 +68,6 @@ public class TestIsolationExecutionListener extends BaseTestExecutionListener {
             }
         }
 
-        final var initializer = getBean(testContext, RepositoryInitializer.class);
         initializer.initialize();
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TestIsolationExecutionListener.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TestIsolationExecutionListener.java
@@ -34,7 +34,11 @@ public class TestIsolationExecutionListener extends BaseTestExecutionListener {
         final var initializer = getBean(testContext, RepositoryInitializer.class);
 
         // must wait for the initialization to finish
+        int i = 0;
         while (!initializer.isInitializationComplete()) {
+            if (++i > 6000) {
+                throw new RuntimeException("Repository failed to initialize");
+            }
             TimeUnit.MILLISECONDS.sleep(10);
         }
 


### PR DESCRIPTION
# What does this Pull Request do?

Fixes the itests so that they are reset correctly between tests. Without this, GH Actions runs consistently fail. The problem is related to [the change](https://github.com/fcrepo/fcrepo/commit/5503287dd7b62eaaf3d6f4031cae82994c8dfc9d) that made Fedora start before the repo was initialized. In some instances the tests were being run while the initialization was still going. The code was changed to wait for the initialization to complete.

# How should this be tested?

Tests should pass

# Interested parties
@fcrepo/committers
