### PR TITLE
FCREPO-3922: NonRdfSource metadata throws stacktrace once deleted

### DIFF
--- a/fcrepo-webapp/src/main/webapp/static/js/common.js
+++ b/fcrepo-webapp/src/main/webapp/static/js/common.js
@@ -119,7 +119,7 @@
           // (c.f. https://jira.duraspace.org/browse/FCREPO-2387)
           // WARNING: Fragile code relying on magic suffix '/fcr:metadata' and absence of 'Link' header
           // on external resource.
-          if(!url.match(/.*fcr:(metadata|tx|fixity)/)){
+          if(!url.match(/.*fcr:(metadata|tx|fixity|versions)/)){
             newLocation = url + "/fcr:metadata";
           }
           location.href = newLocation;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3922

# What does this Pull Request do?
* Adds versions endpoint to matcher
* Handle invalid memento exception in the WebACFilter

# Why are we doing this?
The admin ui will incorrectly try to navigate to `fcr:metadata` when accessing tombstone versions of resources. This prevents it from doing so by checking if the url ends with `fcr:versions` in order to prevent it from appending `fcr:metadata` again. In my limited use with the ui I haven't seen anything be broken, but it could use more thorough testing.

In addition when this bug was discovered we saw that the server was returning a 500 with a stacktrace instead of a 400. The `InvalidMementoPathException` was never being handled in the `WebACFilter` which has been updated to return a 400 with a `constrainedBy` link header. We should eventually create integration tests to trigger both the InvalidResourceIdentifierException and InvalidMementoPathException.

# How should this be tested?

* Rebuild and run Fedora
* In the Fedora UI:
  * Create a binary, edit it’s metadata, delete it (preferably taking a second or more for each action to get 3 mementos).
  * Access the versions endpoint of your binary
  * Navigate to the first two mementos
  * For the third memento, when navigating see the tombstone
* Use curl to try to access the third memento's metadata incorrectly and receive a 400
  * curl -v -u fedoraAdmin:fedoraAdmin http://localhost:8080/rest/5a2ff56a-0b13-4d9c-8b9f-58e479118ffc/fcr:versions/20240328195445/fcr:metadata

# Interested parties
@fcrepo/committers
