### PR TITLE
bumping ActiveMQ to non-exploited version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <project_organization>fcrepo</project_organization>
     <fcrepo-storage-ocfl.version>6.4.0-SNAPSHOT</fcrepo-storage-ocfl.version>
     <!-- Dependency version properties -->
-    <activemq.version>5.16.3</activemq.version>
+    <activemq.version>5.16.7</activemq.version>
     <aws.version>2.17.50</aws.version>
     <caffeine.version>3.0.4</caffeine.version>
     <commons-codec.version>1.15</commons-codec.version>


### PR DESCRIPTION
**Bumping ActiveMQ to non-exploited version**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3911

# What does this Pull Request do?
only bumps minor version of activemq

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
