### PR TITLE
Don't re-write fcr:fixity links

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -119,7 +119,7 @@
           // (c.f. https://jira.duraspace.org/browse/FCREPO-2387)
           // WARNING: Fragile code relying on magic suffix '/fcr:metadata' and absence of 'Link' header
           // on external resource.
-          if(!url.match(/.*fcr:(metadata|tx)/)){
+          if(!url.match(/.*fcr:(metadata|tx|fixity)/)){
             newLocation = url + "/fcr:metadata";
           }
           location.href = newLocation;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3831

# What does this Pull Request do?
Currently when you upload a binary you get a  `fedora:hasFixityService` triple, it is getting redirected to `http://localhost:8080/rest/<uri>/fcr:fixity/fcr:metadata`. This should not be redirected.

# How should this be tested?

Before the PR add a binary and click the `fedora:hasFixityService` link in the HTML UI. Get an 404 white page in the browser.
Pull in the PR and try again, get the fixity result.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
