### PR TITLE
Allow getting a resource from a tombstone when performing memento dat…

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraLdp.java
@@ -219,8 +219,8 @@ public class FedoraLdp extends ContentExposingResource {
         LOGGER.info("HEAD for: {}", externalPath);
 
         final String datetimeHeader = headers.getHeaderString(ACCEPT_DATETIME);
-        if (!isBlank(datetimeHeader) && resource().isOriginalResource()) {
-            return getMemento(datetimeHeader, resource(), inlineDisposition);
+        if (!isBlank(datetimeHeader) && resource(true).isOriginalResource()) {
+            return getMemento(datetimeHeader, resource(true), inlineDisposition);
         }
 
         final ImmutableList<MediaType> acceptableMediaTypes = ImmutableList.copyOf(headers
@@ -303,8 +303,8 @@ public class FedoraLdp extends ContentExposingResource {
             throws IOException, UnsupportedAlgorithmException {
 
         final String datetimeHeader = headers.getHeaderString(ACCEPT_DATETIME);
-        if (!isBlank(datetimeHeader) && resource().isOriginalResource()) {
-            return getMemento(datetimeHeader, resource(), inlineDisposition);
+        if (!isBlank(datetimeHeader) && resource(true).isOriginalResource()) {
+            return getMemento(datetimeHeader, resource(true), inlineDisposition);
         }
 
         checkCacheControlHeaders(request, servletResponse, resource(), transaction());

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -59,14 +59,6 @@
 
         <dependency>
             <groupId>org.fcrepo</groupId>
-            <artifactId>fcrepo-auth-common</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.fcrepo</groupId>
             <artifactId>fcrepo-http-commons</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
…etime negotiation

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3948

# What does this Pull Request do?
Switches from the `resource()` method to `resource(true)` which will return even if the resource is now a tombstone.

# How should this be tested?

Before the PR
1. Create a resource
2. Wait a second
3. Alter the resource
4. Wait a second
5. Delete the resource
6. Get the resource's timemap (URI + '/fcr:versions') and determine the RFC-1123 date time of the second version.
    
    i.e. `http://localhost:8080/rest/some-container/fcr:versions/20240702151230`
          `20240702151230` => `2024-07-02 15:12:30`
          `Tue, 02 Jul 2024 15:12:30 GMT`
7. GET (and HEAD) the original resource with the `Accept-Datetime` header set to the RFC-1123 date time

    `curl -ufedoraAdmin:fedoraAdmin -i -H"Accept-Datetime: Tue, 02 Jul 2024 15:12:30 GMT" http://localhost:8080/rest/some-container`
8. Get a 410 Gone.
9. Pull in this PR and rebuild 
10. Perform the same GET (and HEAD) as in step 7, get a `302 Found` with the `Location` set to the original memento location.

**Note**: The dependency removal was because it was included twice. Not related to this issue.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
