### PR TITLE
URL encode user agent if there was a space in the user name

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/observer/ResourceOperationEventBuilder.java
@@ -6,17 +6,20 @@
 
 package org.fcrepo.kernel.impl.observer;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
 import org.fcrepo.kernel.api.identifiers.FedoraId;
 import org.fcrepo.kernel.api.observer.Event;
 import org.fcrepo.kernel.api.observer.EventType;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.kernel.impl.util.UserUtil;
-
-import java.net.URI;
-import java.time.Instant;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
 
 /**
  * Converts a ResourceOperation into an Event.
@@ -125,7 +128,7 @@ public class ResourceOperationEventBuilder implements EventBuilder {
 
     @Override
     public EventBuilder withUserAgent(final String userAgent) {
-        this.userAgent = userAgent;
+        this.userAgent = (userAgent.contains(" ") ? URLEncoder.encode(userAgent, UTF_8) : userAgent);
         return this;
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/util/UserUtil.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/util/UserUtil.java
@@ -6,13 +6,16 @@
 
 package org.fcrepo.kernel.impl.util;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-
-import java.net.URI;
-
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.slf4j.LoggerFactory.getLogger;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.net.URI;
+import java.net.URLEncoder;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
 
 /**
  * @author Daniel Bernstein
@@ -63,7 +66,7 @@ public class UserUtil {
             baseUri = DEFAULT_USER_AGENT_BASE_URI;
         }
 
-        final String userAgentUri = baseUri + userId;
+        final String userAgentUri = baseUri + (userId.contains(" ") ? URLEncoder.encode(userId, UTF_8) : userId);
 
         LOGGER.trace("Default URI is created for user {}: {}", userId, userAgentUri);
         return URI.create(userAgentUri);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/observer/EventAccumulatorImplTest.java
@@ -6,8 +6,25 @@
 
 package org.fcrepo.kernel.impl.observer;
 
-import com.google.common.eventbus.EventBus;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.eventbus.EventBus;
 import org.fcrepo.config.AuthPropsConfig;
 import org.fcrepo.config.ServerManagedPropsMode;
 import org.fcrepo.kernel.api.Transaction;
@@ -30,24 +47,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.Set;
-
-import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 /**
  * @author pwinckles
@@ -295,7 +294,7 @@ public class EventAccumulatorImplTest {
     }
 
     @Test
-    public void testUserAgentWithSpace() throws PathNotFoundException{
+    public void testUserAgentWithSpace() throws PathNotFoundException {
         final var fId1 = FedoraId.create("/test/1");
         final var fId2 = FedoraId.create("/test/2");
         final var op1 = createOp(fId1, "user name");
@@ -307,17 +306,17 @@ public class EventAccumulatorImplTest {
         expectResource(fId1, CONTAINER_TYPE);
         expectResource(fId2, RESOURCE_TYPE);
 
-        accumulator.emitEvents(transaction, BASE_URL, USER_AGENT);
+        accumulator.emitEvents(transaction, BASE_URL, "user agent");
 
         verify(eventBus, times(2)).post(eventCaptor.capture());
 
         final var events = eventCaptor.getAllValues();
 
         assertThat(events, containsInAnyOrder(
-                defaultEvent(fId1, Set.of(EventType.RESOURCE_CREATION),
-                        Set.of(CONTAINER_TYPE.toString())),
-                defaultEvent(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
-                        Set.of(RESOURCE_TYPE.toString()))
+                event(fId1, Set.of(EventType.RESOURCE_CREATION),
+                        Set.of(CONTAINER_TYPE.toString()), BASE_URL, "user+agent"),
+                event(fId2, Set.of(EventType.RESOURCE_MODIFICATION),
+                        Set.of(RESOURCE_TYPE.toString()), BASE_URL, "user+agent")
         ));
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3938

# What does this Pull Request do?
URL encodes the user name if we use it to build a user agent and it has a space, or URL encode the user agent if it has a space.

# How should this be tested?

Prior to this PR you need to get a user name with a space. I haven't tested this but I am guessing if you configure your Tomcat with a user "john smith" and create an object in Fedora using that login you should get a stack trace.

After you will not.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
