### PR TITLE
Show the failed URI during identifier conversion

### DIFF
--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -80,7 +80,7 @@ public class HttpIdentifierConverter {
 
             return FEDORA_ID_PREFIX + fedoraId;
         }
-        throw new IllegalArgumentException("Cannot translate NULL path");
+        throw new IllegalArgumentException(String.format("Cannot translate NULL path extracted from URI %s", httpUri));
     }
 
     /**

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -80,7 +80,7 @@ public class HttpIdentifierConverter {
 
             return FEDORA_ID_PREFIX + fedoraId;
         }
-        throw new IllegalArgumentException(String.format("Cannot translate NULL path extracted from URI %s", httpUri));
+        throw new IllegalArgumentException("Cannot translate NULL path extracted from URI " + httpUri);
     }
 
     /**


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3818

**Note**: This does _not_ solve the issue, it does make it give out some useful information as to what URL is being called when the machine fails.

# What does this Pull Request do?
Updates the Exception message to include the original URI that attempted to be converted to an internal ID.

# How should this be tested?

This exception most often appears when running Fedora inside of Tomcat and accessing either the splash page or repository root, but otherwise it can be random.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
