### PR TITLE
Skip WebAc if we're not requesting a fedora resource.

### DIFF
--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerRolesPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/ContainerRolesPrincipalProvider.java
@@ -9,6 +9,7 @@ import static java.util.Collections.emptySet;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.io.Serializable;
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -31,7 +32,7 @@ public class ContainerRolesPrincipalProvider extends AbstractPrincipalProvider {
     /**
      * @author Kevin S. Clarke
      */
-    public static class ContainerRolesPrincipal implements Principal {
+    public static class ContainerRolesPrincipal implements Principal, Serializable {
 
         private final String name;
 

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProvider.java
@@ -7,6 +7,7 @@ package org.fcrepo.auth.common;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.io.Serializable;
 import java.security.Principal;
 import java.util.Set;
 
@@ -23,7 +24,7 @@ public class DelegateHeaderPrincipalProvider extends HttpHeaderPrincipalProvider
     private static final String SEP = "no-separator";
     protected static final String DELEGATE_HEADER = "On-Behalf-Of";
 
-    public static class DelegatedHeaderPrincipal implements Principal {
+    public static class DelegatedHeaderPrincipal implements Principal, Serializable {
 
         private final String name;
 

--- a/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
+++ b/fcrepo-auth-common/src/main/java/org/fcrepo/auth/common/HttpHeaderPrincipalProvider.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.io.Serializable;
 import java.security.Principal;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +26,7 @@ import java.util.Set;
  */
 public class HttpHeaderPrincipalProvider extends AbstractPrincipalProvider {
 
-    public static class HttpHeaderPrincipal implements Principal {
+    public static class HttpHeaderPrincipal implements Principal, Serializable {
 
         private final String name;
 


### PR DESCRIPTION
Make our principal providers implement Serializable

**JIRA Ticket**: Sort of [FCREPO-3358](https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3358) and https://github.com/fcrepo/fcrepo/issues/2031

# What does this Pull Request do?

I think this is my error, but when we can't resolve the Fedora resource we still do all the auth code instead of passing along to the next item in the chain. I'm not sure how we can reliably check for authorization based on the current resource if we can't resolve it. 

This normally works, except in Islandora where (for some reason) our Tomcat Valve causes a request to the root context path to throw a 500. Basically the same error that we catch here
```java
  try {
      FedoraId.create(identifierConverter(httpRequest).toInternalId(requestUrl));
  } catch (final InvalidResourceIdentifierException e) {
      printException(response, SC_BAD_REQUEST, e);
      return;
  } catch (final IllegalArgumentException e) {
      // No Fedora request path provided, so just continue along.
  }
```
Explodes further on.

This wraps the WebAC chain to only execute if we can resolve the current Fedora resource.

It also makes our 3 extra principal providers implement Serializable, this is also used by the Islandora Tomcat Valve as we pass in the roles using the `HttpHeaderPrincipalProvider`. See linked Github issue for more information on the error message from Tomcat.

# How should this be tested?

Deploy Fedora to a Tomcat 9 instance, also build [Islandora Syn](https://github.com/Islandora/Syn) and include the library in your Tomcat `lib` directory.
Then add to your `<tomcat home>/conf/context.xml` a line like
```xml
<Valve className="ca.islandora.syn.valve.SynValve" pathname="/path/to/syn-settings.xml" />
```

You can find an example `syn-settings.xml` in the [`conf`](https://github.com/Islandora/Syn/tree/1.x/conf) folder of the `Syn` git repo. It really doesn't matter what is in the file, as you just need to be able to get Tomcat running.

Then try a GET to the root context path, so if you deploy Fedora at `fedora.war` try `http://localhost:8080/fedora`. Also try `http://localhost:8080/fedora/` and `http://localhost:8080/fedora/rest` just to make sure.

Before this PR you should see a 500 Server error when accessing `http://localhost:8080/fedora` but not `http://localhost:8080/fedora/rest`.
After this PR both should work.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
