### PR TITLE
Return a bad request for invalid fields in simple search

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraSearchIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraSearchIT.java
@@ -461,6 +461,15 @@ public class FedoraSearchIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testInvalidField() throws Exception {
+        final var invalidCondition = "customCondition=*";
+        final String searchUrl = getSearchEndpoint() + "condition=" + encode(invalidCondition);
+        try (final CloseableHttpResponse response = execute(new HttpGet(searchUrl))) {
+            assertEquals(BAD_REQUEST.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
     public void testOrderingISAscendingByDefaultIfOrderByIsDefined() throws Exception {
         final var prefix = getRandomUniqueId();
         final var resources = createResources(prefix, 3);

--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/Condition.java
@@ -55,8 +55,14 @@ public class Condition {
             return super.toString().toLowerCase();
         }
 
-        public static Field fromString(final String fieldStr) {
-            return Field.valueOf(fieldStr.toUpperCase());
+        public static Field fromString(final String fieldStr) throws InvalidConditionExpressionException {
+            for (final var field : values()) {
+                if (field.toString().equalsIgnoreCase(fieldStr)) {
+                   return field;
+                }
+            }
+
+            throw new InvalidConditionExpressionException(fieldStr + " is not a valid search field");
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3828

# What does this Pull Request do?

Return a bad request for invalid fields in simple search

# How should this be tested?

* Ensure the integration test passes: `mvn clean verify`
* Build the one click application: `mvn  install -pl fcrepo-webapp -P one-click`
* Run the one click app: `java -jar fcrepo-webapp/target/fcrepo-webapp-6.3.0-SNAPSHOT-jetty-console.jar`
* Query the search API with an invalid search field:  `curl --verbose "http://localhost:8080/rest/fcr:search?condition=blob_size<=12"`
* Check that the response from the above request is a 400

# Interested parties
@fcrepo/committers
