### PR TITLE
Make binaries store their RDF using the binary's ID instead of the bi…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -195,7 +195,7 @@ public class HttpRdfService {
         final String externalURI = idTranslator.toExternalId(resourceId.getFullDescribedId());
         final UpdateRequest request = UpdateFactory.create(requestBody, externalURI);
         final List<Update> updates = request.getOperations();
-        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig, resourceId);
+        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig);
         for (final Update update : updates) {
             update.visit(visitor);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -148,7 +148,11 @@ public class HttpRdfService {
                 }
                 if (stmt.getSubject().isURIResource()) {
                     final String originalSubj = stmt.getSubject().getURI();
-                    final String subj = idTranslator.translateUri(originalSubj);
+                    String subj = idTranslator.translateUri(originalSubj);
+                    if (extResourceId.isDescription() && extResourceId.getFullId().equals(subj)) {
+                        // Convert to the binary's ID
+                        subj = extResourceId.getFullDescribedId();
+                    }
 
                     RDFNode obj = stmt.getObject();
                     if (stmt.getObject().isURIResource()) {
@@ -255,7 +259,7 @@ public class HttpRdfService {
 
     /**
      * Does the statement's triple touch any server managed properties / namespaces.
-     * ie.
+     * i.e.
      * - has a rdf:type with an object which is in a managed namespace
      * - has a predicate which is in a managed namespace.
      *

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -118,7 +118,7 @@ public class HttpRdfService {
                                      final boolean lenientHandling)
                                      throws RepositoryRuntimeException, BadRequestException {
         final List<ConstraintViolationException> exceptions = new ArrayList<>();
-        final String externalURI = idTranslator.toExternalId(extResourceId.getFullId());
+        final String externalURI = idTranslator.toExternalId(extResourceId.getFullDescribedId());
         final Model model = parseBodyAsModel(stream, contentType, externalURI);
         final List<Statement> insertStatements = new ArrayList<>();
         final StmtIterator stmtIterator = model.listStatements();
@@ -188,7 +188,7 @@ public class HttpRdfService {
      */
     public String patchRequestToInternalString(final FedoraId resourceId, final String requestBody,
                                                final HttpIdentifierConverter idTranslator) {
-        final String externalURI = idTranslator.toExternalId(resourceId.getFullId());
+        final String externalURI = idTranslator.toExternalId(resourceId.getFullDescribedId());
         final UpdateRequest request = UpdateFactory.create(requestBody, externalURI);
         final List<Update> updates = request.getOperations();
         final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/HttpRdfService.java
@@ -191,7 +191,7 @@ public class HttpRdfService {
         final String externalURI = idTranslator.toExternalId(resourceId.getFullDescribedId());
         final UpdateRequest request = UpdateFactory.create(requestBody, externalURI);
         final List<Update> updates = request.getOperations();
-        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig);
+        final SparqlTranslateVisitor visitor = new SparqlTranslateVisitor(idTranslator, fedoraPropsConfig, resourceId);
         for (final Update update : updates) {
             update.visit(visitor);
         }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/SparqlTranslateVisitor.java
@@ -53,18 +53,13 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
 
     private static final Logger LOGGER = getLogger(SparqlTranslateVisitor.class);
 
-    private static final String CUSTOM_SPARQL_VARIABLE = "fedoraBinaryFix";
-
-    private static final Node CUSTOM_SPARQL_VAR_NODE = NodeFactory.createVariable(CUSTOM_SPARQL_VARIABLE);
-
     private List<Update> newUpdates = new ArrayList<>();
 
     private HttpIdentifierConverter idTranslator;
 
     private boolean isRelaxedMode;
 
-    public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter, final FedoraPropsConfig config,
-                                  final FedoraId id) {
+    public SparqlTranslateVisitor(final HttpIdentifierConverter identifierConverter, final FedoraPropsConfig config) {
         idTranslator = identifierConverter;
         isRelaxedMode = config.getServerManagedPropsMode().equals(RELAXED);
     }
@@ -153,7 +148,7 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
     private Element processElements(final Element element) {
         if (element instanceof ElementGroup) {
             final ElementGroup group = new ElementGroup();
-            ((ElementGroup)element).getElements().stream().map(this::processElements).forEach(group::addElement);
+            ((ElementGroup) element).getElements().forEach(e -> group.addElement(processElements(e)));
             return group;
         } else if (element instanceof ElementPathBlock) {
             final BasicPattern basicPattern = new BasicPattern();
@@ -255,7 +250,7 @@ public class SparqlTranslateVisitor extends UpdateVisitorBase {
                 // If this was converted to an internal ID, make a FedoraId out of it.
                 final var id = FedoraId.create(newUri);
                 if (id.isDescription()) {
-                    // If we are dealing with a binary description so convert it to the binary
+                    // If we are dealing with a binary description ID convert it to the binary ID.
                     return NodeFactory.createURI(id.getFullDescribedId());
                 }
             }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/HttpRdfServiceTest.java
@@ -6,13 +6,13 @@
 package org.fcrepo.http.api.services;
 
 import static org.fcrepo.config.ServerManagedPropsMode.STRICT;
+import static org.fcrepo.http.commons.test.util.TestHelpers.setField;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.when;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -21,12 +21,17 @@ import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.DCTerms;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.junit.Before;
 import org.junit.Test;
 import java.io.InputStream;
 import java.io.ByteArrayInputStream;
+import java.util.UUID;
+import java.util.function.Predicate;
+
 import org.junit.runner.RunWith;
 
 import org.fcrepo.config.FedoraPropsConfig;
@@ -37,7 +42,6 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.Logger;
 
 /**
  * Unit tests for HttpRdfService
@@ -47,23 +51,20 @@ import org.slf4j.Logger;
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class HttpRdfServiceTest {
 
-    private static final Logger log = getLogger(HttpRdfService.class);
-
-    @Mock
     private HttpIdentifierConverter idTranslator;
 
     @Mock
     private FedoraResource resource;
 
-    @Mock
-    private FedoraPropsConfig fedoraPropsConfig;
+    private FedoraPropsConfig fedoraPropsConfig = new FedoraPropsConfig();
 
     @InjectMocks
     private HttpRdfService httpRdfService;
 
-    private static final String FEDORA_URI_1 = "http://www.example.com/fedora/rest/resource1";
+    private static final String HTTP_BASE_URI = "http://www.example.com/fedora/rest/";
+    private static final String FEDORA_URI_1 = HTTP_BASE_URI + "resource1";
     private static final Resource FEDORA_URI_1_RESOURCE = ResourceFactory.createResource(FEDORA_URI_1);
-    private static final String FEDORA_URI_2 = "http://www.example.com/fedora/rest/resource2";
+    private static final String FEDORA_URI_2 = HTTP_BASE_URI + "resource2";
     private static final Resource FEDORA_URI_2_RESOURCE = ResourceFactory.createResource(FEDORA_URI_2);
     private static final FedoraId FEDORA_ID_1 = FedoraId.create("info:fedora/resource1");
     private static final Resource FEDORA_ID_1_RESOURCE = ResourceFactory.createResource(FEDORA_ID_1.getFullId());
@@ -85,25 +86,14 @@ public class HttpRdfServiceTest {
                 "    dcterms:isPartOf <" + FEDORA_ID_2 + "> .";
     private static final MediaType CONTENT_TYPE = new MediaType("text", "turtle");
 
+    public HttpRdfServiceTest() {
+        fedoraPropsConfig.setServerManagedPropsMode(STRICT);
+        idTranslator = new HttpIdentifierConverter(UriBuilder.fromUri(HTTP_BASE_URI + "{path: .*}"));
+    }
+
     @Before
-    public void setup() {
-        when(fedoraPropsConfig.getServerManagedPropsMode()).thenReturn(STRICT);
-        when(idTranslator.translateUri(FEDORA_URI_1)).thenReturn(FEDORA_ID_1.getFullId());
-        when(idTranslator.translateUri(FEDORA_URI_2)).thenReturn(FEDORA_ID_2.getFullId());
-        when(idTranslator.translateUri(NON_FEDORA_URI)).thenReturn(NON_FEDORA_URI);
-
-        when(idTranslator.toExternalId(FEDORA_ID_1.getFullId())).thenReturn(FEDORA_URI_1);
-        when(idTranslator.toExternalId(FEDORA_ID_2.getFullId())).thenReturn(FEDORA_URI_2);
-        when(idTranslator.inInternalDomain(FEDORA_ID_1.getFullId())).thenReturn(true);
-        when(idTranslator.inInternalDomain(FEDORA_ID_2.getFullId())).thenReturn(true);
-        when(idTranslator.inInternalDomain(NON_FEDORA_URI)).thenReturn(false);
-
-        when(resource.getId()).thenReturn(FEDORA_ID_1.getFullId());
-
-        when(idTranslator.translateUri("http://other.com/resource")).thenReturn("http://other.com/resource");
-        when(idTranslator.translateUri(FEDORA_ID_1.getFullId())).thenReturn(FEDORA_ID_1.getFullId());
-
-        log.debug("Rdf is: {}", RDF);
+    public void setUp() {
+        setField(httpRdfService, "fedoraPropsConfig", fedoraPropsConfig);
     }
 
     @Test
@@ -277,6 +267,53 @@ public class HttpRdfServiceTest {
         assertStringMatch("<" + FEDORA_ID_2 + "> <http://example.org#pointer> " +
                 "<" + FEDORA_ID_1 + ">", translated);
         assertStringMatch("?o <http://example.org#pointer> <" + FEDORA_ID_2 + ">", translated);
+    }
+
+    /**
+     * Test that binary descriptions URIs in subjects are converted to the binary IDs.
+     */
+    @Test
+    public void testPutToInternal_BinaryDescriptionSubject() {
+        final var binaryUri = HTTP_BASE_URI + UUID.randomUUID();
+        final var binaryDescUri = binaryUri + "/" + FCR_METADATA;
+        final var descriptionId = FedoraId.create(idTranslator.toInternalId(binaryDescUri));
+        // Predicate to filter for a resource with the full binary description ID (i.e. ending in /fcr:metadata)
+        final Predicate<Resource> keepDescId = a -> a.isURIResource() && a.hasURI(descriptionId.getFullId());
+        final var rdf = "@prefix dc: <"  + DC.getURI() + "> ." +
+                "@prefix dcterms: <"  + DCTerms.getURI() + "> ." +
+                "<" + binaryDescUri + "> dc:title 'fancy title' ;" +
+                "    dcterms:isPartOf <" + binaryUri + "> .";
+        final InputStream requestBodyStream = new ByteArrayInputStream(rdf.getBytes());
+        final Resource binaryRes = ResourceFactory.createResource(descriptionId.getFullDescribedId());
+        final var translated = httpRdfService.bodyToInternalModel(descriptionId, requestBodyStream, CONTENT_TYPE,
+                idTranslator, false);
+        assertTrue(translated.contains(binaryRes, DCTerms.isPartOf, binaryRes));
+        assertTrue(translated.contains(binaryRes, DC.title, ResourceFactory.createPlainLiteral("fancy title")));
+        assertFalse(translated.listSubjects().filterKeep(keepDescId).hasNext());
+    }
+
+    /**
+     * Test we don't touch binary description URIs in the object of a triple.
+     */
+    @Test
+    public void testPutToInternal_BinaryDescriptionObject() {
+        final var binaryUri = HTTP_BASE_URI + UUID.randomUUID();
+        final var binaryDescUri = binaryUri + "/" + FCR_METADATA;
+        final var descriptionId = FedoraId.create(idTranslator.toInternalId(binaryDescUri));
+        // Predicate to filter for a resource with the full binary description ID (i.e. ending in /fcr:metadata)
+        final Predicate<Resource> keepDescId = a -> a.isURIResource() && a.hasURI(descriptionId.getFullId());
+        final var rdf = "@prefix dc: <"  + DC.getURI() + "> ." +
+                "@prefix dcterms: <"  + DCTerms.getURI() + "> ." +
+                "<" + binaryUri + "> dc:title 'fancy title' ;" +
+                "    dcterms:isPartOf <" + binaryDescUri + "> .";
+        final InputStream requestBodyStream = new ByteArrayInputStream(rdf.getBytes());
+        final Resource binaryRes = ResourceFactory.createResource(descriptionId.getFullDescribedId());
+        final Resource binaryDescRes = ResourceFactory.createResource(descriptionId.getFullId());
+        final var translated = httpRdfService.bodyToInternalModel(descriptionId, requestBodyStream, CONTENT_TYPE,
+                idTranslator, false);
+        assertTrue(translated.contains(binaryRes, DCTerms.isPartOf, binaryDescRes));
+        assertTrue(translated.contains(binaryRes, DC.title, ResourceFactory.createPlainLiteral("fancy title")));
+        assertFalse(translated.listSubjects().filterKeep(keepDescId).hasNext());
     }
 
     /**

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
@@ -1,0 +1,203 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.http.api.services;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.ws.rs.core.UriBuilder;
+
+import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.config.ServerManagedPropsMode;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
+import org.apache.jena.update.Update;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateRequest;
+import org.apache.jena.vocabulary.DC_11;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Tests for SparqlTranslateVisitor
+ * @author whikloj
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class SparqlTranslateVisitorTest {
+
+    private static final String URI_BASE = "http://localhost:8080/rest/";
+
+    private HttpIdentifierConverter identifierConverter;
+
+    private String idEnding;
+
+    private String httpUri;
+
+    private FedoraId resourceId;
+
+    private final FedoraPropsConfig propsConfig = new FedoraPropsConfig();
+
+    public SparqlTranslateVisitorTest() {
+        final var builder = UriBuilder.fromUri(URI_BASE + "{path: .*}");
+        identifierConverter = new HttpIdentifierConverter(builder);
+        propsConfig.setServerManagedPropsMode(ServerManagedPropsMode.STRICT);
+    }
+
+    private SparqlTranslateVisitor makeVisitor() {
+        return makeVisitor(UUID.randomUUID().toString());
+    }
+
+    private SparqlTranslateVisitor makeVisitor(final String id) {
+        idEnding = id;
+        final var internalhttpUri = URI_BASE + idEnding;
+        resourceId = FedoraId.create(identifierConverter.toInternalId(internalhttpUri));
+        httpUri = identifierConverter.toExternalId(resourceId.getFullDescribedId());
+        return new SparqlTranslateVisitor(identifierConverter, propsConfig, resourceId);
+    }
+
+    private String runVisits(final String input, final SparqlTranslateVisitor visitor) {
+        final UpdateRequest request = UpdateFactory.create(input, httpUri);
+        final List<Update> updates = request.getOperations();
+        for (final Update update : updates) {
+            update.visit(visitor);
+        }
+        return visitor.getTranslatedRequest().toString();
+    }
+
+    private String sparqlEqualityCleanup(final String input) {
+        return input.replaceAll("\\n", " ").replaceAll("\\s+", " ")
+                .replaceAll("\\. }", ".}").replaceAll("\\{ }", "{}").trim();
+    }
+
+    /**
+     * Assert equality while accounting for changes in the Sparql text when run through the visitor.
+     * @param expected
+     *   The expected string.
+     * @param actual
+     *   The actual string.
+     */
+    private void assertEqualsSparqlStrings(final String expected, final String actual) {
+        final var expect1 = sparqlEqualityCleanup(expected);
+        final var actual1 = sparqlEqualityCleanup(actual);
+        assertEquals(
+                expect1,
+                actual1
+        );
+    }
+
+    @Test
+    public void testInsertDataContainer() {
+        final var originalString = "INSERT DATA { <> <" + DC_11.title.getURI() + "> \"Some title\" . }";
+        final var visitor = makeVisitor();
+        final var expected = "INSERT DATA { <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" .}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteDataContainer() {
+        final var originalString = "DELETE DATA { <> <" + DC_11.title.getURI() + "> \"Some title\" . }";
+        final var visitor = makeVisitor();
+        final var expected = "DELETE DATA { <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" .}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testInsertDataBinary() {
+        final var originalString = "INSERT DATA { <> <" + DC_11.title.getURI() + "> \"Some title\" . }";
+        final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
+        final var expected = "INSERT DATA { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" .}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteDataBinary() {
+        final var originalString = "DELETE DATA { <> <" + DC_11.title.getURI() + "> \"Some title\" . }";
+        final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
+        final var expected = "DELETE DATA { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" . " +
+                "<" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> \"Some title\" . }";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testInsertWhereContainer() {
+        final var originalString = "INSERT { <> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE {}";
+        final var visitor = makeVisitor();
+        final var expected = "INSERT { <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> \"Some " +
+                "title\" .} WHERE {}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteWhereContainer() {
+        final var originalString = "DELETE { <> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE {}";
+        final var visitor = makeVisitor();
+        final var expected = "DELETE { <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> \"Some " +
+                "title\" .} WHERE {}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testInsertWhereBinary() {
+        final var originalString = "INSERT { <> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE {}";
+        final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
+        final var expected = "INSERT { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> " +
+                "\"Some title\" .} WHERE {}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteWhereBinary() {
+        final var originalString = "DELETE { <> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE {}";
+        final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
+        final var expected = "DELETE { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" . <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() +
+                "> \"Some title\" . } WHERE {}";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteAndInsertWhereContainer() {
+        final var originalString =
+                "DELETE { <> <" + DC_11.title.getURI() + "> ?o . } INSERT { <> <" + DC_11.title.getURI() + "> " +
+                        "\"Some title\" . } WHERE { <> <" + DC_11.title.getURI() + "> ?o }";
+        final var visitor = makeVisitor();
+        final var expected = "DELETE { <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?o . } INSERT " +
+                "{ <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE { <" +
+                resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?o }";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+
+    @Test
+    public void testDeleteAndInsertWhereBinary() {
+        final var originalString =
+                "DELETE { <> <" + DC_11.title.getURI() + "> ?o . } INSERT { <> <" + DC_11.title.getURI() + "> " +
+                        "\"Some title\" . } WHERE { <> <" + DC_11.title.getURI() + "> ?o }";
+        final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
+        final var expected = "DELETE { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() +
+                "> ?o . <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?o .} INSERT " +
+                "{ <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE " +
+                "{ <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> ?o }";
+        final var output = runVisits(originalString, visitor);
+        assertEqualsSparqlStrings(expected, output);
+    }
+}

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
@@ -40,8 +40,6 @@ public class SparqlTranslateVisitorTest {
 
     private HttpIdentifierConverter identifierConverter;
 
-    private String idEnding;
-
     private String httpUri;
 
     private FedoraId resourceId;
@@ -58,20 +56,14 @@ public class SparqlTranslateVisitorTest {
 
     @Before
     public void setUp() {
-        // Run by default, run again to override the values.
-        makeVisitor();
-    }
-
-    private void makeVisitor() {
         makeVisitor(UUID.randomUUID().toString());
     }
 
     private void makeVisitor(final String id) {
-        idEnding = id;
-        final var internalhttpUri = URI_BASE + idEnding;
+        final var internalhttpUri = URI_BASE + id;
         resourceId = FedoraId.create(identifierConverter.toInternalId(internalhttpUri));
         httpUri = identifierConverter.toExternalId(resourceId.getFullDescribedId());
-        visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig, resourceId);
+        visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig);
     }
 
     private String runVisits(final String input, final SparqlTranslateVisitor visitor) {
@@ -118,13 +110,13 @@ public class SparqlTranslateVisitorTest {
     }
 
     private void runMultipleTests(final List<String> uris, final String expected, final String inputTemplate) {
-        visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig, resourceId);
+        visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig);
         for (final var uri : uris) {
             final var input = String.format(inputTemplate, uri);
             final var output = runVisits(input, visitor);
             assertEqualsSparqlStrings(expected, output);
             // Need to clear the request queue
-            visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig, resourceId);
+            visitor = new SparqlTranslateVisitor(identifierConverter, propsConfig);
         }
     }
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/services/SparqlTranslateVisitorTest.java
@@ -194,9 +194,10 @@ public class SparqlTranslateVisitorTest {
                         "\"Some title\" . } WHERE { <> <" + DC_11.title.getURI() + "> ?o }";
         final var visitor = makeVisitor(UUID.randomUUID() + "/fcr:metadata");
         final var expected = "DELETE { <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() +
-                "> ?o . <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?o .} INSERT " +
+                "> ?o . <" + resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?fedoraBinaryFix .} INSERT " +
                 "{ <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> \"Some title\" . } WHERE " +
-                "{ <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> ?o }";
+                "{ <" + resourceId.getFullDescribedId() + "> <" + DC_11.title.getURI() + "> ?o . <" +
+                resourceId.getFullId() + "> <" + DC_11.title.getURI() + "> ?fedoraBinaryFix }";
         final var output = runVisits(originalString, visitor);
         assertEqualsSparqlStrings(expected, output);
     }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
@@ -80,6 +80,12 @@ public class FedoraId {
      */
     private final String encodedFullId;
 
+    /**
+     * The Full ID of the described resource. For binary -> binary, container -> container, binary description -> binary
+     */
+    private final String describedId;
+
+
     private String hashUri;
     private boolean isRepositoryRoot = false;
     private boolean isNonRdfSourceDescription = false;
@@ -108,6 +114,7 @@ public class FedoraId {
         this.baseId = processIdentifier();
         enforceStorageLayoutNamingConstraints();
         this.encodedFullId = fedoraIdEscaper.escape(this.fullId);
+        this.describedId = this.fullId.replace("/" + FCR_METADATA, "");
     }
 
     /**
@@ -344,10 +351,11 @@ public class FedoraId {
 
     /**
      * Returns the FullId of the described resource.
+     *
      * @return The ID.
      */
     public String getFullDescribedId() {
-        return fullId.replace("/" + FCR_METADATA, "");
+        return describedId;
     }
 
     /**

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/identifiers/FedoraId.java
@@ -343,6 +343,14 @@ public class FedoraId {
     }
 
     /**
+     * Returns the FullId of the described resource.
+     * @return The ID.
+     */
+    public String getFullDescribedId() {
+        return fullId.replace("/" + FCR_METADATA, "");
+    }
+
+    /**
      * Creates a new Fedora ID based on this ID that points to a tombstone resource. If this ID is already a tombstone,
      * then it returns itself. Otherwise, it uses the base ID, without extensions, to construct the new ID.
      *

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
@@ -487,6 +487,28 @@ public class FedoraIdTest {
         assertIdSuffixConstraint("~fcr-acl.nt");
     }
 
+    @Test
+    public void testAsDescribedId() {
+        assertAsDescribedId("original" + "/" + FCR_METADATA + "/" + FCR_VERSIONS,
+                "original/" + FCR_VERSIONS);
+        assertAsDescribedId("original/" + FCR_METADATA + "#blah",
+                "original" + "#blah");
+        assertAsDescribedId("original/" + FCR_METADATA + "/" + FCR_VERSIONS + "/20200401101901",
+                "original/" + FCR_VERSIONS + "/20200401101901");
+        assertAsDescribedId("original/" + FCR_VERSIONS,
+                "original/" + FCR_VERSIONS);
+        assertAsDescribedId("original/" + FCR_VERSIONS + "/20200401101900",
+                "original/" + FCR_VERSIONS + "/20200401101900");
+        assertAsDescribedId("original/" + FCR_TOMBSTONE,
+                "original/" + FCR_TOMBSTONE);
+        assertAsDescribedId("original/" + FCR_ACL,
+                "original/" + FCR_ACL);
+        assertAsDescribedId("original/child/" + FCR_METADATA,
+                "original/child");
+        assertAsDescribedId("original/child/" + FCR_METADATA + "#sad",
+                "original/child#sad");
+    }
+
     private void assertAsMemento(final String original, final String expected) {
         final var id = FedoraId.create(original);
         assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
@@ -515,6 +537,12 @@ public class FedoraIdTest {
         final var id = FedoraId.create(original);
         assertEquals(FedoraTypes.FEDORA_ID_PREFIX + "/" + expected,
                 id.asDescription().getFullId());
+    }
+
+    private void assertAsDescribedId(final String original, final String expected) {
+        final var id = FedoraId.create(original);
+        assertEquals(FEDORA_ID_PREFIX + "/" + expected,
+                id.getFullDescribedId());
     }
 
     /**

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -88,7 +88,7 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     public RdfStream getTriples() {
         // Remap the subject to the described resource
         // TODO: With FCREPO-3819 and FCREPO-3820, this will no longer be necessary.
-        //       But existing sites might RDF with NonRdfSourceDescription subjects, so leave it for now.
+        //       But existing sites might have RDF with NonRdfSourceDescription subjects, so leave it for now.
         final Node describedID = createURI(this.getDescribedResource().getId());
         final Stream<Triple> triples = super.getTriples().map(t ->
                 new Triple(describedID, t.getPredicate(), t.getObject()));

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -87,6 +87,8 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
     @Override
     public RdfStream getTriples() {
         // Remap the subject to the described resource
+        // TODO: With FCREPO-3819 and FCREPO-3820, this will no longer be necessary.
+        //       But existing sites might RDF with NonRdfSourceDescription subjects, so leave it for now.
         final Node describedID = createURI(this.getDescribedResource().getId());
         final Stream<Triple> triples = super.getTriples().map(t ->
                 new Triple(describedID, t.getPredicate(), t.getObject()));

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRelaxableResourceOperationBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/operations/AbstractRelaxableResourceOperationBuilder.java
@@ -44,7 +44,7 @@ public abstract class AbstractRelaxableResourceOperationBuilder extends Abstract
     public RelaxableResourceOperationBuilder relaxedProperties(final Model model) {
         // Has no affect if the server is not in relaxed mode
         if (model != null && serverManagedPropsMode == ServerManagedPropsMode.RELAXED) {
-            final var resc = model.getResource(rescId.getResourceId());
+            final var resc = model.getResource(rescId.asResourceId().getFullDescribedId());
 
             final var createdDateVal = getCreatedDate(resc);
             if (createdDateVal != null) {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReplacePropertiesServiceImpl.java
@@ -69,7 +69,8 @@ public class ReplacePropertiesServiceImpl extends AbstractService implements Rep
             // Extract triples which impact the headers of binary resources from incoming description RDF
             final BinaryHeaderDetails binHeaders = extractNonRdfSourceHeaderTriples(fedoraId, inputModel);
 
-            final var rdfStream = fromModel(inputModel.createResource(fedoraId.getFullId()).asNode(), inputModel);
+            final var rdfStream = fromModel(
+                    inputModel.createResource(fedoraId.getFullDescribedId()).asNode(), inputModel);
             final var serverManagedMode = fedoraPropsConfig.getServerManagedPropsMode();
 
             // create 2 updates -- one for the properties coming in and one for and server managed properties

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/UpdatePropertiesServiceImpl.java
@@ -50,7 +50,7 @@ public class UpdatePropertiesServiceImpl extends AbstractService implements Upda
             final var psession = persistentStorageSessionManager.getSession(tx);
             final var triples = psession.getTriples(fedoraId, null);
             final Model model = triples.collect(toModel());
-            final UpdateRequest request = UpdateFactory.create(sparqlUpdateStatement, fedoraId.getFullId());
+            final UpdateRequest request = UpdateFactory.create(sparqlUpdateStatement, fedoraId.getFullDescribedId());
             UpdateAction.execute(request, model);
             replacePropertiesService.perform(tx, userPrincipal, fedoraId, model);
         } catch (final PersistentItemNotFoundException ex) {


### PR DESCRIPTION
…nary description's

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3819 & https://fedora-repository.atlassian.net/browse/FCREPO-3820

# What does this Pull Request do?
Switches to using the binary's ID for stored RDF via PUT/POST, also adjusts PATCH requests to use the same subject to match queries.

# How should this be tested?

Before this PR.
Create a binary
Update the triples with a PUT or PATCH request using the `<>` for the current resource.
Check the triples on disk in OCFL and see that the subject is the binary description ID.
ie. after PUT
```
<info:fedora/binary/fcr:metadata> <http://purl.org/dc/terms/title> "This is my NEW title" .
```
and PATCH
```
<info:fedora/binary/fcr:metadata> <http://purl.org/dc/terms/title> "Revised title" .
```
Pull in this PR and try the same steps, see that now it is the actual binary's ID.
ie. after PUT
```
<info:fedora/binary> <http://purl.org/dc/terms/title> "This is my NEW title" .
```
and PATCH
```
<info:fedora/binary> <http://purl.org/dc/terms/title> "Revised title" .
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
