### PR TITLE
Include Transction ID in Conflict Response

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -429,4 +429,11 @@ public class FedoraPropsConfig extends BasePropsConfig {
         return includeTransactionOnConflict;
     }
 
+    /**
+     * @param includeTransactionOnConflict if transaction ids should be included in conflict error responses
+     */
+    public void setIncludeTransactionOnConflict(final boolean includeTransactionOnConflict) {
+        this.includeTransactionOnConflict = includeTransactionOnConflict;
+    }
+
 }

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -47,6 +47,7 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_JMS_DESTINATION_NAME = "fcrepo.jms.destination.name";
     public static final String FCREPO_JMS_ENABLED = "fcrepo.jms.enabled";
     private static final String FCREPO_EVENT_THREADS = "fcrepo.event.threads";
+    public static final String FCREPO_TRANSACTION_ON_CONFLICT = "fcrepo.response.include.transaction";
 
     private static final String DATA_DIR_DEFAULT_VALUE = "data";
     private static final String LOG_DIR_DEFAULT_VALUE = "logs";
@@ -137,6 +138,9 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${fcrepo.banner.enabled:true}")
     private boolean bannerEnabled;
+
+    @Value("${" + FCREPO_TRANSACTION_ON_CONFLICT + ":false}")
+    private boolean includeTransactionOnConflict;
 
 
     @PostConstruct
