### PR TITLE
Tombstones have null interaction model

### DIFF
--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -568,7 +568,8 @@ public class WebACFilter extends RequestContextFilter {
      * @return whether it is a direct or indirect container.
      */
     private boolean isResourceIndirectOrDirect(final FedoraResource resource) {
-        return resource != null && Stream.of(resource.getInteractionModel()).map(URI::create)
+        return resource != null && resource.getInteractionModel() != null &&
+                Stream.of(resource.getInteractionModel()).map(URI::create)
                 .anyMatch(directOrIndirect::contains);
     }
 
@@ -750,8 +751,9 @@ public class WebACFilter extends RequestContextFilter {
      * @return true if a binary or binary description.
      */
     private static boolean isBinaryOrDescription(final FedoraResource resource) {
-        return resource.getInteractionModel().equals(NON_RDF_SOURCE.toString()) ||
-                resource.getInteractionModel().equals(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI);
+        return resource.getInteractionModel() != null && (
+                resource.getInteractionModel().equals(NON_RDF_SOURCE.toString()) ||
+                resource.getInteractionModel().equals(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI));
     }
 
     /**

--- a/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
+++ b/fcrepo-auth-webac/src/main/java/org/fcrepo/auth/webac/WebACFilter.java
@@ -568,6 +568,7 @@ public class WebACFilter extends RequestContextFilter {
      * @return whether it is a direct or indirect container.
      */
     private boolean isResourceIndirectOrDirect(final FedoraResource resource) {
+        // Tombstone are the only known resource with a null interaction model.
         return resource != null && resource.getInteractionModel() != null &&
                 Stream.of(resource.getInteractionModel()).map(URI::create)
                 .anyMatch(directOrIndirect::contains);
@@ -751,6 +752,7 @@ public class WebACFilter extends RequestContextFilter {
      * @return true if a binary or binary description.
      */
     private static boolean isBinaryOrDescription(final FedoraResource resource) {
+        // Tombstone are the only known resource with a null interaction model.
         return resource.getInteractionModel() != null && (
                 resource.getInteractionModel().equals(NON_RDF_SOURCE.toString()) ||
                 resource.getInteractionModel().equals(FEDORA_NON_RDF_SOURCE_DESCRIPTION_URI));


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3848

# What does this Pull Request do?
When a normal user tried to delete a tombstone a check is done on its interaction model. But a tombstone returns `null` which was not accounted for in the code. This modifies the two checks.

# How should this be tested?

1. Create a container and add an ACL for a normal user.
     ```shell
     > curl -u fedoraAdmin:fedoraAdmin -X PUT someBox http://localhost:8080/rest

     > curl -u fedoraAdmin:fedoraAdmin -X PUT -H"Content-type: text/turtle" --data "@prefix acl: <http://www.w3.org/ns/auth/acl#> . <#authz> a acl:Authorization; acl:agent \"testuser\"; acl:mode acl:Read, acl:Write, acl:Append; acl:accessTo </rest/someBox>; acl:default </rest/someBox> ." http://localhost:8080/rest/someBox/fcr:acl 
     ```
1. Have the normal user create a new container inside the container from step 1.
     ```shell
     > curl -u testuser:testpass -X PUT http://localhost:8080/rest/someBox/nextBox
    ```
3. Have the normal user delete the new container.
     ```shell
     > curl -u testuser:testpass -X DELETE http://localhost:8080/rest/someBox/nextBox
     ```
5. Have the normal user delete the tombstone.
     ```shell
     > curl -u testuser:testpass -X DELETE http://localhost:8080/rest/someBox/nextBox/fcr:tombstone

Before this PR, get a stack trace. But after the PR it should work fine.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
