### PR TITLE
Return mementos and timemaps on Tombstones

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -101,6 +101,7 @@ import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.exception.InsufficientStorageException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
+import org.fcrepo.kernel.api.exception.ItemNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.exception.PathNotFoundRuntimeException;
 import org.fcrepo.kernel.api.exception.PreconditionException;
@@ -263,13 +264,28 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      * @return {@link RdfStream}
      */
     private RdfStream getResourceTriples(final int limit, final FedoraResource resource) {
-
         final LdpPreferTag ldpPreferences = getLdpPreferTag();
 
         final List<Stream<Triple>> embedStreams = new ArrayList<>();
 
-        embedStreams.add(resourceTripleService.getResourceTriples(
-                transaction(), resource, ldpPreferences, limit));
+        try {
+            embedStreams.add(resourceTripleService.getResourceTriples(
+                    transaction(), resource, ldpPreferences, limit));
+        } catch (ItemNotFoundException e) {
+            if (resource instanceof Tombstone && ((Tombstone) resource).getDeletedObject().isMemento()) {
+                // There is a version created when the object is deleted.
+                // This memento has no content file so an ItemNotFound is thrown. Generate a new 410 Gone response.
+                final var orig_resource = ((Tombstone) resource).getDeletedObject();
+                final var timeMap = identifierConverter().toExternalId(
+                        orig_resource.getFedoraId().asTimemap().toString()
+                );
+                final var tombstone = identifierConverter().toExternalId(
+                        resource.getFedoraId().asTombstone().toString()
+                );
+                throw new TombstoneException(orig_resource, tombstone, timeMap);
+            }
+            throw e;
+        }
 
         // Embed the children of this object
         if (ldpPreferences.displayEmbed()) {
@@ -384,7 +400,16 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected FedoraResource resource() {
         if (fedoraResource == null) {
-            fedoraResource = getResourceFromPath(externalPath());
+            try {
+                fedoraResource = getResourceFromPath(externalPath());
+            } catch (TombstoneException e) {
+                // We now want to display Mementos for a deleted object, so catch the Tombstone exception.
+                fedoraResource = e.getFedoraResource();
+                if (! fedoraResource.isMemento()) {
+                    // Rethrow the exception if we are not requesting a Memento.
+                    throw e;
+                }
+            }
         }
         return fedoraResource;
     }
@@ -700,7 +725,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             servletResponse.addHeader("ETag", etag.toString());
         }
 
-        if (!resource.getStateToken().isEmpty()) {
+        if (resource.getStateToken() != null && !resource.getStateToken().isEmpty()) {
             //State Tokens, while not used for caching per se,  nevertheless belong
             //here since we can conveniently reuse the value of the etag for
             //our state token
@@ -1042,7 +1067,9 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
             if (originalResource instanceof Tombstone) {
                 final String tombstoneUri = identifierConverter().toExternalId(
                             originalResource.getFedoraId().asTombstone().getFullId());
-                throw new TombstoneException(fedoraResource, tombstoneUri);
+                final String timemapUri = identifierConverter().toExternalId(
+                        originalResource.getTimeMap().getFedoraId().getFullId());
+                throw new TombstoneException(fedoraResource, tombstoneUri, timemapUri);
             }
 
             return fedoraResource;

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -540,7 +540,8 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
         if (resource.isMemento()) {
             options = "GET,HEAD,OPTIONS";
         } else if (resource instanceof TimeMap) {
-            options = "POST,HEAD,GET,OPTIONS";
+            options = (resource.getOriginalResource() instanceof Tombstone ? "HEAD,GET,OPTIONS" :
+                    "POST,HEAD,GET,OPTIONS");
             addAcceptPostHeader();
         } else if (resource instanceof Binary) {
             options = "DELETE,HEAD,GET,PUT,OPTIONS";

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -169,7 +169,13 @@ public class FedoraVersioning extends ContentExposingResource {
         TEXT_HTML_WITH_CHARSET, APPLICATION_LINK_FORMAT })
     public Response getVersionList(@HeaderParam("Accept") final String acceptValue) throws IOException {
 
-        final FedoraResource theTimeMap = resource().getTimeMap();
+        FedoraResource theTimeMap;
+        try {
+            theTimeMap = resource().getTimeMap();
+        } catch (TombstoneException e) {
+            // We return timemaps for deleted resources, so get the original resource from the Tombstone exception.
+            theTimeMap = e.getFedoraResource().getOriginalResource().getTimeMap();
+        }
         checkCacheControlHeaders(request, servletResponse, theTimeMap, transaction());
 
         LOGGER.debug("GET resource '{}'", externalPath());
@@ -243,17 +249,5 @@ public class FedoraVersioning extends ContentExposingResource {
     @Override
     protected String externalPath() {
         return externalPath;
-    }
-
-    @Override
-    protected FedoraResource resource() {
-        FedoraResource fedoraResource;
-        try {
-            fedoraResource = super.resource();
-        } catch (TombstoneException e) {
-            // We return timemaps for deleted resources, so get the original resource from the Tombstone exception.
-            fedoraResource = e.getFedoraResource().getOriginalResource();
-        }
-        return fedoraResource;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraVersioning.java
@@ -14,6 +14,7 @@ import org.fcrepo.kernel.api.exception.CannotCreateMementoException;
 import org.fcrepo.kernel.api.exception.InvalidChecksumException;
 import org.fcrepo.kernel.api.exception.MementoDatetimeFormatException;
 import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+import org.fcrepo.kernel.api.exception.TombstoneException;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Scope;
@@ -242,5 +243,17 @@ public class FedoraVersioning extends ContentExposingResource {
     @Override
     protected String externalPath() {
         return externalPath;
+    }
+
+    @Override
+    protected FedoraResource resource() {
+        FedoraResource fedoraResource;
+        try {
+            fedoraResource = super.resource();
+        } catch (TombstoneException e) {
+            // We return timemaps for deleted resources, so get the original resource from the Tombstone exception.
+            fedoraResource = e.getFedoraResource().getOriginalResource();
+        }
+        return fedoraResource;
     }
 }

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/services/EtagService.java
@@ -52,8 +52,9 @@ public class EtagService {
     public String getRdfResourceEtag(final Transaction transaction, final FedoraResource resource,
                                      final LdpTriplePreferences prefers,
                                      final Collection<MediaType> acceptableMediaTypes) {
+        final String stateToken = (resource.getStateToken() != null ? resource.getStateToken() : "");
         // Start etag based on the current state of the fedora resource, using the state token
-        final StringBuilder etag = new StringBuilder(resource.getStateToken());
+        final StringBuilder etag = new StringBuilder(stateToken);
 
         // Factor in the requested mimetype(s)
         final String mimetype = acceptableMediaTypes.stream()

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
@@ -5,6 +5,32 @@
  */
 package org.fcrepo.integration.http.api;
 
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.junit.Assert.assertEquals;
+
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.HttpHeaders.LINK;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static javax.ws.rs.core.Response.Status.GONE;
+import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static javax.ws.rs.core.Response.Status.OK;
+
+import javax.ws.rs.core.Link;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.codec.Charsets;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -21,30 +47,6 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.junit.Test;
 import org.springframework.test.context.TestExecutionListeners;
-
-import javax.ws.rs.core.Link;
-import java.io.IOException;
-import java.net.URI;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.concurrent.TimeUnit;
-
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static javax.ws.rs.core.HttpHeaders.LINK;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.CREATED;
-import static javax.ws.rs.core.Response.Status.GONE;
-import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-import static javax.ws.rs.core.Response.Status.OK;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
-import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
-import static org.junit.Assert.assertEquals;
 
 /**
  * Tests related to tombstone stuff.

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraTombstonesIT.java
@@ -5,8 +5,30 @@
  */
 package org.fcrepo.integration.http.api;
 
-import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.codec.Charsets;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.StringEntity;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.junit.Test;
+import org.springframework.test.context.TestExecutionListeners;
+
+import javax.ws.rs.core.Link;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
@@ -17,25 +39,12 @@ import static javax.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
-
-import javax.ws.rs.core.Link;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-
-import org.apache.commons.codec.Charsets;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.StringEntity;
-import org.junit.Test;
-import org.springframework.test.context.TestExecutionListeners;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
+import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
+import static org.fcrepo.kernel.api.RdfLexicon.CONTAINS;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests related to tombstone stuff.
@@ -57,6 +66,11 @@ public class FedoraTombstonesIT extends AbstractResourceIT {
         try (final CloseableHttpResponse response = execute(req)) {
             return getTombstoneLink(response);
         }
+    }
+
+    private Instant convertMementoToDate(final String mementoUri) {
+        final String[] splits = mementoUri.split(FCR_VERSIONS + "/");
+        return Instant.from(MEMENTO_LABEL_FORMATTER.parse(splits[1]));
     }
 
     @Test
@@ -207,5 +221,58 @@ public class FedoraTombstonesIT extends AbstractResourceIT {
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(new HttpPut(uri + "/" + getRandomUniqueId())));
         assertEquals(BAD_REQUEST.getStatusCode(), getStatus(new HttpPut(uri + "/" + getRandomUniqueId() + "/" +
                 getRandomUniqueId())));
+    }
+
+    @Test
+    public void testTimeMapVisibleOnTombstone() throws Exception {
+        final String uri;
+        try (final var response = execute(postObjMethod())) {
+            assertEquals(CREATED.getStatusCode(), getStatus(response));
+            uri = getLocation(response);
+        }
+        final var timemapUri = uri + "/" + FCR_VERSIONS;
+        TimeUnit.SECONDS.sleep(1);
+        final var patchReq = new HttpPatch(uri);
+        patchReq.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patchReq.setEntity(new StringEntity("INSERT DATA { <> <http://purl.org/dc/elements/1.1/title> \"This is a title\" }"));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(patchReq));
+        TimeUnit.SECONDS.sleep(1);
+        final var patchReq1 = new HttpPatch(uri);
+        patchReq1.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patchReq1.setEntity(new StringEntity("INSERT DATA { <> <http://purl.org/dc/elements/1.1/description> \"This is a description\" }"));
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(patchReq1));
+        // Object should have 3 versions.
+        TimeUnit.SECONDS.sleep(1);
+        // Delete the object, now it has 4 versions.
+        assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(uri)));
+        try (final var response = execute(new HttpGet(uri))) {
+            // Assert it is gone.
+            assertEquals(GONE.getStatusCode(), getStatus(response));
+            // Assert the timemap link header is returned
+            checkForLinkHeader(response, timemapUri, "timemap");
+        }
+        final ArrayList<String> mementos = new ArrayList<>();
+        try (final var response = execute(new HttpGet(timemapUri))) {
+            // Assert the timemap is accessible
+            assertEquals(OK.getStatusCode(), getStatus(response));
+            try (final CloseableDataset dataset = getDataset(response)) {
+                final DatasetGraph graph = dataset.asDatasetGraph();
+                final var iter = graph.find(Node.ANY, Node.ANY, CONTAINS.asNode(), Node.ANY);
+                while (iter.hasNext()) {
+                    final var memento = iter.next().getObject().getURI();
+                    mementos.add(memento);
+                }
+                assertEquals(4, mementos.size(), 0);
+            }
+        }
+        final Node subjectNode = createResource(uri).asNode();
+        // Sort the mementos by datetime.
+        mementos.sort((e1, e2) -> convertMementoToDate(e1).compareTo(convertMementoToDate(e2)));
+        // The other mementos should return 200 OK.
+        for (var foo = 0; foo < mementos.size() - 1; foo += 1) {
+            assertEquals(OK.getStatusCode(), getStatus(new HttpGet(mementos.get(foo))));
+        }
+        // The last is the deleted, which returns the 410 Gone.
+        assertEquals(GONE.getStatusCode(), getStatus(new HttpGet(mementos.get(mementos.size() - 1))));
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -1487,10 +1487,10 @@ public class FedoraVersioningIT extends AbstractResourceIT {
         // Check it is gone
         final HttpGet getDeletedContainer = getObjMethod(id);
         assertEquals(GONE.getStatusCode(), getStatus(getDeletedContainer));
-        // Check the timemap is GONE
+        // Check the timemap still exist
         final HttpGet getDeletedTimemap = getObjMethod(id + "/" + FCR_VERSIONS);
-        assertEquals(GONE.getStatusCode(), getStatus(getDeletedTimemap));
-        // Check the memento is GONE
+        assertEquals(OK.getStatusCode(), getStatus(getDeletedTimemap));
+        // Because the two versions (creation and deletion) occur in the same second, we have a single memento.
         final HttpGet getDeletedMemento = new HttpGet(mementos.get(0));
         assertEquals(GONE.getStatusCode(), getStatus(getDeletedMemento));
     }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/TombstoneExceptionMapper.java
@@ -6,13 +6,14 @@
 package org.fcrepo.http.commons.exceptionhandlers;
 
 import org.fcrepo.kernel.api.exception.TombstoneException;
-
 import org.slf4j.Logger;
 
+import javax.ws.rs.core.Link;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import static javax.ws.rs.core.HttpHeaders.LINK;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.GONE;
 import static javax.ws.rs.core.Response.status;
@@ -35,8 +36,11 @@ public class TombstoneExceptionMapper implements
         final Response.ResponseBuilder response = status(GONE)
                 .entity(e.getMessage());
 
-        if (e.getURI() != null) {
-            response.link(e.getURI(), "hasTombstone");
+        if (e.getTombstoneURI() != null) {
+            response.link(e.getTombstoneURI(), "hasTombstone");
+        }
+        if (e.getTimemapUri() != null) {
+            response.header(LINK, Link.fromUri(e.getTimemapUri()).rel("timemap").build().toString());
         }
 
         return response.type(TEXT_PLAIN_TYPE).build();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/TombstoneException.java
@@ -24,7 +24,11 @@ public class TombstoneException extends RepositoryRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
-    private final String uri;
+    private final String tombstoneUri;
+
+    private final String timemapUri;
+
+    private final FedoraResource fedoraResource;
 
     private static DateTimeFormatter isoFormatter = ISO_INSTANT.withZone(UTC);
 
@@ -33,26 +37,43 @@ public class TombstoneException extends RepositoryRuntimeException {
      * @param resource the fedora resource
      */
     public TombstoneException(final FedoraResource resource) {
-        this(resource, null);
+        this(resource, null, null);
     }
 
     /**
      * Create a new tombstone exception with a URI to the tombstone resource
      * @param resource the fedora resource
      * @param tombstoneUri the uri to the tombstone resource for the Link header.
+     * @param timemapUri the uri to the resource's timemap for a Link header.
      */
-    public TombstoneException(final FedoraResource resource, final String tombstoneUri) {
+    public TombstoneException(final FedoraResource resource, final String tombstoneUri, final String timemapUri) {
         super("Discovered tombstone resource at " + resource.getFedoraId().getFullIdPath() +
                 (Objects.nonNull(resource.getLastModifiedDate()) ? ", departed at: " +
                 isoFormatter.format(resource.getLastModifiedDate()) : ""));
-        this.uri = tombstoneUri;
+        this.tombstoneUri = tombstoneUri;
+        this.timemapUri = timemapUri;
+        this.fedoraResource = resource;
     }
 
     /**
      * Get a URI to the tombstone resource
      * @return the URI to the tombstone resource
      */
-    public String getURI() {
-        return uri;
+    public String getTombstoneURI() {
+        return tombstoneUri;
+    }
+
+    /**
+     * @return the timemap URI
+     */
+    public String getTimemapUri() {
+        return timemapUri;
+    }
+
+    /**
+     * @return the original resource of the tombstone.
+     */
+    public FedoraResource getFedoraResource() {
+        return fedoraResource;
     }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -27,6 +27,7 @@ import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.TimeMap;
+import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
 import org.springframework.stereotype.Component;
@@ -51,6 +52,14 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
         var createdDate = resource.getCreatedDate();
         var lastModifiedBy = resource.getLastModifiedBy();
         var lastModifiedDate = resource.getLastModifiedDate();
+
+        if (createdDate == null && resource.getOriginalResource() instanceof Tombstone) {
+            final var deletedResource = ((Tombstone)resource.getOriginalResource()).getDeletedObject();
+            createdBy = deletedResource.getCreatedBy();
+            createdDate = deletedResource.getCreatedDate();
+            lastModifiedBy = deletedResource.getLastModifiedBy();
+            lastModifiedDate = deletedResource.getLastModifiedDate();
+        }
 
         if (describedResource instanceof Binary) {
             final Binary binary = (Binary) describedResource;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3882

# What does this Pull Request do?
Adds a Link header to the Timemap of the original resource to the Tombstone Exception returned.
Allows access to get the timemap resource of the deleted objects.
Allows access to get the mementos of the deleted objects.

# How should this be tested?

1. Create an object (either RDF or binary)
2. Make a change to that object
3. Delete the object 

| Step | Before PR | After PR |
| --- | --- | --- |
| 4. Get the object | Receive Tombstone with Tombstone Link header | Receive Tombstone with Tombstone and Timemap Link header |
| 5. Get the timemap | Tombstone returned | Timemap is returned |
| 6. Get any memento | Tombstone returned | Memento is returned |


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
