### PR TITLE
Add DirectContainer link header to ldp:hasMemberRelation checks

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/AbstractResourceIT.java
@@ -565,7 +565,7 @@ public abstract class AbstractResourceIT {
         return createObjectWithLinkHeader(pid, null);
     }
 
-    private CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String... linkHeaders) {
+    protected CloseableHttpResponse createObjectWithLinkHeader(final String pid, final String... linkHeaders) {
         final HttpPost httpPost = postObjMethod("/");
         if (isNotEmpty(pid)) {
             httpPost.addHeader("Slug", URLEncoder.encode(pid, StandardCharsets.UTF_8));


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3927

# What does this Pull Request do?
This updates the ServerManagedTriplesIT to add the DirectContainer link header in order for the constraints to be properly checked. This ensures that the checks in `AbstractService#ensureValidDirectContainer` are run and the proper 409 response is returned.

# How should this be tested?

* Test that Fedora rebuilds and tests pass with `mvn install`

# Interested parties
@fcrepo/committers
