### PR TITLE
Add a SMT for OCFL path

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/DisplayOcflPath.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/DisplayOcflPath.java
@@ -1,0 +1,40 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+/**
+ * Display OCFL path mode enum
+ * @author whikloj
+ */
+public enum DisplayOcflPath {
+    NONE("none"),
+    RELATIVE("relative"),
+    ABSOLUTE("absolute");
+
+    private final String value;
+
+    DisplayOcflPath(final String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static DisplayOcflPath fromString(final String value) {
+        for (final var mode : values()) {
+            if (mode.value.equalsIgnoreCase(value)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException("Unknown display OCFL path mode: " + value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -34,6 +34,7 @@ public class OcflPropsConfig extends BasePropsConfig {
     public static final String FCREPO_OCFL_ROOT = "fcrepo.ocfl.root";
     public static final String FCREPO_OCFL_TEMP = "fcrepo.ocfl.temp";
     private static final String FCREPO_OCFL_S3_BUCKET = "fcrepo.ocfl.s3.bucket";
+    private static final String FCREPO_OCFL_SHOW_PATH = "fcrepo.ocfl.display_path";
 
     private static final String OCFL_STAGING = "staging";
     private static final String OCFL_ROOT = "ocfl-root";
@@ -120,6 +121,10 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.verify.inventory:true}")
     private boolean verifyInventory;
 
+    @Value("${" + FCREPO_OCFL_SHOW_PATH + ":none}")
+    private String displayOcflPathStr;
+    private DisplayOcflPath displayOcflPath;
+
     @Value("${fcrepo.ocfl.s3.timeout.connection.seconds:60}")
     private int s3ConnectionTimeout;
 
@@ -187,6 +192,8 @@ public class OcflPropsConfig extends BasePropsConfig {
                             .collect(Collectors.joining(", "))));
         }
         LOGGER.info("Fedora OCFL digest algorithm: {}", FCREPO_DIGEST_ALGORITHM.getAlgorithm());
+        displayOcflPath = DisplayOcflPath.fromString(displayOcflPathStr);
+        LOGGER.info("Fedora OCFL display path: {}", displayOcflPath.getValue());
     }
 
     /**
@@ -545,5 +552,19 @@ public class OcflPropsConfig extends BasePropsConfig {
      */
     public int getS3MaxConcurrency() {
         return s3MaxConcurrency;
+    }
+
+    /**
+     * @param displayOcflPath the display OCFL path mode
+     */
+    public void setDisplayOcflPath(final String displayOcflPath) {
+        this.displayOcflPath = DisplayOcflPath.fromString(displayOcflPath);
+    }
+
+    /**
+     * @return the display OCFL path mode
+     */
+    public DisplayOcflPath getDisplayOcflPath() {
+        return displayOcflPath;
     }
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -109,6 +109,8 @@ public final class RdfLexicon {
             createProperty(REPOSITORY_NAMESPACE + "lastModified");
     public static final Property LAST_MODIFIED_BY =
             createProperty(REPOSITORY_NAMESPACE + "lastModifiedBy");
+    public static final Property FEDORA_OCFL_PATH =
+            createProperty(REPOSITORY_NAMESPACE + "ocflPath");
 
     public static final Resource FEDORA_CONTAINER =
             createResource(REPOSITORY_NAMESPACE + "Container");

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import javax.inject.Inject;
 
+import java.io.File;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -151,10 +152,13 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
             for (int i = 0; i < ocflIdHash.length(); i += 3) {
                 hashSlices.add(ocflIdHash.substring(i, Math.min(i + 3,ocflIdHash.length())));
             }
-            final var ocflPath = hashSlices.get(0) + "/" + hashSlices.get(1) + "/" + hashSlices.get(2) + "/" +
-                    ocflIdHash;
-            return (displayOcflPath == DisplayOcflPath.ABSOLUTE ? ocflPropsConfig.getOcflRepoRoot() + "/" : "") +
-                    ocflPath;
+            final var ocflPath = hashSlices.get(0) + File.separator + hashSlices.get(1) + File.separator +
+                    hashSlices.get(2) + File.separator + ocflIdHash;
+            return (
+                    displayOcflPath == DisplayOcflPath.ABSOLUTE ?
+                            ocflPropsConfig.getOcflRepoRoot() + File.separator :
+                            ""
+            ) + ocflPath;
         } catch (NoSuchAlgorithmException e) {
             final var message = "Unable to resolve OCFL path for resource " + resource.getId();
             LOGGER.error(message, e);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
@@ -1,0 +1,244 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime;
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong;
+import static org.apache.jena.rdf.model.ResourceFactory.createPlainLiteral;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
+import static org.fcrepo.kernel.api.RdfCollectors.toModel;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_OCFL_PATH;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.fcrepo.config.DisplayOcflPath;
+import org.fcrepo.config.OcflPropsConfig;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.Binary;
+import org.fcrepo.kernel.api.models.Container;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author whikloj
+ */
+public class ManagedPropertiesServiceImplTest {
+
+    @Mock
+    private Container containerResource;
+
+    @Mock
+    private Binary binaryResource;
+
+    private static final String RESOURCE_ID = "info:fedora/resource1";
+
+    private static final String RESOURCE_HASH = "69bb8862c69cfa4c1a607c9a8afa693bbd714353f29327a40b0c671d532035f9";
+    private static final String RESOURCE_OCFL_PATH = RESOURCE_HASH.substring(0,3) + "/" +
+            RESOURCE_HASH.substring(3, 6) + "/" + RESOURCE_HASH.substring(6, 9) + "/" + RESOURCE_HASH;
+
+    private static final String OCFL_ROOT = "/ocfl/root";
+
+    private static final FedoraId FEDORA_ID = FedoraId.create(RESOURCE_ID);
+
+    private final Resource subject = createResource(FEDORA_ID.getFullId());
+
+    private static final String USER = "test";
+
+    private static final Instant RESOURCE_LAST_MODIFIED_DATE = Instant.now().minus(2, ChronoUnit.HOURS);
+
+    private static final Instant RESOURCE_CREATED_DATE = Instant.now().minus(1, ChronoUnit.DAYS);
+
+    @Mock
+    private OcflPropsConfig ocflPropsConfig;
+
+    @InjectMocks
+    private ManagedPropertiesServiceImpl managedPropertiesService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(ocflPropsConfig.getDisplayOcflPath()).thenReturn(DisplayOcflPath.NONE);
+        when(ocflPropsConfig.getOcflRepoRoot()).thenReturn(Path.of(OCFL_ROOT));
+
+        when(containerResource.getDescribedResource()).thenReturn(containerResource);
+        when(containerResource.getOriginalResource()).thenReturn(containerResource);
+        when(containerResource.getCreatedBy()).thenReturn(USER);
+        when(containerResource.getCreatedDate()).thenReturn(RESOURCE_CREATED_DATE);
+        when(containerResource.getLastModifiedBy()).thenReturn(USER);
+        when(containerResource.getLastModifiedDate()).thenReturn(RESOURCE_LAST_MODIFIED_DATE);
+        when(containerResource.getFedoraId()).thenReturn(FEDORA_ID);
+        when(containerResource.getId()).thenReturn(FEDORA_ID.getResourceId());
+
+        when(binaryResource.getDescribedResource()).thenReturn(binaryResource);
+        when(binaryResource.getOriginalResource()).thenReturn(binaryResource);
+        when(binaryResource.getCreatedBy()).thenReturn(USER);
+        when(binaryResource.getCreatedDate()).thenReturn(RESOURCE_CREATED_DATE);
+        when(binaryResource.getLastModifiedBy()).thenReturn(USER);
+        when(binaryResource.getLastModifiedDate()).thenReturn(RESOURCE_LAST_MODIFIED_DATE);
+        when(binaryResource.getFedoraId()).thenReturn(FEDORA_ID);
+        when(binaryResource.getId()).thenReturn(FEDORA_ID.getResourceId());
+        when(binaryResource.getContentSize()).thenReturn(1234L);
+        when(binaryResource.getFilename()).thenReturn("test.txt");
+        when(binaryResource.getMimeType()).thenReturn("text/plain");
+        when(binaryResource.getContentDigests()).thenReturn(Collections.singleton(URI.create("sha1:1234")));
+    }
+
+    /**
+     * Assert the expected model for a container resource.
+     * @param model the model to check
+     */
+    private void assertExpectedContainerModel(final Model model) {
+        assertTrue(model.contains(
+                subject,
+                CREATED_DATE,
+                createTypedLiteral(RESOURCE_CREATED_DATE.toString(), XSDdateTime)
+        ));
+        assertTrue(model.contains(
+                subject,
+                CREATED_BY,
+                USER
+        ));
+        assertTrue(model.contains(
+                subject,
+                LAST_MODIFIED_DATE,
+                createTypedLiteral(RESOURCE_LAST_MODIFIED_DATE.toString(), XSDdateTime)
+        ));
+        assertTrue(model.contains(
+                subject,
+                LAST_MODIFIED_BY,
+                USER
+        ));
+    }
+
+    /**
+     * Assert the expected model for a binary resource.
+     * @param model the model to check
+     */
+    private void assertExpectedBinaryModel(final Model model) {
+        assertExpectedContainerModel(model);
+        assertTrue(model.contains(
+                subject,
+                HAS_SIZE,
+                createTypedLiteral("1234", XSDlong)
+        ));
+        assertTrue(model.contains(
+                subject,
+                HAS_ORIGINAL_NAME,
+                createPlainLiteral("test.txt")
+        ));
+        assertTrue(model.contains(
+                subject,
+                HAS_MIME_TYPE,
+                createPlainLiteral("text/plain")
+        ));
+        assertTrue(model.contains(
+                subject,
+                HAS_MESSAGE_DIGEST,
+                createResource("sha1:1234")
+        ));
+    }
+
+    /**
+     * Test a normal container without an OCFL path but all the other SMTs.
+     */
+    @Test
+    public void testGetContainer() {
+        final var triples = managedPropertiesService.get(containerResource);
+        final var model = triples.collect(toModel());
+        assertExpectedContainerModel(model);
+        assertFalse(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                (RDFNode) null
+        ));
+    }
+
+    @Test
+    public void testGetContainerRelative() {
+        when(ocflPropsConfig.getDisplayOcflPath()).thenReturn(DisplayOcflPath.RELATIVE);
+        final var triples = managedPropertiesService.get(containerResource);
+        final var model = triples.collect(toModel());
+        assertExpectedContainerModel(model);
+        assertTrue(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                RESOURCE_OCFL_PATH
+        ));
+    }
+
+    @Test
+    public void testGetContainerAbsolute() {
+        when(ocflPropsConfig.getDisplayOcflPath()).thenReturn(DisplayOcflPath.ABSOLUTE);
+        final var triples = managedPropertiesService.get(containerResource);
+        final var model = triples.collect(toModel());
+        assertExpectedContainerModel(model);
+        assertTrue(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                OCFL_ROOT + "/" + RESOURCE_OCFL_PATH
+        ));
+    }
+
+    @Test
+    public void testGetBinary() {
+        final var triples = managedPropertiesService.get(binaryResource);
+        final var model = triples.collect(toModel());
+        assertExpectedBinaryModel(model);
+        assertFalse(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                (RDFNode) null
+        ));
+    }
+
+    @Test
+    public void testGetBinaryRelative() {
+        when(ocflPropsConfig.getDisplayOcflPath()).thenReturn(DisplayOcflPath.RELATIVE);
+        final var triples = managedPropertiesService.get(binaryResource);
+        final var model = triples.collect(toModel());
+        assertExpectedBinaryModel(model);
+        assertTrue(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                RESOURCE_OCFL_PATH
+        ));
+    }
+
+    @Test
+    public void testGetBinaryAbsolute() {
+        when(ocflPropsConfig.getDisplayOcflPath()).thenReturn(DisplayOcflPath.ABSOLUTE);
+        final var triples = managedPropertiesService.get(binaryResource);
+        final var model = triples.collect(toModel());
+        assertExpectedBinaryModel(model);
+        assertTrue(model.contains(
+                subject,
+                FEDORA_OCFL_PATH,
+                OCFL_ROOT + "/" + RESOURCE_OCFL_PATH
+        ));
+    }
+}

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -60,10 +61,11 @@ public class ManagedPropertiesServiceImplTest {
     private static final String RESOURCE_ID = "info:fedora/resource1";
 
     private static final String RESOURCE_HASH = "69bb8862c69cfa4c1a607c9a8afa693bbd714353f29327a40b0c671d532035f9";
-    private static final String RESOURCE_OCFL_PATH = RESOURCE_HASH.substring(0,3) + "/" +
-            RESOURCE_HASH.substring(3, 6) + "/" + RESOURCE_HASH.substring(6, 9) + "/" + RESOURCE_HASH;
+    private static final String RESOURCE_OCFL_PATH = RESOURCE_HASH.substring(0,3) + File.separator +
+            RESOURCE_HASH.substring(3, 6) + File.separator + RESOURCE_HASH.substring(6, 9) +
+            File.separator + RESOURCE_HASH;
 
-    private static final String OCFL_ROOT = "/ocfl/root";
+    private static final String OCFL_ROOT = File.separator + "ocfl" + File.separator + "root";
 
     private static final FedoraId FEDORA_ID = FedoraId.create(RESOURCE_ID);
 
@@ -167,7 +169,7 @@ public class ManagedPropertiesServiceImplTest {
 
     private void assertTripleExistsAndMatches(final Model model, final Resource subject, final Property predicate,
             final RDFNode object) {
-        assertTrue(model.contains(subject, predicate, object));
+        assertTrue(model.contains(subject, predicate));
         final var stmts = model.listObjectsOfProperty(subject, predicate);
         while (stmts.hasNext()) {
             final var stmt = stmts.next();
@@ -213,7 +215,7 @@ public class ManagedPropertiesServiceImplTest {
                 model,
                 subject,
                 FEDORA_OCFL_PATH,
-                createPlainLiteral(OCFL_ROOT + "/" + RESOURCE_OCFL_PATH)
+                createPlainLiteral(OCFL_ROOT + File.separator + RESOURCE_OCFL_PATH)
         );
     }
 
@@ -252,7 +254,7 @@ public class ManagedPropertiesServiceImplTest {
                 model,
                 subject,
                 FEDORA_OCFL_PATH,
-                createPlainLiteral(OCFL_ROOT + "/" + RESOURCE_OCFL_PATH)
+                createPlainLiteral(OCFL_ROOT + File.separator + RESOURCE_OCFL_PATH)
         );
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.config.DisplayOcflPath;
@@ -163,6 +165,16 @@ public class ManagedPropertiesServiceImplTest {
         ));
     }
 
+    private void assertTripleExistsAndMatches(final Model model, final Resource subject, final Property predicate,
+            final RDFNode object) {
+        assertTrue(model.contains(subject, predicate, object));
+        final var stmts = model.listObjectsOfProperty(subject, predicate);
+        while (stmts.hasNext()) {
+            final var stmt = stmts.next();
+            assertEquals(object, stmt);
+        }
+    }
+
     /**
      * Test a normal container without an OCFL path but all the other SMTs.
      */
@@ -197,11 +209,12 @@ public class ManagedPropertiesServiceImplTest {
         final var triples = managedPropertiesService.get(containerResource);
         final var model = triples.collect(toModel());
         assertExpectedContainerModel(model);
-        assertTrue(model.contains(
+        assertTripleExistsAndMatches(
+                model,
                 subject,
                 FEDORA_OCFL_PATH,
-                OCFL_ROOT + "/" + RESOURCE_OCFL_PATH
-        ));
+                createPlainLiteral(OCFL_ROOT + "/" + RESOURCE_OCFL_PATH)
+        );
     }
 
     @Test
@@ -235,10 +248,11 @@ public class ManagedPropertiesServiceImplTest {
         final var triples = managedPropertiesService.get(binaryResource);
         final var model = triples.collect(toModel());
         assertExpectedBinaryModel(model);
-        assertTrue(model.contains(
+        assertTripleExistsAndMatches(
+                model,
                 subject,
                 FEDORA_OCFL_PATH,
-                OCFL_ROOT + "/" + RESOURCE_OCFL_PATH
-        ));
+                createPlainLiteral(OCFL_ROOT + "/" + RESOURCE_OCFL_PATH)
+        );
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3935

# What does this Pull Request do?
Generates a Server Managed Triple `fedora:ocflPath` with the full path to the base of the resource.

# How should this be tested?

This is a bit hacky as the only way to know if something is in staging or the repo is to get that information from `fcrepo-storage-ocfl` and pass it back as part of the Resource Headers (I think). 

That seemed like a large change, which I think involves to change the resource headers object (in fcrepo-storage-ocfl) to store the path and change the conversion code from OCFL resource headers to Fedora resource headers to set this path. Then change the ResourceFactory to transfer the path from the resource headers to the FedoraResource. Then we could still use the ManagedPropertiesService to set the triple using the path.

This makes some assumptions, which if we ever make the path configurable would make it invalid. 🤷 

To test, build and run this code. Make an object in Fedora, view the metadata for that object and find a new `http://fedora.info/definitions/v4/repository#ocflPath` triple with the full path on disk.

For Archival Groups and their parts, they all point to the path of the Archival Group. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
