### PR TITLE
removing one-click profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,16 @@ described in the [deployment guide](https://wiki.lyrasis.org/display/FEDORA6x/De
 If deployed locally using a war file called `fcrepo.war`, the web application will typically be available at
 http://localhost:8080/fcrepo/rest.
 
-There are two convenient methods for *testing* the Fedora application by launching it directly from the command line.
+There is a convenient method for *testing* the Fedora application by launching it directly from the command line.
 
-One option is to use the "one click" application, which comes with an embedded Jetty servlet. This can be optionally built by running:
-
-    mvn install -pl fcrepo-webapp -P one-click
-
-and can be started by either double-clicking on the jar file or by running the following command:
-
-    java -jar ./fcrepo-webapp/target/fcrepo-webapp-<version>-jetty-console.jar
-
-By default, a Fedora home directory, `fcrepo`, is created in the current directory. You can change the default location by passing in an argument when starting the one-click, e.g.:
-
-    java -Dfcrepo.home=/data/fedora-home -jar fcrepo-webapp-<version>-jetty-console.jar
-
-An alternative is use the maven command: `mvn jetty:run`
+Use the maven command: `mvn jetty:run`
 
 ```
 $ cd fcrepo-webapp
 $ mvn jetty:run
 ```
 
-For both of these methods, your Fedora repository will be available at: [http://localhost:8080/rest/](http://localhost:8080/rest/)
+For this method, your Fedora repository will be available at: [http://localhost:8080/rest/](http://localhost:8080/rest/)
 
 Note: You may need to set the $JAVA_HOME property, since Maven uses it to find the Java runtime to use, overriding your PATH.
 `mvn --version` will show which version of Java is being used by Maven, e.g.:

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <!-- integration test properties -->
     <fcrepo.test.context.path>/</fcrepo.test.context.path>
-    
+
     <!-- sonar -->
     <sonar.artifact.path>${project.build.directory}${file.separator}${project.artifactId}-${project.version}.war</sonar.artifact.path>
 
@@ -22,7 +22,6 @@
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     <!-- for standalone operation -->
     <jetty.users.file>${project.build.directory}/test-classes/jetty-users.properties</jetty.users.file>
-    <jetty-console.version>1.64</jetty-console.version>
   </properties>
 
   <dependencies>
@@ -457,99 +456,5 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>one-click</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <properties>
-      </properties>
-
-      <build>
-        <resources>
-          <resource>
-            <directory>src/main/resources</directory>
-            <filtering>true</filtering>
-            <includes>
-              <include>**/fcrepo-config.xml</include>
-            </includes>
-          </resource>
-        </resources>
-
-        <plugins>
-          <plugin>
-            <artifactId>maven-war-plugin</artifactId>
-            <configuration>
-              <attachClasses>true</attachClasses>
-              <webResources>
-                <resource>
-                  <directory>src/main/jetty-console</directory>
-                  <filtering>true</filtering>
-                </resource>
-                <resource>
-                  <directory>src/main/webapp</directory>
-                  <includes>
-                    <include>*.html</include>
-                  </includes>
-                  <filtering>true</filtering>
-                </resource>
-              </webResources>
-                <archive>
-                  <index>true</index>
-                  <manifest>
-                    <addClasspath>true</addClasspath>
-                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                  </manifest>
-                </archive>
-            </configuration>
-          </plugin>
-
-          <plugin>
-            <groupId>org.fcrepo</groupId>
-            <artifactId>jetty-console-maven-plugin</artifactId>
-            <version>${jetty-console.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>createconsole</goal>
-                </goals>
-                <configuration>
-                  <backgroundImage>${basedir}/src/main/webapp/static/images/fedora_logo_10in.png</backgroundImage>
-                  <destinationFile>
-                    ${project.build.directory}${file.separator}${project.artifactId}-${project.version}-jetty-console.jar
-                  </destinationFile>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-clean-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>remove-war</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>clean</goal>
-                </goals>
-                <configuration>
-                  <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                  <filesets>
-                    <fileset>
-                      <directory>${project.build.directory}</directory>
-                      <includes>
-                        <include>**/*.war</include>
-                      </includes>
-                    </fileset>
-                  </filesets>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION


**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3923

# What does this Pull Request do?
Removes the one-click profile as it is deprecated and updates the README to remove mention of it. 

# How should this be tested?

* Attempt to run the one-click
* confirm that any dependencies which were only used by the one-click profile;e have been removed from the pom files

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
