### PR TITLE
Add other resources part to NonRdfSourceDescription HTML template

### DIFF
--- a/fcrepo-http-api/src/main/resources/views/binary.vsl
+++ b/fcrepo-http-api/src/main/resources/views/binary.vsl
@@ -46,6 +46,32 @@
                     #triples($contentNode)
                 </div>
             </div>
+
+            ## output other nodes
+
+            <h2>Other Resources</h2>
+            <div class="panel-group" id="accordion">
+            #foreach($subject in $model.listSubjects())
+                #if( $subject != $topic )
+                    #set( $subUri = #$helpers.getResourceId($subject) )
+                    <div class="panel panel-default" resource="$subUri">
+                        <div class="panel-heading collapsed" data-toggle="collapse" data-target="#$helpers.parameterize($subUri)_triples" >
+                            #if( $subject.getURI() && $subject.getURI().startsWith("http") )
+                                <h3 class="ctitle panel-title"><a href="$subject.getURI()">$esc.html($helpers.getObjectTitle($rdf, $subject.asNode()))</a></h3>
+                            #else
+                                <h3 class="ctitle panel-title">$esc.html($helpers.getObjectTitle($rdf, $subject.asNode()))</h3>
+                            #end
+                        </div>
+                        <div class="panel-collapse collapse"  id="$helpers.parameterize($subUri)_triples">
+                            <div class="panel-body">
+                                #triples($subject.asNode())
+                            </div>
+                        </div>
+                    </div>
+                #end
+            #end
+            </div>
+
         </div>
     </div>
     #parse("views/common-footer.vsl")


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3904

# What does this Pull Request do?
You can have a hash uri in the metadata of a binary. It displays except when you view the HTML UI. This is because the velocity templates don't currently display these other properties.

# How should this be tested?

Create a binary and update the metadata with a hash uri.
i.e.
```bash
> curl -ufedoraAdmin:fedoraAdmin -v -H"Content-type: image/jpeg" -d "@test_image.jpg" -H"Slug: test_image" -XPOST http://localhost:8080/rest

> curl -ufedoraAdmin:fedoraAdmin -v -XPATCH -d " INSERT DATA { <#somePart> <http://purl.org/dc/elements/1.1/title> 'Some part' . <> <http://purl.org/dc/elements/1.1/title> 'Binary thing' . }" -H"Content-type: application/sparql-update" http://localhost:8080/rest/test_image/fcr:metadata
```

View the binary description RDF as non-HTML
```bash
> curl -ufedoraAdmin:fedoraAdmin -v http://localhost:8080/rest/test_image/fcr:metadata
```
and view it through a web browser at the URL

Before the PR, you will see the `<http://localhost:8080/rest/test_image#somePart> <http://purl.org/dc/elements/1.1/title>  "Some part" .` triple in the non-HTML, but in your web browser it will be missing. 

Stop Fedora. 
Pull in the PR and build it.
Restart your Fedora.

In the browser you will now see "Some part" under "Other Resources", the non-HTML is unaffected.


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers and @tomcbe
