### PR TITLE
Move ACL cache clear to ReplacePropertiesService to catch both PATCH …

### DIFF
--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -5,6 +5,7 @@
  */
 package org.fcrepo.integration.auth.webac;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.stream;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
@@ -2416,5 +2417,80 @@ public class WebACRecipesIT extends AbstractResourceIT {
         final HttpPost txnCreatePost = postObjMethod("rest/fcr:tx");
         setAuth(txnCreatePost, "testUser92");
         assertEquals(SC_CREATED, getStatus(txnCreatePost));
+    }
+
+    @Test
+    public void testAlterAclWithPatch() throws IOException {
+        final String targetResource = "/rest/" + getRandomUniqueId();
+        final String username = "user88";
+        // Make a basic container.
+        final String targetUri = ingestObj(targetResource);
+        final String readwriteString = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
+                "<#readauthz> a acl:Authorization ;\n" +
+                "   acl:agent \"" + username + "\" ;\n" +
+                "   acl:mode acl:Read, acl:Write, acl:Append ;\n" +
+                "   acl:accessTo <" + targetResource + "> ;\n" +
+                "   acl:default <" + targetResource + "> .";
+        // Allow user to read and write this object.
+        ingestAclString(targetUri, readwriteString, "fedoraAdmin");
+
+        // Test we can append a container as username
+        final HttpPost okPost = postObjMethod(targetResource);
+        setAuth(okPost, username);
+        assertEquals(SC_CREATED, getStatus(okPost));
+
+        // Change the ACL to read-only for username
+        final String readonlyString = "prefix acl: <http://www.w3.org/ns/auth/acl#> " +
+                " DELETE { <#readauthz> acl:mode acl:Write . <#readauthz> acl:mode acl:Append .} WHERE {}";
+        final HttpPatch httpPatch = patchObjMethod(targetResource + "/fcr:acl");
+        setAuth(httpPatch, "fedoraAdmin");
+        httpPatch.setEntity(new StringEntity(readonlyString, UTF_8));
+        httpPatch.setHeader(CONTENT_TYPE, "application/sparql-update");
+        assertEquals(SC_NO_CONTENT, getStatus(httpPatch));
+
+        // Test we can't append a container as username
+        final HttpPost noPost = postObjMethod(targetResource);
+        setAuth(noPost, username);
+        assertEquals(SC_FORBIDDEN, getStatus(noPost));
+    }
+
+    @Test
+    public void testAlterAclWithPut() throws IOException {
+        final String targetResource = "/rest/" + getRandomUniqueId();
+        final String username = "user88";
+        // Make a basic container.
+        final String targetUri = ingestObj(targetResource);
+        final String readwriteString = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
+                "<#readauthz> a acl:Authorization ;\n" +
+                "   acl:agent \"" + username + "\" ;\n" +
+                "   acl:mode acl:Read, acl:Write, acl:Append ;\n" +
+                "   acl:accessTo <" + targetResource + "> ;\n" +
+                "   acl:default <" + targetResource + "> .";
+        // Allow user to read and write this object.
+        ingestAclString(targetUri, readwriteString, "fedoraAdmin");
+
+        // Test we can append a container as username
+        final HttpPost okPost = postObjMethod(targetResource);
+        setAuth(okPost, username);
+        assertEquals(SC_CREATED, getStatus(okPost));
+
+        // Change the ACL to read-only for username
+        final String readonlyString = "@prefix acl: <http://www.w3.org/ns/auth/acl#> .\n" +
+                "<#readauthz> a acl:Authorization ;\n" +
+                "   acl:agent \"" + username + "\" ;\n" +
+                "   acl:mode acl:Read ;\n" +
+                "   acl:accessTo <" + targetResource + "> ;\n" +
+                "   acl:default <" + targetResource + "> .";
+        final HttpPut httpPut = putObjMethod(targetResource + "/fcr:acl");
+        setAuth(httpPut, "fedoraAdmin");
+        httpPut.setEntity(new StringEntity(readonlyString, UTF_8));
+        httpPut.setHeader(CONTENT_TYPE, "text/turtle");
+        httpPut.setHeader("Prefer", "handling=lenient");
+        assertEquals(SC_NO_CONTENT, getStatus(httpPut));
+
+        // Test we can't append a container as username
+        final HttpPost noPost = postObjMethod(targetResource);
+        setAuth(noPost, username);
+        assertEquals(SC_FORBIDDEN, getStatus(noPost));
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
@@ -8,12 +8,9 @@ package org.fcrepo.kernel.impl.services;
 
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 
-import java.util.Optional;
-
 import javax.inject.Inject;
 
 import org.fcrepo.kernel.api.Transaction;
-import org.fcrepo.kernel.api.auth.ACLHandle;
 import org.fcrepo.kernel.api.exception.AccessDeniedException;
 import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.MalformedRdfException;
@@ -24,14 +21,12 @@ import org.fcrepo.kernel.api.services.UpdatePropertiesService;
 import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 import org.fcrepo.persistence.api.exceptions.PersistentItemNotFoundException;
 import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
-import org.springframework.stereotype.Component;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.update.UpdateAction;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
-
-import com.github.benmanes.caffeine.cache.Cache;
+import org.springframework.stereotype.Component;
 
 /**
  * This class implements the update properties operation.
@@ -47,9 +42,6 @@ public class UpdatePropertiesServiceImpl extends AbstractService implements Upda
     @Inject
     private PersistentStorageSessionManager persistentStorageSessionManager;
 
-    @Inject
-    private Cache<String, Optional<ACLHandle>> authHandleCache;
-
     @Override
     public void updateProperties(final Transaction tx, final String userPrincipal,
                                  final FedoraId fedoraId, final String sparqlUpdateStatement)
@@ -61,10 +53,6 @@ public class UpdatePropertiesServiceImpl extends AbstractService implements Upda
             final UpdateRequest request = UpdateFactory.create(sparqlUpdateStatement, fedoraId.getFullId());
             UpdateAction.execute(request, model);
             replacePropertiesService.perform(tx, userPrincipal, fedoraId, model);
-            if (fedoraId.isAcl()) {
-                // Flush ACL cache on any ACL creation/update/deletion.
-                authHandleCache.invalidateAll();
-            }
         } catch (final PersistentItemNotFoundException ex) {
             throw new ItemNotFoundException(ex.getMessage(), ex);
         } catch (final PersistentStorageException ex) {


### PR DESCRIPTION
…and PUT requests

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3795

# What does this Pull Request do?
We have an ACL cache to hold the resolved set of rules to avoid locating them multiple times. This cache is cleared when we update/delete an ACL.

Except we were only handling updates via PATCH and not PUT.

# How should this be tested?

Check out the two new integration tests, but basically.

This works:

1. Create a container.
2. Add an ACL giving a non-admin user Write or Append (or both) permissions.
3. See you can create a child to the above container as the non-admin user.
4. Update (PATCH) the ACL to give the non-admin user ONLY Read access to the container from step 1.
5. See you can not create another child to the above container.

This doesn't:

1. Create a container.
2. Add an ACL giving a non-admin user Write or Append (or both) permissions.
3. See you can create a child to the above container as the non-admin user.
4. Update (PUT) the ACL to give the non-admin user ONLY Read access to the container from step 1.
5. See you _can_ create another child to the above container.

This PR fixes the second case.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
