### PR TITLE
Add property for HikariCP initialization fail timeout

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/DatabaseConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/DatabaseConfig.java
@@ -60,6 +60,9 @@ public class DatabaseConfig extends BasePropsConfig {
     @Value("${fcrepo.db.connection.checkout.timeout:30000}")
     private Integer checkoutTimeout;
 
+    @Value("${fcrepo.db.connection.initializationFail.timeout:1}")
+    private Integer initializeFailTimeout;
+
     private static final Map<String, String> DB_DRIVER_MAP = Map.of(
             "h2", "org.h2.Driver",
             "postgresql", "org.postgresql.Driver",
@@ -96,6 +99,7 @@ public class DatabaseConfig extends BasePropsConfig {
         dataSource.setPassword(dbPassword);
         dataSource.setConnectionTimeout(checkoutTimeout);
         dataSource.setMaximumPoolSize(maxPoolSize);
+        dataSource.setInitializationFailTimeout(initializeFailTimeout);
 
         flyway(dataSource);
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3903

# What does this Pull Request do?
Exposes property for the HikariCP `initializationFailTimeout` (https://github.com/brettwooldridge/HikariCP#infrequently-used), the default is `1` which fails immediately. Changing this to `-1` seems to allow the startup to wait.

This will also require the addition of this new property to documentation.

# How should this be tested?

Setup and then stop a mysql container.
```sh
> docker run --name fcrepo-database -e MYSQL_ROOT_PASSWORD=root-pw -e MYSQL_DATABASE=fcrepo -e MYSQL_USER=fcrepo-user -e MYSQL_PASSWORD=fcrepo-pw -p 3306:3306 -d mysql:8.0
> docker container stop fcrepo-database
```
Then start Fedora with the new `fcrepo.db.connection.fail.timeout` set.

If you set it to `-Dfcrepo.db.connection.fail.timeout=1`, (which is the default) 

```sh
> mvn -Dfcrepo.db.connection.fail.timeout=1 -Dfcrepo.log=DEBUG -Dfcrepo.db.url=jdbc:mysql://localhost:3306/fcrepo -Dfcrepo.db.user=fcrepo-user -Dfcrepo.db.password=fcrepo-pw -Dfcrepo.home=/Users/jaredwhiklo/www/fcrepo4/ocfl_temp jetty:run -pl fcrepo-webapp
```
You'll see
```
INFO 13:23:32.252 [main] (OcflPropsConfig) Fedora OCFL digest algorithm: SHA-512
INFO 13:23:32.272 [main] (DatabaseConfig) JDBC URL: jdbc:mysql://localhost:3306/fcrepo
INFO 13:23:32.272 [main] (DatabaseConfig) JDBC User: fcrepo-user
INFO 13:23:32.272 [main] (DatabaseConfig) JDBC Password length: 9
INFO 13:23:32.272 [main] (DatabaseConfig) Using database driver: com.mysql.cj.jdbc.Driver
DEBUG 13:23:32.277 [main] (DatabaseConfig) Instantiating a new flyway bean
ERROR 13:23:33.382 [main] (HikariPool) HikariPool-1 - Exception during pool initialization.
com.mysql.cj.jdbc.exceptions.CommunicationsException: Communications link failure

The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
```
and then stacktraces.

If you set it to `-Dfcrepo.db.connection.fail.timeout=0` or `-Dfcrepo.db.connection.fail.timeout=-1`

```sh
> mvn -Dfcrepo.db.connection.fail.timeout=-1 -Dfcrepo.log=DEBUG -Dfcrepo.db.url=jdbc:mysql://localhost:3306/fcrepo -Dfcrepo.db.user=fcrepo-user -Dfcrepo.db.password=fcrepo-pw -Dfcrepo.home=/Users/jaredwhiklo/www/fcrepo4/ocfl_temp jetty:run -pl fcrepo-webapp
```

It should stop initializing and hang at
```
INFO 13:19:01.301 [main] (OcflPropsConfig) Fedora OCFL digest algorithm: SHA-512
INFO 13:19:01.319 [main] (DatabaseConfig) JDBC URL: jdbc:mysql://localhost:3306/fcrepo
INFO 13:19:01.319 [main] (DatabaseConfig) JDBC User: fcrepo-user
INFO 13:19:01.319 [main] (DatabaseConfig) JDBC Password length: 9
INFO 13:19:01.319 [main] (DatabaseConfig) Using database driver: com.mysql.cj.jdbc.Driver
DEBUG 13:19:01.324 [main] (DatabaseConfig) Instantiating a new flyway bean
```
Without exiting (i.e. another terminal/window) restart the database container
```sh
> docker container start fcrepo-database
```
The application should then continue to start up.
```
INFO 13:22:27.419 [main] (OcflPropsConfig) Fedora OCFL digest algorithm: SHA-512
INFO 13:22:27.439 [main] (DatabaseConfig) JDBC URL: jdbc:mysql://localhost:3306/fcrepo
INFO 13:22:27.439 [main] (DatabaseConfig) JDBC User: fcrepo-user
INFO 13:22:27.439 [main] (DatabaseConfig) JDBC Password length: 9
INFO 13:22:27.439 [main] (DatabaseConfig) Using database driver: com.mysql.cj.jdbc.Driver
DEBUG 13:22:27.445 [main] (DatabaseConfig) Instantiating a new flyway bean
DEBUG 13:22:49.174 [main] (DbPlatform) Identified database as: MySQL
DEBUG 13:22:49.183 [main] (DbPlatform) Identified database as: MySQL
DEBUG 13:22:49.188 [main] (DbPlatform) Identified database as: MySQL
DEBUG 13:22:49.195 [main] (WebappConfig) Event bus threads: org.fcrepo.config.FedoraPropsConfig$$EnhancerBySpringCGLIB$$f87ee774@7ad0d002
DEBUG 13:22:49.210 [main] (DbPlatform) Identified database as: MySQL
INFO 13:22:49.249 [main] (JmsConfig) JMS messaging enabled
INFO 13:22:49.282 [main] (AuthConfig) Auth delegate principal provider enabled
DEBUG 13:22:49.697 [main] (AbstractJMSPublisher) Initializing: org.fcrepo.jms.JMSTopicPublisher
DEBUG 13:22:49.800 [ScheduledTask1] (TransactionManagerImpl) Cleaning up expired transactions
INFO 13:22:49.805 [ScheduledTask1] (RepositoryInitializer) Initializing repository
DEBUG 13:22:49.820 [ScheduledTask1] (IndexBuilderImpl) No index rebuild necessary
```


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
