### PR TITLE
Timemaps should use the ACL of the original resource

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -446,7 +446,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     private void addAclHeader(final FedoraResource resource) {
         if (!(resource instanceof WebacAcl) && !resource.isMemento()) {
-            final String resourceUri = getUri(resource.getDescribedResource()).toString();
+            final FedoraResource resourceForAcl = resource instanceof TimeMap ? resource.getOriginalResource() :
+                    resource.getDescribedResource();
+            final String resourceUri = getUri(resourceForAcl).toString();
             final String aclLocation =  resourceUri + (resourceUri.endsWith("/") ? "" : "/") + FCR_ACL;
             servletResponse.addHeader(LINK, buildLink(aclLocation, "acl"));
         }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -842,7 +842,6 @@ public class FedoraVersioningIT extends AbstractResourceIT {
      * @param uri the URI of the resource.
      */
     private static void verifyTimeMapHeaders(final CloseableHttpResponse response, final String uri) {
-        final String ldpcvUri = uri + "/" + FCR_VERSIONS;
         checkForLinkHeader(response, RESOURCE.toString(), "type");
         checkForLinkHeader(response, CONTAINER.toString(), "type");
         checkForLinkHeader(response, RDF_SOURCE.getURI(), "type");
@@ -850,7 +849,7 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         checkForLinkHeader(response, uri, "timegate");
         checkForLinkHeader(response, uri + "/" + FCR_VERSIONS, "timemap");
         checkForLinkHeader(response, VERSIONING_TIMEMAP_TYPE, "type");
-        checkForLinkHeader(response, ldpcvUri + "/" + FCR_ACL, "acl");
+        checkForLinkHeader(response, uri + "/" + FCR_ACL, "acl");
         assertFalse(response.getFirstHeader("Allow").getValue().contains("DELETE"));
         assertTrue(response.getFirstHeader("Allow").getValue().contains("GET"));
         assertTrue(response.getFirstHeader("Allow").getValue().contains("HEAD"));


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3825

# What does this Pull Request do?
Timemaps are displaying a Link header for an ACL off of the Timemap (i.e. `RESOURCE/fcr:versions/fcr:acl` instead of `RESOURCE/fcr:acl`). That is an invalid identifier and so it not accessible.
This PR changes the link header to the Original Resource's ACL.

# How should this be tested?

Before the PR, create any resource, get the Timemap and review the headers. See the `rel="acl"` one.
Pull in this PR and see how the Link header has changed.

# Interested parties
@fcrepo/committers
