### PR TITLE
Allow continuation of a reindex

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/FedoraPropsConfig.java
@@ -41,6 +41,7 @@ public class FedoraPropsConfig extends BasePropsConfig {
     private static final String FCREPO_REBUILD_VALIDATION = "fcrepo.rebuild.validation";
     private static final String FCREPO_REBUILD_VALIDATION_FIXITY = "fcrepo.rebuild.validation.fixity";
     private static final String FCREPO_REBUILD_ON_START = "fcrepo.rebuild.on.start";
+    private static final String FCREPO_REBUILD_CONTINUE = "fcrepo.rebuild.continue";
     private static final String FCREPO_JMS_BASEURL = "fcrepo.jms.baseUrl";
     private static final String FCREPO_SERVER_MANAGED_PROPS_MODE = "fcrepo.properties.management";
     private static final String FCREPO_JMS_DESTINATION_TYPE = "fcrepo.jms.destination.type";
@@ -100,6 +101,9 @@ public class FedoraPropsConfig extends BasePropsConfig {
 
     @Value("${" + FCREPO_REBUILD_ON_START + ":false}")
     private boolean rebuildOnStart;
+
+    @Value("${" + FCREPO_REBUILD_CONTINUE + ":false}")
+    private boolean rebuildContinue;
 
     @Value("${" + FCREPO_JMS_BASEURL + ":#{null}}")
     private String jmsBaseUrl;
@@ -311,6 +315,20 @@ public class FedoraPropsConfig extends BasePropsConfig {
      */
     public void setRebuildOnStart(final boolean rebuildOnStart) {
         this.rebuildOnStart = rebuildOnStart;
+    }
+
+    /**
+     * @return true if we should run a rebuild to add those resources missing from the indexes.
+     */
+    public boolean isRebuildContinue() {
+        return rebuildContinue;
+    }
+
+    /**
+     * @param rebuildContinue A boolean flag indicating whether or not to continue a rebuild on start
+     */
+    public void setRebuildContinue(final boolean rebuildContinue) {
+        this.rebuildContinue = rebuildContinue;
     }
 
     /**

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/ObjectExistsInOcflIndexException.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/exceptions/ObjectExistsInOcflIndexException.java
@@ -1,0 +1,37 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.persistence.api.exceptions;
+
+import org.fcrepo.kernel.api.exception.RepositoryRuntimeException;
+
+/**
+ * If an OCFL object already exists in the index.
+ * @author whikloj
+ * @since 6.4.1
+ */
+public class ObjectExistsInOcflIndexException extends RepositoryRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Basic constructor
+     *
+     * @param msg The text of the exception.
+     */
+    public ObjectExistsInOcflIndexException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param msg message
+     * @param rootCause cause
+     */
+    public ObjectExistsInOcflIndexException(final String msg, final Throwable rootCause) {
+        super(msg, rootCause);
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3907

# What does this Pull Request do?
Adds a new flag to allow the continuation of a failed re-indexing.

# How should this be tested?

In theory you need a lot of objects.
1. Start up the site either with empty indexes to with `fcrepo.rebuild.on.start=true` set.
2. Stop or wait for it to fail (assuming it does normally fail)
3. Set `fcrepo.rebuild.continue=true`, you can remove the `fcrepo.rebuild.on.start` flag but this flag takes precendence so you will still be okay.
4. Start Fedora.

The messages will now show a count of those skipped items as well as successful and errors. At the end you should have all your items available.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
