### PR TITLE
Upgrade OCFL version 1.1 and allow choice for upgrading old objects

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -114,6 +114,9 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.cache.db.ocfl.id_map.timeout.minutes:30}")
     private long fedoraToOcflCacheTimeout;
 
+    @Value("${fcrepo.ocfl.upgrade.enabled:false}")
+    private boolean ocflUpgradeOnWrite;
+
     private DigestAlgorithm FCREPO_DIGEST_ALGORITHM;
 
     /**
@@ -475,5 +478,12 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public long getFedoraToOcflCacheTimeout() {
         return fedoraToOcflCacheTimeout;
+    }
+
+    /**
+     * @return True to write new versions of OCFL on older objects, false to keep the original version.
+     */
+    public boolean isOcflUpgradeOnWrite() {
+        return ocflUpgradeOnWrite;
     }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -77,10 +77,11 @@ public class OcflPersistenceConfig {
                     ocflPropsConfig.getOcflS3Prefix(),
                     ocflPropsConfig.getOcflTemp(),
                     ocflPropsConfig.getDefaultDigestAlgorithm(),
-                    ocflPropsConfig.isOcflS3DbEnabled());
+                    ocflPropsConfig.isOcflS3DbEnabled(),
+                    ocflPropsConfig.isOcflUpgradeOnWrite());
         } else {
             return createFilesystemRepository(ocflPropsConfig.getOcflRepoRoot(), ocflPropsConfig.getOcflTemp(),
-                    ocflPropsConfig.getDefaultDigestAlgorithm());
+                    ocflPropsConfig.getDefaultDigestAlgorithm(), ocflPropsConfig.isOcflUpgradeOnWrite());
         }
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/AbstractReindexerTest.java
@@ -114,7 +114,7 @@ public class AbstractReindexerTest {
         when(transaction.getId()).thenReturn(session1Id);
         when(txManager.create()).thenReturn(transaction);
 
-        repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM);
+        repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM, false);
 
         ocflIndex = new TestOcflObjectIndex();
         ocflIndex.reset();

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -147,7 +147,7 @@ public class OcflPersistentStorageSessionTest {
         final var workDir = tempFolder.newFolder("ocfl-work").toPath();
 
         final var objectMapper = OcflPersistentStorageUtils.objectMapper();
-        final var repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM);
+        final var repository = createFilesystemRepository(repoDir, workDir, DEFAULT_FEDORA_ALGORITHM, false);
         objectSessionFactory = new DefaultOcflObjectSessionFactory(repository, stagingDir,
                 objectMapper,
                 new NoOpCache<>(),


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3861 and https://fedora-repository.atlassian.net/browse/FCREPO-3862

# What does this Pull Request do?
Upgrades the version of OCFL Fedora writes from 1.0 to 1.1. 
It also adds a configuration property `fcrepo.ocfl.upgrade.enabled` to configure whether older (1.0) OCFL objects will get new versions written in 1.1 or stay with 1.0. It defaults to `false` (i.e. write in the old version)

# How should this be tested?

1. How I did this was wrote out a new OCFL repo with Fedora built from `main` (i.e. OCFL 1.0) and added a 2 or 3 objects.
1. Then I copied that directory to a second directory.
1. Then I stood this version up on top of one of the directories with no property configured. 
       * I wrote a new object then verified the on-disk representation was in OCFL 1.1
       * I edited an existing object and verified that the object and new version were still OCFL 1.0
1. Then I stood this version up on top of one of the directories with `fcrepo.ocfl.upgrade.enabled=true` configured. 
       * I wrote a new object then verified the on-disk representation was in OCFL 1.1
       * I edited an existing object and verified that the object and new version were now OCFL 1.1

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
