### PR TITLE
FCREPO-3689: Switch URL Decoder

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StreamingBaseHtmlProviderIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/StreamingBaseHtmlProviderIT.java
@@ -1,0 +1,84 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.integration.http.api;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.junit.Test;
+import org.springframework.test.context.TestExecutionListeners;
+
+/**
+ * @author mikejritter
+ */
+@TestExecutionListeners(
+    listeners = { TestIsolationExecutionListener.class },
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public class StreamingBaseHtmlProviderIT extends AbstractResourceIT {
+
+    private static final String TEXT_HTML = "text/html";
+
+    @Test
+    public void testGetContainer() throws IOException {
+        final String id = getRandomUniqueId();
+        final HttpPut put = putObjMethod(id);
+        executeAndClose(put);
+
+        final HttpGet get = getObjMethod(id);
+        get.addHeader("Accept", TEXT_HTML);
+
+        try (final var response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testGetEncodedCharacters() throws IOException {
+        final String id = "/some%3Atest";
+        final HttpPut put = putObjMethod(id);
+        executeAndClose(put);
+
+        final HttpGet get = getObjMethod(id);
+        get.addHeader("Accept", TEXT_HTML);
+
+        try (final var response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testGetContainerUTFCharacters() throws IOException {
+        final String id = "/ÅŤéșţ!";
+        final HttpPut put = putObjMethod(id);
+        executeAndClose(put);
+
+        final HttpGet get = getObjMethod(id);
+        get.addHeader("Accept", TEXT_HTML);
+
+        try (final var response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+    }
+
+    @Test
+    public void testGetContainerOtherCharacters() throws IOException {
+        final String id = "/a+&test";
+        final HttpPut put = putObjMethod(id);
+        executeAndClose(put);
+
+        final HttpGet get = getObjMethod(id);
+        get.addHeader("Accept", TEXT_HTML);
+
+        try (final var response = execute(get)) {
+            assertEquals(OK.getStatusCode(), getStatus(response));
+        }
+    }
+
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverter.java
@@ -9,7 +9,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,6 +18,7 @@ import org.fcrepo.kernel.api.identifiers.FedoraId;
 
 import org.glassfish.jersey.uri.UriTemplate;
 import org.slf4j.Logger;
+import org.springframework.util.StringUtils;
 
 /**
  * Convert between HTTP URIs (LDP paths) and internal Fedora ID using a
@@ -72,7 +72,7 @@ public class HttpIdentifierConverter {
         if (path != null) {
             final String decodedPath;
             if (!encoded) {
-                decodedPath = URLDecoder.decode(path, UTF_8);
+                decodedPath = StringUtils.uriDecode(path, UTF_8);
             } else {
                 decodedPath = path;
             }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/api/rdf/HttpIdentifierConverterTest.java
@@ -295,6 +295,30 @@ public class HttpIdentifierConverterTest {
     }
 
     /**
+     * Test some characters that should remain the same when part of the path
+     */
+    @Test
+    public void testQueryParamCharacters() {
+        final String id = "+&";
+        final String testUri = uriBase + "/" + id;
+        final String fedoraId = converter.toInternalId(testUri);
+        final String expectedId = FEDORA_ID_PREFIX + "/" + id;
+        assertEquals(expectedId, fedoraId);
+    }
+
+    /**
+     * Test encoded versions characters that should remain the same when part of the path
+     */
+    @Test
+    public void testEncodedQueryParamCharacters() {
+        final String encoded = "%2B%26";
+        final String testUri = uriBase + "/" + encoded;
+        final String fedoraId = converter.toInternalId(testUri);
+        final String expectedId = FEDORA_ID_PREFIX + "/+&";
+        assertEquals(expectedId, fedoraId);
+    }
+
+    /**
      * Utility function to get a UUID.
      * @return a UUID.
      */


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3869

# What does this Pull Request do?

Switch from the Java [URLDecoder](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/URLDecoder.html) to Spring [StringUtils](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/StringUtils.html#uriDecode(java.lang.String,java.nio.charset.Charset)) when decoding uris for internal ids.

# How should this be tested?

* Build + Run Fedora
* Using a snippet of the script in the issue, the test cases can be run
```
#!/bin/sh

info_fedora="http://localhost:8080/rest"
put="curl -XPUT -u fedoraAdmin:fedoraAdmin -H'Content-Type:application/ld+json'"

for n in 'c&h' 'c+h' 'c_h'; do
 encoded=$(jq -sRr --arg x $n '$x|@uri');
 v=$(echo -n "info:fedora/$n" | shasum -a 256); echo $n $encoded $v;
 curl --no-progress-meter -v -XPUT -u fedoraAdmin:fedoraAdmin -H'Content-Type:application/ld+json' --data "{\"@id\":\"\",\"http://schema.org/name\":\"$n\"}" "${info_fedora}/$encoded"
done

for n in 'c&h' 'c+h' 'c_h'; do
 encoded=$(jq -sRr --arg x $n '$x|@uri');
 echo "=$n or $encoded ="
 curl --no-progress-meter -XGET -u fedoraAdmin:fedoraAdmin -H'Accept:application/ld+json' --head ${info_fedora}/$encoded | grep HTTP
 curl --no-progress-meter -XGET -u fedoraAdmin:fedoraAdmin -H'Accept:application/ld+json' ${info_fedora}/$encoded | jq -r '[.[]["@id"],.[]["http://schema.org/name"][]["@value"]]'
 echo '==html=='
 curl --no-progress-meter -XGET -u fedoraAdmin:fedoraAdmin -H'Accept:text/html' --head ${info_fedora}/$encoded | grep HTTP
done
```
* As a note: jq was waiting for input when doing the encoding, so I had to `ctrl+d` through each step.
* If `jq` isn't available, the encoded versions are `%2B` for `+` and `%26` for `&`, though only `+` is affected by this change. The third curl command would also need to be adjusted.

It might be good to test an encoded UTF-8 string as well. I did include a test in the IT for this though. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
