### PR TITLE
Only rewrite NonRdfSourceDescription subjects

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/NonRdfSourceDescriptionImpl.java
@@ -90,8 +90,13 @@ public class NonRdfSourceDescriptionImpl extends FedoraResourceImpl implements N
         // TODO: With FCREPO-3819 and FCREPO-3820, this will no longer be necessary.
         //       But existing sites might have RDF with NonRdfSourceDescription subjects, so leave it for now.
         final Node describedID = createURI(this.getDescribedResource().getId());
-        final Stream<Triple> triples = super.getTriples().map(t ->
-                new Triple(describedID, t.getPredicate(), t.getObject()));
+        final Stream<Triple> triples = super.getTriples().map(t -> {
+            if (t.getSubject().hasURI(this.getId())) {
+                return new Triple(describedID, t.getPredicate(), t.getObject());
+            } else {
+                return t;
+            }
+        });
         return new DefaultRdfStream(describedID, triples);
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3859

# What does this Pull Request do?
Changes the NonRdfSourceDescription to stop rewrite ALL subjects of triples and only rewrites the NonRdfSourceDescription to match its described binary.

# How should this be tested?

Steps in the ticket or test added in this PR are best. Essentially make a binary, update the description to include a triple with some external URI as the subject. When you GET that description see that all triples have the same subject (that is the binary's URI).

```
> curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ashley.art/fcr:metadata
@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/ashley.art>
        <http://schema.org/about>  <http://en.wikipedia.org/Cat> ;
        <http://schema.org/name>   "Ashley" ;
        <http://schema.org/name>   "Cat" ;
        premis:hasSize             "33"^^<http://www.w3.org/2001/XMLSchema#long> ;
        ebucore:filename           "" ;
        ebucore:hasMimeType        "text/x-ascii-art" ;
        premis:hasMessageDigest    <urn:sha-512:cb651521ded1606687038b96e7ca19f000470b3d645484277a091a9d6709ccada6bb2568256fa1cd9a5806fe25d9e37e51c478b3761689468a792f65589e6028> ;
        fedora:created             "2022-10-27T17:56:06.835234Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified        "2022-10-27T17:56:06.835234Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy           "fedoraAdmin" ;
        fedora:lastModifiedBy      "fedoraAdmin" ;
        rdf:type                   ldp:NonRDFSource ;
        rdf:type                   ldp:Resource ;
        rdf:type                   fedora:Resource ;
        rdf:type                   fedora:Binary ;
        fedora:hasFixityService    <http://localhost:8080/rest/ashley.art/fcr:fixity> .
```

After this PR, see that only the current resource (which is a binary description i.e. ending in /fcr:metadata) would be re-written as it's described binary.

```
> curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/ashley.art/fcr:metadata
@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/ashley.art>
        <http://schema.org/about>  <http://en.wikipedia.org/Cat> ;
        <http://schema.org/name>   "Ashley" .

<http://en.wikipedia.org/Cat>
        <http://schema.org/name>  "Cat" .

<http://localhost:8080/rest/ashley.art>
        premis:hasSize           "33"^^<http://www.w3.org/2001/XMLSchema#long> ;
        ebucore:filename         "" ;
        ebucore:hasMimeType      "text/x-ascii-art" ;
        premis:hasMessageDigest  <urn:sha-512:cb651521ded1606687038b96e7ca19f000470b3d645484277a091a9d6709ccada6bb2568256fa1cd9a5806fe25d9e37e51c478b3761689468a792f65589e6028> ;
        fedora:created           "2022-10-27T17:56:06.835234Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified      "2022-10-27T17:56:06.835234Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy         "fedoraAdmin" ;
        fedora:lastModifiedBy    "fedoraAdmin" ;
        rdf:type                 ldp:NonRDFSource ;
        rdf:type                 ldp:Resource ;
        rdf:type                 fedora:Resource ;
        rdf:type                 fedora:Binary ;
        fedora:hasFixityService  <http://localhost:8080/rest/ashley.art/fcr:fixity> .
```

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers 
