### PR TITLE
405 on DELETE Memento

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -382,6 +382,13 @@ public class FedoraLdp extends ContentExposingResource {
      */
     @DELETE
     public Response deleteObject() {
+        LOGGER.info("Delete resource '{}'", externalPath);
+        if (externalPath.contains("/" + FedoraTypes.FCR_VERSIONS)) {
+            handleRequestDisallowedOnMemento();
+
+            return status(METHOD_NOT_ALLOWED).build();
+        }
+
         hasRestrictedPath(externalPath);
         if (resource() instanceof Container) {
             final String depth = headers.getHeaderString("Depth");
@@ -397,8 +404,6 @@ public class FedoraLdp extends ContentExposingResource {
                 "NonRDFSource descriptions are removed when their associated NonRDFSource object is removed.",
                 METHOD_NOT_ALLOWED);
         }
-
-        LOGGER.info("Delete resource '{}'", externalPath);
 
         try {
             evaluateRequestPreconditions(request, servletResponse, resource(), transaction());

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1249,6 +1249,17 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testDeleteOnMemento() throws Exception {
+        createVersionedContainer(id);
+
+        final String mementoUri = createMemento(subjectUri);
+        final var delete = new HttpDelete(mementoUri);
+
+        // status 405: DELETE on memento is not allowed.
+        assertEquals(405, getStatus(delete));
+    }
+
+    @Test
     public void testPostOnInvalidMementoPath() throws Exception {
         createVersionedContainer(id);
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3824

# What does this Pull Request do?
Changes response on DELETE to a Memento from `409 Conflict` to `405 Method Not Allowed`

# How should this be tested?

Before PR create an object, then create a new version, then try to delete the version. Get:
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_version/00e7d1de-1758-4cb9-8044-6a762e8c2a14/fcr:versions/20220512161636 -XDELETE

HTTP/1.1 409 Conflict
Date: Thu, 12 May 2022 16:16:57 GMT
Set-Cookie: JSESSIONID=node01soir2ymob8vom0ew3290ysd283.node0; Path=/
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 11-May-2022 16:16:57 GMT; SameSite=lax
Link: <http://localhost:8080/static/constraints/ServerManagedTypeException.rdf>; rel="http://www.w3.org/ns/ldp#constrainedBy"
Content-Type: text/plain;charset=utf-8
Content-Length: 44
Server: Jetty(9.4.34.v20201102)

Path cannot contain a fcr: prefixed segment.
```

Pull in the PR and try again get 
```
> curl -i -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/test_version/00e7d1de-1758-4cb9-8044-6a762e8c2a14/fcr:versions/20220512161636 -XDELETE

HTTP/1.1 405 Method Not Allowed
Set-Cookie: JSESSIONID=node0kjxaekpsi8yxs447ffmfkmu30.node0; Path=/
Set-Cookie: rememberMe=deleteMe; Path=/; Max-Age=0; Expires=Wed, 11-May-2022 16:37:32 GMT; SameSite=lax
Content-Length: 0
Server: Jetty(9.4.44.v20210927)
```

That is all.

# Interested parties
@fcrepo/committers
