### PR TITLE
Re-add wildcard types and modify checks for acceptable types.

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -406,6 +406,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testHeadAnyContentType() throws IOException {
+        testDefaultContentType(RDFMediaType.WILDCARD, false);
+    }
+
+    @Test
     public void testGetTurtleContentType() throws IOException {
         testDefaultContentType(RDFMediaType.TURTLE_WITH_CHARSET, true);
     }
@@ -425,6 +430,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         testDefaultContentType(null, true);
     }
 
+    @Test
+    public void testGetAnyContentType() throws IOException {
+        testDefaultContentType(RDFMediaType.WILDCARD, true);
+    }
+
     private void testDefaultContentType(final String mimeType, final boolean isGet) throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
@@ -436,16 +446,20 @@ public class FedoraLdpIT extends AbstractResourceIT {
             req = headObjMethod(id);
         }
         String mt = mimeType;
+        final String returnType;
         if (mt != null) {
             req.addHeader("Accept", mt);
+            if (mt.equals(RDFMediaType.WILDCARD)) {
+                returnType = RDFMediaType.TURTLE_WITH_CHARSET;
+            } else {
+                returnType = mt;
+            }
         } else {
             mt = RDFMediaType.TURTLE_WITH_CHARSET;
+            returnType = mt;
         }
         try (final CloseableHttpResponse response = execute(req)) {
-            final Collection<String> contentTypes = getHeader(response, CONTENT_TYPE);
-            final String contentType = contentTypes.iterator().next();
-            assertTrue("Didn't find LDP valid content-type header: " + contentType +
-                    "; expected result: " + mt, contentType.contains(mt));
+            checkContentTypeMatches(response, returnType);
             testHeadVaryAndPreferHeaders(response);
         }
     }
