### PR TITLE
Use Set to deduplicate any extra versions

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -38,10 +38,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
@@ -179,7 +179,7 @@ public class FedoraVersioning extends ContentExposingResource {
             final String extUrl = identifierConverter().toDomain(externalPath());
 
             final URI parentUri = URI.create(extUrl);
-            final List<Link> versionLinks = new ArrayList<>();
+            final Set<Link> versionLinks = new HashSet<>();
             versionLinks.add(Link.fromUri(parentUri).rel("original").build());
             versionLinks.add(Link.fromUri(parentUri).rel("timegate").build());
             // So we don't collect the children twice, store them in an array.

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -190,6 +190,18 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testResponseForMultipleMementosInASecond() throws Exception {
+        final var v1 = now();
+        createVersionedContainer(id);
+        TimeUnit.SECONDS.sleep(1);
+
+        final var v2 = now();
+        createMemento(subjectUri);
+        createMemento(subjectUri);
+        verifyTimemapResponse(subjectUri, id, new String[]{v1, v2}, v1, v2);
+    }
+
+    @Test
     public void getTimeMapFromBinaryWithMultipleVersions() throws Exception {
         final var v1 = now();
         createVersionedBinary(id, OCTET_STREAM_TYPE, "v1");


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3655

# What does this Pull Request do?
Fixes the `application/link-format` output when there are more than one version in a second. The RDF formats seem to automatically deduplicate, but we manually generate this format.

# How should this be tested?

This is most obvious with an automated script because you need to generate more than one version in a single second.

1. Once you have generated multiple versions in a single second, then `GET` the Timemap (`/fcr:versions`) as `text/turtle` and see only one version per second.
1. Get the Timemap with `Accept: application/link-format` and see duplicate versions.
1. Pull in this PR and do the second GET again and see only one per second

# Interested parties
@fcrepo/committers