@@ -416,6 +420,13 @@ public class FedoraPropsConfig extends BasePropsConfig {
      */
     public boolean getBannerEnabled() {
         return bannerEnabled;
+    }
+
+    /**
+     * @return if transaction ids should be included in conflict error responses
+     */
+    public boolean includeTransactionOnConflict() {
+        return includeTransactionOnConflict;
     }
 
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/TransactionsIT.java
@@ -986,6 +986,7 @@ public class TransactionsIT extends AbstractResourceIT {
 
     @Test
     public void concurrentSparqlUpdatesShouldNotBeAllowed() throws Exception {
+        propsConfig.setIncludeTransactionOnConflict(true);
         final var containerId = getRandomUniqueId();
 
         putContainer(containerId, null);
@@ -1001,6 +1002,7 @@ public class TransactionsIT extends AbstractResourceIT {
         final var response = getResource(containerId, null);
         assertTrue("title should have been updated", response.contains("new title"));
         assertFalse("concurrent update should not have been applied", response.contains("concurrent update!"));
+        propsConfig.setIncludeTransactionOnConflict(false);
     }
 
     @Test
@@ -1200,7 +1202,11 @@ public class TransactionsIT extends AbstractResourceIT {
         } catch (final HttpResponseException e) {
             assertEquals(CONFLICT.getStatusCode(), e.getStatusCode());
             assertTrue("concurrent update exception",
-                    e.getReasonPhrase().contains("updated by another transaction"));
+                       e.getReasonPhrase().contains("updated by another transaction"));
+            assertEquals("transaction id in response", propsConfig.includeTransactionOnConflict(),
+                         e.getReasonPhrase().contains("existingTransactionId"));
+            assertEquals("transaction id in response", propsConfig.includeTransactionOnConflict(),
+                         e.getReasonPhrase().contains("conflictingTransactionId"));
         }
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
@@ -5,15 +5,17 @@
  */
 package org.fcrepo.http.commons.exceptionhandlers;
 
+import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
 import org.slf4j.Logger;
 
+import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import static javax.ws.rs.core.Response.status;
-import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -25,10 +27,14 @@ public class ConcurrentUpdateExceptionMapper implements
 
     private static final Logger LOGGER = getLogger(ConcurrentUpdateExceptionMapper.class);
 
+    @Inject
+    private FedoraPropsConfig config;
+
     @Override
     public Response toResponse(final ConcurrentUpdateException e) {
         debugException(this, e, LOGGER);
-        return status(Response.Status.CONFLICT).entity(e.getMessage()).type(TEXT_PLAIN_WITH_CHARSET).build();
+        return status(Response.Status.CONFLICT).entity(e.getResponseBody(config.includeTransactionOnConflict()))
+                                               .type(RDFMediaType.APPLICATION_JSON_TYPE).build();
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
@@ -6,17 +6,22 @@
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.http.commons.api.rdf.HttpIdentifierConverter;
 import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.http.commons.responses.ConcurrentExceptionResponse;
 import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
 import org.slf4j.Logger;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 import static javax.ws.rs.core.Response.status;
+import static org.fcrepo.http.commons.session.TransactionConstants.TX_PREFIX;
+import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -31,11 +36,26 @@ public class ConcurrentUpdateExceptionMapper implements
     @Inject
     private FedoraPropsConfig config;
 
+    @Context
+    private UriInfo uriInfo;
+
     @Override
     public Response toResponse(final ConcurrentUpdateException e) {
         debugException(this, e, LOGGER);
+        final var response = new ConcurrentExceptionResponse(e.getResponseMessage());
+
+        // create external links for the transaction ids
+        if (config.includeTransactionOnConflict()) {
+            final var identifierConverter = new HttpIdentifierConverter(uriInfo.getBaseUriBuilder()
+                                                                               .clone().path("/{path: .*}"));
+            final var existingId = FEDORA_ID_PREFIX + "/" + TX_PREFIX + e.getExistingTransactionId();
+            final var conflictingId = FEDORA_ID_PREFIX + "/" + TX_PREFIX + e.getConflictingTransactionId();
+            response.setExistingTransactionId(identifierConverter.toExternalId(existingId));
+            response.setConflictingTransactionId(identifierConverter.toExternalId(conflictingId));
+        }
+
         return status(Response.Status.CONFLICT)
-            .entity(new ConcurrentExceptionResponse(e, config.includeTransactionOnConflict()))
+            .entity(response)
             .type(RDFMediaType.APPLICATION_JSON_TYPE).build();
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ConcurrentUpdateExceptionMapper.java
@@ -7,6 +7,7 @@ package org.fcrepo.http.commons.exceptionhandlers;
 
 import org.fcrepo.config.FedoraPropsConfig;
 import org.fcrepo.http.commons.domain.RDFMediaType;
+import org.fcrepo.http.commons.responses.ConcurrentExceptionResponse;
 import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
 import org.slf4j.Logger;
 
@@ -33,8 +34,9 @@ public class ConcurrentUpdateExceptionMapper implements
     @Override
     public Response toResponse(final ConcurrentUpdateException e) {
         debugException(this, e, LOGGER);
-        return status(Response.Status.CONFLICT).entity(e.getResponseBody(config.includeTransactionOnConflict()))
-                                               .type(RDFMediaType.APPLICATION_JSON_TYPE).build();
+        return status(Response.Status.CONFLICT)
+            .entity(new ConcurrentExceptionResponse(e, config.includeTransactionOnConflict()))
+            .type(RDFMediaType.APPLICATION_JSON_TYPE).build();
     }
 
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExceptionDebugLogging.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/ExceptionDebugLogging.java
@@ -28,8 +28,7 @@ public interface ExceptionDebugLogging {
         if (!logger.isDebugEnabled()) {
             return;
         }
-        logger.debug("{} intercepted exception:{} \n", context.getClass()
-                .getSimpleName(), error);
+        logger.debug("{} intercepted exception:", context.getClass().getSimpleName(), error);
         logger.trace(error.getMessage(), error);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ConcurrentExceptionResponse.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ConcurrentExceptionResponse.java
@@ -26,15 +26,10 @@ public class ConcurrentExceptionResponse {
     /**
      * Response for {@link org.fcrepo.kernel.api.exception.ConcurrentUpdateException}
      *
-     * @param e the exception to map
-     * @param includeTransactions whether transaction ids should be included
+     * @param message the exception message
      */
-    public ConcurrentExceptionResponse(final ConcurrentUpdateException e, final boolean includeTransactions) {
-        this.message = e.getResponseMessage();
-        if (includeTransactions) {
-            this.existingTransactionId = e.getExistingTransactionId();
-            this.conflictingTransactionId = e.getConflictingTransactionId();
-        }
+    public ConcurrentExceptionResponse(final String message) {
+        this.message = message;
     }
 
     public String getMessage() {
@@ -47,5 +42,13 @@ public class ConcurrentExceptionResponse {
 
     public String getConflictingTransactionId() {
         return conflictingTransactionId;
+    }
+
+    public void setExistingTransactionId(final String existingTransactionId) {
+        this.existingTransactionId = existingTransactionId;
+    }
+
+    public void setConflictingTransactionId(final String conflictingTransactionId) {
+        this.conflictingTransactionId = conflictingTransactionId;
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ConcurrentExceptionResponse.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/responses/ConcurrentExceptionResponse.java
@@ -1,0 +1,51 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.http.commons.responses;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.fcrepo.kernel.api.exception.ConcurrentUpdateException;
+
+/**
+ * Response body for {@link ConcurrentUpdateException}. The message always is returned, and the transaction ids are
+ * returned if the fcrepo.response.include.transaction property is set.
+ *
+ * @author mikejritter
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ConcurrentExceptionResponse {
+
+    private final String message;
+
+    private String existingTransactionId;
+
+    private String conflictingTransactionId;
+
+    /**
+     * Response for {@link org.fcrepo.kernel.api.exception.ConcurrentUpdateException}
+     *
+     * @param e the exception to map
+     * @param includeTransactions whether transaction ids should be included
+     */
+    public ConcurrentExceptionResponse(final ConcurrentUpdateException e, final boolean includeTransactions) {
+        this.message = e.getResponseMessage();
+        if (includeTransactions) {
+            this.existingTransactionId = e.getExistingTransactionId();
+            this.conflictingTransactionId = e.getConflictingTransactionId();
+        }
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getExistingTransactionId() {
+        return existingTransactionId;
+    }
+
+    public String getConflictingTransactionId() {
+        return conflictingTransactionId;
+    }
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
@@ -5,9 +5,6 @@
  */
 package org.fcrepo.kernel.api.exception;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This exception indicates that a resource could not be modified because it is currently being modified by another
  * transaction.
@@ -38,15 +35,15 @@ public class ConcurrentUpdateException extends RepositoryRuntimeException {
         this.existingTx = existingTx;
     }
 
-    public Map<String, String> getResponseBody(final boolean includeTxId) {
-        final var response = new HashMap<String, String>();
-        response.put("message", String.format(HTTP_MESSAGE, resource));
-        if (includeTxId) {
-            response.put("existingTransactionId", existingTx);
-            response.put("conflictingTransactionId", conflictingTx);
-        }
-
-        return response;
+    public String getResponseMessage() {
+        return String.format(HTTP_MESSAGE, resource);
     }
 
+    public String getExistingTransactionId() {
+        return existingTx;
+    }
+
+    public String getConflictingTransactionId() {
+        return conflictingTx;
+    }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/ConcurrentUpdateException.java
@@ -5,6 +5,9 @@
  */
 package org.fcrepo.kernel.api.exception;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * This exception indicates that a resource could not be modified because it is currently being modified by another
  * transaction.
@@ -13,13 +16,37 @@ package org.fcrepo.kernel.api.exception;
  */
 public class ConcurrentUpdateException extends RepositoryRuntimeException {
 
+    private static final String LOG_MESSAGE =
+        "Cannot update %s because it is being updated by another transaction (%s).";
+    private static final String HTTP_MESSAGE = "Cannot update %s because it is being updated by another transaction";
+
+    private final String resource;
+    private final String existingTx;
+    private final String conflictingTx;
+
     /**
      * Constructor
      *
-     * @param msg message
+     * @param resource the Fedora response
+     * @param conflictingTx the transaction id attempting to lock the resource
+     * @param existingTx the transaction id holding the resource
      */
-    public ConcurrentUpdateException(final String msg) {
-        super(msg);
+    public ConcurrentUpdateException(final String resource, final String conflictingTx, final String existingTx) {
+        super(String.format(LOG_MESSAGE, resource, existingTx));
+        this.resource = resource;
+        this.conflictingTx = conflictingTx;
+        this.existingTx = existingTx;
+    }
+
+    public Map<String, String> getResponseBody(final boolean includeTxId) {
+        final var response = new HashMap<String, String>();
+        response.put("message", String.format(HTTP_MESSAGE, resource));
+        if (includeTxId) {
+            response.put("existingTransactionId", existingTx);
+            response.put("conflictingTransactionId", conflictingTx);
+        }
+
+        return response;
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManager.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/lock/InMemoryResourceLockManager.java
@@ -87,9 +87,7 @@ public class InMemoryResourceLockManager implements ResourceLockManager {
                     // 2. We need a non-exclusive lock, but another tx holds an exclusive lock
                     if ((lockType == EXCLUSIVE && !lock.getTransactionId().equals(txId))
                             || lock.hasLockType(EXCLUSIVE)) {
-                        throw new ConcurrentUpdateException(
-                                String.format("Cannot update %s because it is being updated by another transaction.",
-                                        resourceId.getResourceId()));
+                        throw new ConcurrentUpdateException(resourceId.getResourceId(), txId, lock.getTransactionId());
                     }
                 }
             }


### PR DESCRIPTION

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3893

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
* #2040 

# What does this Pull Request do?
This updates the Concurrent Update handling to allow the transaction ids to be included in various places. When logging the existing transaction id is always present, and in the http response the existing and conflicting ids can be enabled via a property (`fcrepo.response.include.transaction`).

* Adds property to include transaction ids in 409s
* Moved exception messages into ConcurrentUpdateException
* Added transaction ids to ConcurrentUpdateException
* Added model for ConcurrentUpdateException response body
* Removed unused placeholder in ExceptionDebugLogging

# How should this be tested?

* Note - I tested this with an existing container (`my-container`), and a simple sparql update (`body.rdf`):
  ```
  PREFIX dc: <http://purl.org/dc/elements/1.1/>
  INSERT {   
    <> dc:title "some-resource-title" .
  }
  WHERE { }
  ```
* Run `mvn clean install` (or your preferred way of building) to ensure all tests pass and there are no checkstyle errors
* Run Fedora without the property set and verify the transactions are not present in the response, e.g.
  ```
  mvn jetty:run -pl fcrepo-webapp -Dfcrepo.log=DEBUG -Dfcrepo.home=${FEDORA_DATA}
  curl -v -u fedoraAdmin:fedoraAdmin -X POST http://localhost:8080/rest/fcr:tx # Get the TX ID
  curl -v -u fedoraAdmin:fedoraAdmin -H "Atomic-ID: ${TX_ID}" -X PATCH -H "Content-Type: application/sparql-update" --data-binary "@body.rdf" "http://localhost:8080/rest/my-container"
  curl -v -u fedoraAdmin:fedoraAdmin -X PATCH -H "Content-Type: application/sparql-update" --data-binary "@body.rdf" "http://localhost:8080/rest/my-container" # This should return the 409
  curl -v -u fedoraAdmin:fedoraAdmin -X PUT ${TX_ID}
  ``` 
* Run Fedora with the include tx property set and verify the transactions are present in the response, e.g.
  ```
  mvn jetty:run -pl fcrepo-webapp -Dfcrepo.log=DEBUG -Dfcrepo.home=${FEDORA_DATA} -Dfcrepo.response.include.transaction=true
  curl -v -u fedoraAdmin:fedoraAdmin -X POST http://localhost:8080/rest/fcr:tx # Get the TX ID
  curl -v -u fedoraAdmin:fedoraAdmin -H "Atomic-ID: ${TX_ID}" -X PATCH -H "Content-Type: application/sparql-update" --data-binary "@body.rdf" "http://localhost:8080/rest/my-container"
  curl -v -u fedoraAdmin:fedoraAdmin -X PATCH -H "Content-Type: application/sparql-update" --data-binary "@body.rdf" "http://localhost:8080/rest/my-container" # This should return the 409
  curl -v -u fedoraAdmin:fedoraAdmin -X PUT ${TX_ID}
  ```

# Interested parties
@fcrepo/committers
