### PR TITLE
Fcrepo 3841

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -135,6 +135,10 @@ public class FedoraPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.cache.webac.acl.timeout.minutes:10}")
     private long webacCacheTimeout;
 
+    @Value("${fcrepo.register.api.banner:true}")
+    private boolean fcrepoRegsiterApiBanner;
+
+
     @PostConstruct
     private void postConstruct() throws IOException {
         LOGGER.info("Fedora home: {}", fedoraHome);
@@ -400,5 +404,12 @@ public class FedoraPropsConfig extends BasePropsConfig {
      */
     public long getWebacCacheTimeout() {
         return webacCacheTimeout;
+    }
+
+    /**
+     * @return whether to display the registration link banner in API responses or not.
+     */
+    public boolean getFcrepoRegsiterApiBanner() {
+        return fcrepoRegsiterApiBanner;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -161,6 +161,11 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     static final String HTTP_HEADER_ACCEPT_PATCH = "Accept-Patch";
 
+    static final String REGISTER_REPO_LINK = "https://registry.lyrasis.org/";
+    static final String REGISTER_REPO_TEXT = "We strongly encourage all users to register their instance " +
+                                             "in the DuraSpace Community Supported Program Registry hosted " +
+                                             "by LYRASIS. Register your installation today:";
+
     private static final String FCR_PREFIX = "fcr:";
     private static final Set<String> ALLOWED_FCR_PARTS = Set.of(FCR_METADATA, FCR_ACL);
 
@@ -589,6 +594,14 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected void addResourceHttpHeaders(final FedoraResource resource) {
         addResourceHttpHeaders(resource, false);
+    }
+
+
+    protected void addRegisterHeaders() {
+        if (fedoraPropsConfig.getFcrepoRegsiterApiBanner() == true) {
+            servletResponse.addHeader("USER-REGISTRATION", REGISTER_REPO_TEXT + " " + REGISTER_REPO_LINK);
+            servletResponse.addHeader("Link", "<" + REGISTER_REPO_LINK + ">; rel=\"user-regisration\"");
+        }
     }
 
     /**

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -789,6 +789,7 @@ public class FedoraLdp extends ContentExposingResource {
             servletResponse.addHeader(LINK, "<" + canonical + ">;rel=\"canonical\"");
 
         }
+        addRegisterHeaders();
         addExternalContentHeaders(resource);
         addTransactionHeaders(resource);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/FedoraLdpTest.java
@@ -254,6 +254,7 @@ public class FedoraLdpTest {
 
         final HttpRdfService httpRdfService = new HttpRdfService();
         setField(httpRdfService, "fedoraPropsConfig", fedoraPropsConfig);
+        setField(testObj, "fedoraPropsConfig", fedoraPropsConfig);
         when(fedoraPropsConfig.getServerManagedPropsMode()).thenReturn(STRICT);
 
         setField(testObj, "request", mockRequest);


### PR DESCRIPTION
**Add text and registration link to registration page to all API responses**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3841

* part of https://fedora-repository.atlassian.net/browse/FCREPO-3840

# What does this Pull Request do?
Adds 2 configurable headres to all API responses to link to the repo registration page

# How should this be tested?

* Ensure that the headers appear and are valid whilst also being removable by the ```fcrepo.register.api.banner``` property being set to ```false```

# Interested parties
@fcrepo/committers
