### PR TITLE
FCREPO-3890: Add fedora version info endpoint

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/BasePropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/BasePropsConfig.java
@@ -23,7 +23,8 @@ import org.springframework.context.annotation.PropertySources;
 @PropertySources({
         @PropertySource(value = BasePropsConfig.DEFAULT_FCREPO_CONFIG_FILE_PROP_SOURCE,
                 ignoreResourceNotFound = true),
-        @PropertySource(value = BasePropsConfig.FCREPO_CONFIG_FILE_PROP_SOURCE, ignoreResourceNotFound = true)
+        @PropertySource(value = BasePropsConfig.FCREPO_CONFIG_FILE_PROP_SOURCE, ignoreResourceNotFound = true),
+        @PropertySource(value = BasePropsConfig.GIT_PROPERTIES, ignoreResourceNotFound = true)
 })
 abstract class BasePropsConfig {
 
@@ -32,6 +33,7 @@ abstract class BasePropsConfig {
     public static final String DEFAULT_FCREPO_CONFIG_FILE_PROP_SOURCE =
             "file:${" + FCREPO_HOME_PROPERTY + ":" + DEFAULT_FCREPO_HOME_VALUE + "}/config/fcrepo.properties";
     public static final String FCREPO_CONFIG_FILE_PROP_SOURCE = "file:${fcrepo.config.file}";
+    public static final String GIT_PROPERTIES = "classpath:git.properties";
 
     protected Path createDirectories(final Path path) throws IOException {
         try {

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/SystemInfoConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/SystemInfoConfig.java
@@ -1,0 +1,31 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Small config to get info from git properties and the implementation version
+ *
+ * @author mikejritter
+ */
+@Configuration
+public class SystemInfoConfig extends BasePropsConfig {
+
+    public static final String GIT_COMMIT = "git.commit.id.abbrev";
+
+    @Value("${" + GIT_COMMIT + ":#{null}}")
+    private String gitCommit;
+
+    public String getGitCommit() {
+        return gitCommit;
+    }
+
+    public String getImplementationVersion() {
+        return SystemInfoConfig.class.getPackage().getImplementationVersion();
+    }
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSystemInfo.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraSystemInfo.java
@@ -1,0 +1,49 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.http.api;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import io.micrometer.core.annotation.Timed;
+import org.fcrepo.config.SystemInfoConfig;
+
+
+/**
+ * Endpoint to display system info
+ *
+ * @author mikejritter
+ * @since 5/1/2023
+ */
+@Timed
+@Path("/fcr:systeminfo")
+public class FedoraSystemInfo extends FedoraBaseResource {
+
+    @Inject
+    private SystemInfoConfig config;
+
+    /**
+     * JAX-RS entry
+     */
+    public FedoraSystemInfo() {
+        super();
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response getSystemInfo() {
+        final var systemInfo = Map.of("version", config.getImplementationVersion(),
+                                      "commit", config.getGitCommit());
+        return Response.ok().entity(systemInfo).build();
+    }
+
+}

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/SearchResultProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/SearchResultProvider.java
@@ -12,6 +12,7 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.tools.generic.EscapeTool;
 
 import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.config.SystemInfoConfig;
 import org.fcrepo.http.api.FedoraSearch;
 import org.fcrepo.http.commons.responses.ViewHelpers;
 import org.fcrepo.search.api.Condition;
@@ -61,6 +62,9 @@ public class SearchResultProvider implements MessageBodyWriter<SearchResult> {
 
     @Inject
     private FedoraPropsConfig fedoraPropsConfig;
+
+    @Inject
+    private SystemInfoConfig systemInfoConfig;
 
     private static final EscapeTool escapeTool = new EscapeTool();
 
@@ -155,6 +159,8 @@ public class SearchResultProvider implements MessageBodyWriter<SearchResult> {
         context.put("esc", escapeTool);
         context.put("uriInfo", uriInfo);
         context.put("fedoraProps", fedoraPropsConfig);
+        context.put("fedoraCommit", systemInfoConfig.getGitCommit());
+        context.put("fedoraVersion", systemInfoConfig.getImplementationVersion());
         return context;
     }
 

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/responses/StreamingBaseHtmlProvider.java
@@ -48,6 +48,7 @@ import javax.ws.rs.ext.Provider;
 
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.config.OcflPropsConfig;
+import org.fcrepo.config.SystemInfoConfig;
 import org.fcrepo.http.api.FedoraLdp;
 import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.responses.HtmlTemplate;
@@ -105,6 +106,9 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
 
     @Inject
     private FedoraPropsConfig fedoraPropsConfig;
+
+    @Inject
+    private SystemInfoConfig systemInfoConfig;
 
     private boolean autoVersioningEnabled;
 
@@ -265,6 +269,8 @@ public class StreamingBaseHtmlProvider implements MessageBodyWriter<RdfNamespace
         context.put("topic", subject);
         context.put("originalResource", VIEW_HELPERS.getOriginalResource(subject));
         context.put("uriInfo", uriInfo);
+        context.put("fedoraCommit", systemInfoConfig.getGitCommit());
+        context.put("fedoraVersion", systemInfoConfig.getImplementationVersion());
         return context;
     }
 

--- a/fcrepo-http-api/src/main/resources/views/binary.vsl
+++ b/fcrepo-http-api/src/main/resources/views/binary.vsl
@@ -5,7 +5,6 @@
 #set( $title = $helpers.getObjectTitle($rdf, $topic) )
 #set( $contentNode = $helpers.getContentNode($topic) )
 
-
 #parse("views/common.vsl")
 <html>
 <head>
@@ -14,14 +13,11 @@
     #parse("views/common-head.vsl")
 </head>
 
-
 <body class="fcrepo_binary">
 <div  id="main" class="container" resource="$topic.getURI()">
     #parse("views/common-node-header.vsl")
 
-
     <div class="row">
-
         <div class="col-md-12">
             #parse("views/common-breadcrumb.vsl")
         </div>
@@ -50,13 +46,9 @@
                     #triples($contentNode)
                 </div>
             </div>
-
         </div>
-
-
     </div>
-
-
+    #parse("views/common-footer.vsl")
 </div>
 </body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/common-footer.vsl
+++ b/fcrepo-http-api/src/main/resources/views/common-footer.vsl
@@ -1,0 +1,9 @@
+<footer class="navbar navbar-default" style="margin-bottom: 0px; margin-top: 40px" role="navigation">
+  <ul class="nav navbar-nav">
+    <li><a href="https://fedora-repository.atlassian.net/issues/">Issue Tracker</a></li>
+    <li><a href="https://wiki.lyrasis.org/display/FF">Wiki</a></li>
+    <li><a href="https://wiki.lyrasis.org/display/FF/Documentation">REST API Documentation</a></li>
+    <li><a href="http://fedora.info">Ontologies and Specifications</a></li>
+  </ul>
+  <p class="navbar-text pull-right">Release: <span id="version">$fedoraVersion</span> | Commit <span id="commit">$fedoraCommit</span></p>
+</footer>

--- a/fcrepo-http-api/src/main/resources/views/default.vsl
+++ b/fcrepo-http-api/src/main/resources/views/default.vsl
@@ -72,11 +72,8 @@
             #end
             </div>
         </div>
-
-
     </div>
-
-
+    #parse("views/common-footer.vsl")
 </div>
 </body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/fcr-fixity.vsl
+++ b/fcrepo-http-api/src/main/resources/views/fcr-fixity.vsl
@@ -64,10 +64,8 @@
 		         #end
 		     </div>
         </div>
-
     </div>
-
-
+    #parse("views/common-footer.vsl")
 </div>
 </body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
+++ b/fcrepo-http-api/src/main/resources/views/fcr-versions.vsl
@@ -29,7 +29,8 @@
         #else
             <p>No versions have been created for this resource.</p>
         #end
-     </div>
-  </div>
+    </div>
+    #parse("views/common-footer.vsl")
+</div>
 </body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/resource.vsl
+++ b/fcrepo-http-api/src/main/resources/views/resource.vsl
@@ -76,8 +76,7 @@
         </div>
 
     </div>
-
-
+    #parse("views/common-footer.vsl")
 </div>
 </body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/root.vsl
+++ b/fcrepo-http-api/src/main/resources/views/root.vsl
@@ -72,8 +72,8 @@
         </div>
 
       </div>
+    </div>
+    #parse("views/common-footer.vsl")
 </div>
-
-  </div>
-  </body>
+</body>
 </html>

--- a/fcrepo-http-api/src/main/resources/views/search.vsl
+++ b/fcrepo-http-api/src/main/resources/views/search.vsl
@@ -50,6 +50,7 @@
             #end
         </div>
     </div>
+    #parse("views/common-footer.vsl")
 </div>
 </body>
 </html>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -283,6 +283,26 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>

--- a/fcrepo-webapp/src/main/webapp/static/css/common.css
+++ b/fcrepo-webapp/src/main/webapp/static/css/common.css
@@ -2,10 +2,6 @@
     display: none;
 }
 
-body {
-    padding-bottom: 40px;
-}
-
 .fcrepo_binary #action_create {
     display: none;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -753,6 +753,12 @@
           <artifactId>jetty-maven-plugin</artifactId>
           <version>${jetty.version}</version>
         </plugin>
+
+        <plugin>
+          <groupId>io.github.git-commit-id</groupId>
+          <artifactId>git-commit-id-maven-plugin</artifactId>
+          <version>5.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3890

# What does this Pull Request do?
* Creates new endpoint /systeminfo for displaying version info
* Adds version and git commit to web ui
* Update the header on the root ui page to be consistent with other pages

# How should this be tested?
* Build Fedora, e.g.
  * `mvn clean verify -Pone-click`
* Run Fedora, e.g.
  * `java -jar fcrepo-webapp/target/fcrepo-webapp-6.5.0-SNAPSHOT-jetty-console.jar`
* Check the `/fcr:systeminfo` info returns the correct response
  * `curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/fcr:systeminfo`
* Check the web ui and make sure the footer exists on all pages

# Other Notes

I haven't tested acls on the new endpoint but might be worth trying.

The splash page also displays the version and commit, however does it in a different way (seems like it gets set during the build, and uses a different plugin for getting the git commit).

# Interested parties
@fcrepo/committers
