### PR TITLE
FCREPO-3876: NPEs when using Archive Groups

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -591,12 +591,18 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         addResourceHttpHeaders(resource, false);
     }
 
+    protected void addResourceHttpHeaders(final FedoraResource resource, final boolean dispositionInline) {
+        addResourceHttpHeaders(resource, dispositionInline, false);
+    }
+
     /**
      * Add any resource-specific headers to the response
      * @param resource the resource
      * @param dispositionInline whether to return a binary as Content-Disposition inline
      */
-    protected void addResourceHttpHeaders(final FedoraResource resource, final boolean dispositionInline) {
+    protected void addResourceHttpHeaders(final FedoraResource resource,
+                                          final boolean dispositionInline,
+                                          final boolean isRedirect) {
         if (resource instanceof Binary) {
             final Binary binary = (Binary)resource;
 
@@ -625,7 +631,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
             servletResponse.addHeader(CONTENT_TYPE, binary.getMimeType());
             // Returning content-length > 0 causes the client to wait for additional data before following the redirect.
-            if (!binary.isRedirect()) {
+            // final var responseIsRedirect = servletResponse.getStatus() >= 300 && servletResponse.getStatus() < 400;
+            if (!binary.isRedirect() && !isRedirect) {
                 servletResponse.addHeader(CONTENT_LENGTH, String.valueOf(binary.getContentSize()));
             }
             servletResponse.addHeader("Accept-Ranges", "bytes");

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -360,13 +360,14 @@ public class FedoraLdp extends ContentExposingResource {
             final Instant mementoDatetime = Instant.from(MEMENTO_RFC_1123_FORMATTER.parse(datetimeHeader));
             final FedoraResource memento = resource.findMementoByDatetime(mementoDatetime);
             final Response builder;
+            boolean isRedirect = false;
             if (memento != null) {
-                builder =
-                    status(FOUND).header(LOCATION, getUri(memento)).build();
+                isRedirect = true;
+                builder = status(FOUND).header(LOCATION, getUri(memento)).build();
             } else {
                 builder = status(NOT_ACCEPTABLE).build();
             }
-            addResourceHttpHeaders(resource, inlineDisposition);
+            addResourceHttpHeaders(resource, inlineDisposition, isRedirect);
             setVaryAndPreferenceAppliedHeaders(servletResponse, prefer, resource);
             return builder;
         } catch (final DateTimeParseException e) {
@@ -780,7 +781,13 @@ public class FedoraLdp extends ContentExposingResource {
 
     @Override
     protected void addResourceHttpHeaders(final FedoraResource resource, final boolean dispositionInline) {
-        super.addResourceHttpHeaders(resource, dispositionInline);
+        addResourceHttpHeaders(resource, dispositionInline, false);
+    }
+
+    protected void addResourceHttpHeaders(final FedoraResource resource,
+                                          final boolean dispositionInline,
+                                          final boolean isRedirect) {
+        super.addResourceHttpHeaders(resource, dispositionInline, isRedirect);
 
         if (!transaction().isShortLived()) {
             final String canonical = identifierConverter().toExternalId(resource.getFedoraId().getFullId())

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -183,13 +183,14 @@ public class FedoraVersioning extends ContentExposingResource {
             versionLinks.add(Link.fromUri(parentUri).rel("original").build());
             versionLinks.add(Link.fromUri(parentUri).rel("timegate").build());
             // So we don't collect the children twice, store them in an array.
-            final FedoraResource[] children = theTimeMap.getChildren().toArray(FedoraResource[]::new);
+            final FedoraResource[] children = theTimeMap.getChildren()
+                                                        .filter(FedoraResource::isMemento)
+                                                        .toArray(FedoraResource[]::new);
 
             Arrays.stream(children).forEach(t -> {
                 final URI childUri = getUri(t);
                 versionLinks.add(Link.fromUri(childUri).rel("memento")
-                                     .param("datetime",
-                        MEMENTO_RFC_1123_FORMATTER.format(t.getMementoDatetime()))
+                                     .param("datetime", MEMENTO_RFC_1123_FORMATTER.format(t.getMementoDatetime()))
                                      .build());
             });
             // Based on the dates of the above mementos, add the range to the below link.

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/models/FedoraResourceImpl.java
@@ -172,7 +172,7 @@ public class FedoraResourceImpl implements FedoraResource {
         FedoraResource match = null;
         long matchDiff = 0;
 
-        for (final var it = getTimeMap().getChildren().iterator(); it.hasNext();) {
+        for (final var it = getTimeMap().getChildren().filter(FedoraResource::isMemento).iterator(); it.hasNext();) {
             final var current = it.next();
             // Negative if the memento is AFTER the requested datetime
             // Positive if the memento is BEFORE the requested datetime


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3876

# What does this Pull Request do?
This updates fixes NPEs in two API calls - one for fcr:versions and the other using `Accept-Datetime` header. The NPE was being caused by trying to get the memento datetime on a tombstone, which obviously does not exist. Adding an additional check to make sure the resources are mementos resolves this issue.

Additionally, after fixing the NPE for the `Accept-Datetime` call an HTTP 500 was being returned. This was being caused by the `Content-Length` header being set and having no body in the response. Normally we would expect to see a 302 so I wasn't entirely sure what was going on, but jetty was not happy with this when finishing the response and was creating the exception. To resolve this I opted to pass a flag `isRedirect` so that we can skip setting any headers when not needed. I'm not sure if this is the best option but it simply is one. 

Also I don't have an Integration test created for this yet, but can do so if required. 

# How should this be tested?

Use the script from https://fedora-repository.atlassian.net/browse/FCREPO-3866 for the two bugs

or 

* Create an archive group
* Create a resource in the AG
* Deleted the resource + tombstone
* Recreate the resource in the AG
* Test the API calls for
  * `http://localhost:8080/fcrepo/rest/archivegroup/resource/fcr:versions`
  * `Accept-Datetime: $(date) http://localhost:8080/fcrepo/rest/archivegroup/resource`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