@@ -3338,6 +3352,19 @@ public class FedoraLdpIT extends AbstractResourceIT {
         httpGet2.setHeader(ACCEPT, "application/pdf");
         assertEquals(OK.getStatusCode(), getStatus(httpGet2));
 
+        final HttpGet httpGet3 = new HttpGet(objectUrl);
+        httpGet3.addHeader(ACCEPT, "*/*");
+        try (final var response = execute(httpGet3)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            checkContentTypeMatches(response, "application/pdf");
+        }
+
+        final HttpGet httpGet4 = new HttpGet(objectUrl);
+        try (final var response = execute(httpGet4)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            checkContentTypeMatches(response, "application/pdf");
+        }
+
         final HttpHead httpHead = new HttpHead(objectUrl);
         httpHead.setHeader(ACCEPT, "image/tiff");
         assertEquals(NOT_ACCEPTABLE.getStatusCode(), getStatus(httpHead));
@@ -3345,6 +3372,26 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final HttpHead httpHead2 = new HttpHead(objectUrl);
         httpHead2.setHeader(ACCEPT, "application/pdf");
         assertEquals(OK.getStatusCode(), getStatus(httpHead2));
+
+        final HttpHead httpHead3 = new HttpHead(objectUrl);
+        httpHead3.setHeader(ACCEPT, "*/*");
+        try (final var response = execute(httpHead3)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            checkContentTypeMatches(response, "application/pdf");
+        }
+
+        final HttpHead httpHead4 = new HttpHead(objectUrl);
+        try (final var response = execute(httpHead4)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            checkContentTypeMatches(response, "application/pdf");
+        }
+    }
+
+    private static void checkContentTypeMatches(final CloseableHttpResponse response, final String contentType) {
+        final Collection<String> contentTypes = getHeader(response, CONTENT_TYPE);
+        final String type = contentTypes.iterator().next();
+        assertTrue("Didn't find LDP valid content-type header: " + type +
+                "; expected result: " + contentType, type.contains(contentType));
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -160,6 +160,7 @@ import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ByteArrayEntity;
@@ -386,36 +387,61 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     @Test
     public void testHeadTurtleContentType() throws IOException {
-        testHeadDefaultContentType(RDFMediaType.TURTLE_WITH_CHARSET);
+        testDefaultContentType(RDFMediaType.TURTLE_WITH_CHARSET, false);
     }
 
     @Test
     public void testHeadRDFContentType() throws IOException {
-        testHeadDefaultContentType(RDFMediaType.RDF_XML);
+        testDefaultContentType(RDFMediaType.RDF_XML, false);
     }
 
     @Test
     public void testHeadJSONLDContentType() throws IOException {
-        testHeadDefaultContentType(RDFMediaType.JSON_LD);
+        testDefaultContentType(RDFMediaType.JSON_LD, false);
     }
 
     @Test
     public void testHeadDefaultContentType() throws IOException {
-        testHeadDefaultContentType(null);
+        testDefaultContentType(null, false);
     }
 
-    private void testHeadDefaultContentType(final String mimeType) throws IOException {
+    @Test
+    public void testGetTurtleContentType() throws IOException {
+        testDefaultContentType(RDFMediaType.TURTLE_WITH_CHARSET, true);
+    }
+
+    @Test
+    public void testGetRDFContentType() throws IOException {
+        testDefaultContentType(RDFMediaType.RDF_XML, true);
+    }
+
+    @Test
+    public void testGetJSONLDContentType() throws IOException {
+        testDefaultContentType(RDFMediaType.JSON_LD, true);
+    }
+
+    @Test
+    public void testGetDefaultContentType() throws IOException {
+        testDefaultContentType(null, true);
+    }
+
+    private void testDefaultContentType(final String mimeType, final boolean isGet) throws IOException {
         final String id = getRandomUniqueId();
         createObjectAndClose(id);
 
-        final HttpHead headObjMethod = headObjMethod(id);
+        final HttpRequestBase req;
+        if (isGet) {
+            req = getObjMethod(id);
+        } else {
+            req = headObjMethod(id);
+        }
         String mt = mimeType;
         if (mt != null) {
-            headObjMethod.addHeader("Accept", mt);
+            req.addHeader("Accept", mt);
         } else {
             mt = RDFMediaType.TURTLE_WITH_CHARSET;
         }
-        try (final CloseableHttpResponse response = execute(headObjMethod)) {
+        try (final CloseableHttpResponse response = execute(req)) {
             final Collection<String> contentTypes = getHeader(response, CONTENT_TYPE);
             final String contentType = contentTypes.iterator().next();
             assertTrue("Didn't find LDP valid content-type header: " + contentType +


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3810

# What does this Pull Request do?
Re-adds wildcards to the Jersey endpoints otherwise Jersey rejects `Accept` headers that aren't in the list (which are all RDF types and `text/plain` and `text/html`).

Also makes HEAD requests respond the same as a GET request.

# How should this be tested?

Before this PR.
Put up a binary that is not `text/plain` or `text/html` (you can put up plain text and claim it is `application/pdf` though)
ie.
```
> curl -ufedoraAdmin:fedoraAdmin -XPUT -H"Content-type: application/pdf" --data-binary "Some fake binary" http://localhost:8080/rest/test_binary

HTTP/1.1 201 Created
```

Do a HEAD request to see the Content-type is set correctly.
```
> curl -I -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary

HTTP/1.1 200 OK
...
Content-Type: application/pdf
...
```

Now do a HEAD and/or GET request using that mimetype with the Accept header.
```
> curl -I -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary -H"Accept: application/pdf"

HTTP/1.1 406 Not Acceptable
```
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary -H"Accept: application/pdf"

HTTP/1.1 406 Not Acceptable
```

Pull in this PR, rebuild and try getting them again.
```
> curl -I -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary -H"Accept: application/pdf"             

HTTP/1.1 200 OK
```
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary -H"Accept: application/pdf"             

HTTP/1.1 200 OK
```

But it still fails if the type is not compatible.
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary/fcr:metadata -H"Accept: application/pdf"

HTTP/1.1 406 Not Acceptable
```
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_binary -H"Accept: image/tiff"                  

HTTP/1.1 406 Not Acceptable
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
