### PR TITLE
More sonatype host fixes

### DIFF
--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -23,7 +23,7 @@
     <project.copyrightYear>2015</project.copyrightYear>
     <!-- scm, site distribution names -->
     <project_name>${project.artifactId}</project_name>
-    <project_organization>fcrepo4</project_organization>
+    <project_organization>fcrepo</project_organization>
     <!-- OSGi -->
     <osgi.import.packages />
     <osgi.private.packages />

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -543,11 +543,11 @@
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Shapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://${sonatype.host}/content/repositories/snapshots/</url>
     </snapshotRepository>
     <repository>
       <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://${sonatype.host}/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     <!-- Use ${project_name} and ${project_organization instead of ${project.artifactId}
       to avoid incorrect replacements of "fcrepo4" in child modules
       (for scm, site-distribution, etc -->
-    <project_name>fcrepo4</project_name>
-    <project_organization>fcrepo4</project_organization>
+    <project_name>fcrepo</project_name>
+    <project_organization>fcrepo</project_organization>
     <!-- Dependency version properties -->
     <activemq.version>5.16.7</activemq.version>
     <commons-codec.version>1.15</commons-codec.version>
@@ -704,7 +704,7 @@
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/fcrepo4/fcrepo4/issues</url>
+    <url>https://github.com/fcrepo/fcrepo/issues</url>
   </issueManagement>
 
   <ciManagement>


### PR DESCRIPTION
Missed the snapshot repositories, also fixed the Github URLs to point to the new org/repo.

**JIRA Ticket**: Related to releasing because of https://fedora-repository.atlassian.net/browse/FCREPO-3911

# What does this Pull Request do?
Changes URLs

# How should this be tested?

You will be able to release Fedora 5 🤞 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
