### PR TITLE
Add buffer when reading input stream during fixity check

### DIFF
--- a/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapper.java
+++ b/fcrepo-persistence-common/src/main/java/org/fcrepo/persistence/common/MultiDigestInputStreamWrapper.java
@@ -37,6 +37,8 @@ import org.fcrepo.config.DigestAlgorithm;
  */
 public class MultiDigestInputStreamWrapper {
 
+    private static final int BUFFER_SIZE = 8192;
+
     private final InputStream sourceStream;
 
     private final Map<String, String> algToDigest;
@@ -165,8 +167,9 @@ public class MultiDigestInputStreamWrapper {
 
         if (!streamRetrieved) {
             // Stream not previously consumed, consume it now in order to calculate digests
+            final var buffer = new byte[BUFFER_SIZE];
             try (final InputStream is = getInputStream()) {
-                while (is.read() != -1) {
+                while (is.read(buffer) != -1) {
                 }
             } catch (final IOException e) {
                 throw new RepositoryRuntimeException("Failed to read content stream while calculating digests", e);


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3872

# What does this Pull Request do?

* Adds a buffer when reading input streams during fixity check

# How should this be tested?

* Ingest a largeish binary
  * If needed one is provided in the ticket
* Call `fcr:fixity` on the ingested binary 
  * e.g. `curl -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/binary-id/fcr:fixity`
  * `time curl ...` can be used to note the amount of time the call takes
* Build + run the changes from this PR
* Rerun the curl call on `fcr:fixity` and compare the response times

# Notes

Buffer size was informed by guava

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
