### PR TITLE
Fix too long ranges and end start ranges

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/RangeIT.java
@@ -1,0 +1,108 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.integration.http.api;
+
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.springframework.test.context.TestExecutionListeners;
+
+/**
+ * Test of Range related requests.
+ * @author whikloj
+ */
+@TestExecutionListeners(
+        listeners = { TestIsolationExecutionListener.class },
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public class RangeIT extends AbstractResourceIT{
+
+    @Test
+    public void testPartialRange() throws IOException {
+        final var pid = getRandomUniqueId();
+
+        final String contentLength = createDatastreamAndGetLength(pid);
+        final var getRange = getObjMethod(pid);
+        final var halfContentLength = Math.round((float) Integer.parseInt(contentLength) / 2);
+        getRange.addHeader("Range", "bytes=0-" + halfContentLength);
+        try (final var res = execute(getRange)) {
+            assertEquals(206, res.getStatusLine().getStatusCode());
+            checkForLinkHeader(res, NON_RDF_SOURCE.getURI(), "type");
+            assertEquals(String.valueOf(halfContentLength + 1), res.getFirstHeader("Content-Length").getValue());
+            assertEquals(
+                    "bytes 0-" + halfContentLength + "/" + contentLength,
+                    res.getFirstHeader("Content-Range").getValue()
+            );
+        }
+    }
+
+    @Test
+    public void testRangeAsContentLength() throws IOException {
+        final var pid = getRandomUniqueId();
+        final String contentLength = createDatastreamAndGetLength(pid);
+        final var range = "0-" + contentLength;
+        final var getRange = getObjMethod(pid);
+        getRange.addHeader("Range", "bytes=" + range);
+        try (final var res = execute(getRange)) {
+            assertEquals(206, res.getStatusLine().getStatusCode());
+            checkForLinkHeader(res, NON_RDF_SOURCE.getURI(), "type");
+            assertEquals("bytes " + range + "/" + contentLength, res.getFirstHeader("Content-Range").getValue());
+        }
+    }
+
+    @Test
+    public void testRangeTooLong() throws IOException {
+        final var pid = getRandomUniqueId();
+        final String contentLength = createDatastreamAndGetLength(pid);
+        final var getRangeVal = "0-" + Integer.parseInt(contentLength) + 1;
+        final var returnRangeVal = "0-" + (Integer.parseInt(contentLength) - 1);
+        final var getRange = getObjMethod(pid);
+        getRange.addHeader("Range", "bytes=" + getRangeVal);
+        try (final var res = execute(getRange)) {
+            assertEquals(206, res.getStatusLine().getStatusCode());
+            checkForLinkHeader(res, NON_RDF_SOURCE.getURI(), "type");
+            assertEquals(
+                    "bytes " + returnRangeVal + "/" + contentLength,
+                    res.getFirstHeader("Content-Range").getValue()
+            );
+        }
+    }
+
+    @Test
+    public void testLastHalf() throws IOException {
+        final var pid = getRandomUniqueId();
+        final String contentLength = createDatastreamAndGetLength(pid);
+        final var halfContentLength = Math.round((float) Integer.parseInt(contentLength) / 2);
+        final Integer contentLengthInt = Integer.parseInt(contentLength);
+        final var rangeEnd = contentLengthInt - 1;
+        final var rangeStart = rangeEnd - halfContentLength;
+        final var range = "-" + halfContentLength;
+        final var getRange = getObjMethod(pid);
+        getRange.addHeader("Range", "bytes=" + range);
+        try (final var res = execute(getRange)) {
+            assertEquals(206, res.getStatusLine().getStatusCode());
+            checkForLinkHeader(res, NON_RDF_SOURCE.getURI(), "type");
+            assertEquals(String.valueOf(halfContentLength), res.getFirstHeader("Content-Length").getValue());
+            assertEquals(
+                    "bytes " + rangeStart + "-" + rangeEnd + "/" + contentLength,
+                    res.getFirstHeader("Content-Range").getValue()
+            );
+        }
+    }
+
+    private String createDatastreamAndGetLength(final String pid) throws IOException {
+        final String content = RandomStringUtils.random(100, true, true);
+        createDatastream(pid, content);
+        try (final var res = execute(getObjMethod(pid))) {
+            assertEquals(200, res.getStatusLine().getStatusCode());
+            checkForLinkHeader(res, NON_RDF_SOURCE.getURI(), "type");
+            return res.getFirstHeader("Content-Length").getValue();
+        }
+    }
+}

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
@@ -20,6 +20,9 @@ public class Range {
 
     private final long start;
 
+    // Did the Range actually specify a start?
+    private final boolean no_start;
+
     private final long end;
 
     private static final Pattern rangePattern =
@@ -44,10 +47,21 @@ public class Range {
      * Left and right bounded range
      * @param start the start
      * @param end the end
+     * @param no_start whether there was a starting byte
      */
-    private Range(final long start, final long end) {
+    private Range(final long start, final long end, final boolean no_start) {
         this.start = start;
         this.end = end;
+        this.no_start = no_start;
+    }
+
+    /**
+     * Left and right bounded range
+     * @param start the start
+     * @param end the end
+     */
+    private Range(final long start, final long end) {
+        this(start, end, false);
     }
 
     /**
@@ -65,16 +79,18 @@ public class Range {
     public long size() {
         if (end == -1) {
             return -1;
+        } else if (start == 0 && no_start) {
+            return end;
         }
         return end - start + 1;
     }
 
     /**
      * Start of the range
-     * @return start of the range
+     * @return start of the range, or -1 if no start was specified
      */
     public long start() {
-        return start;
+        return no_start ? -1 : start;
     }
 
     /**
@@ -102,11 +118,14 @@ public class Range {
         final String to = matcher.group(2);
 
         final long start;
+        final boolean no_start;
 
         if (from.equals("")) {
             start = 0;
+            no_start = true;
         } else {
             start = parseLong(from);
+            no_start = false;
         }
 
         final long end;
@@ -116,6 +135,6 @@ public class Range {
             end = parseLong(to);
         }
 
-        return new Range(start, end);
+        return new Range(start, end, no_start);
     }
 }

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
@@ -37,7 +37,7 @@ public class Range {
      * Left-bounded range
      * @param start the start
      */
-    public Range(final long start) {
+    protected Range(final long start) {
         this(start, -1L);
     }
 
@@ -55,7 +55,7 @@ public class Range {
      * Does this range actually impose limits
      * @return true if the range imposes limits
      */
-    public boolean hasRange() {
+    protected boolean hasRange() {
         return !(start == -1 && end == -1);
     }
 
@@ -63,7 +63,7 @@ public class Range {
      * Length contained in the range
      * @return length of the range
      */
-    public long size() {
+    protected long size() {
         if (end == -1) {
             return -1;
         } else if (start == -1) {
@@ -76,7 +76,7 @@ public class Range {
      * Start of the range
      * @return start of the range, or -1 if no start was specified
      */
-    public long start() {
+    protected long start() {
         return start;
     }
 
@@ -84,7 +84,7 @@ public class Range {
      * End of the range
      * @return end of the range
      */
-    public long end() {
+    protected long end() {
         return end;
     }
 

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/domain/Range.java
@@ -181,7 +181,7 @@ public class Range {
             // If a valid byte-range-set includes at least one byte-range-spec with a first-byte-pos that is less than
             // the current length of the representation, or at least one suffix-byte-range-spec with a non-zero
             // suffix-length, then the byte-range-set is satisfiable. Otherwise, the byte-range-set is unsatisfiable.
-            this.satisfiable = start < length && (end() == -1 || end > start) && (start != -1 && end != -1);
+            this.satisfiable = start < length && (end() == -1 || end >= start) && (start != -1 && end != -1);
         }
 
         /**

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
@@ -64,10 +64,6 @@ public class RangeTest {
         final Range range = Range.convert("something-thats-not-a-range");
 
         assertFalse(range.hasRange());
-        assertEquals(-1L, range.start());
-        assertEquals(-1L, range.end());
-        assertEquals(-1L, range.size());
-
     }
 
     @Test
@@ -97,7 +93,6 @@ public class RangeTest {
     @Test
     public void testRangeOfContentLength1() {
         final Range range = Range.convert("bytes=0-100");
-        assertEquals(101, range.size());
         final var rangeOfLength = range.rangeOfLength(200);
         assertEquals(0, rangeOfLength.start());
         assertEquals(100, rangeOfLength.end());
@@ -107,7 +102,6 @@ public class RangeTest {
     @Test
     public void testRangeOfContentLength2() {
         final Range range = Range.convert("bytes=5-");
-        assertEquals(-1, range.size());
         final var rangeOfLength = range.rangeOfLength(200);
         assertEquals(5, rangeOfLength.start());
         assertEquals(199, rangeOfLength.end());
@@ -117,7 +111,6 @@ public class RangeTest {
     @Test
     public void testRangeOfContentLength3() {
         final Range range = Range.convert("bytes=-150");
-        assertEquals(150, range.size());
         final var rangeOfLength = range.rangeOfLength(200);
         assertEquals(50, rangeOfLength.start());
         assertEquals(199, rangeOfLength.end());
@@ -130,7 +123,6 @@ public class RangeTest {
     @Test
     public void testRangeSizeIsValid() {
         final Range range = Range.convert("bytes=0-100");
-        assertEquals(101, range.size());
         final var rangeOfLength = range.rangeOfLength(90);
         assertEquals(0, rangeOfLength.start());
         assertEquals(89, rangeOfLength.end());

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
@@ -51,9 +51,9 @@ public class RangeTest {
     public void testUnboundedLowerRangeParsing() {
         final Range range = Range.convert("bytes=-50");
 
-        assertEquals(0L, range.start());
+        assertEquals(-1L, range.start());
         assertEquals(50L, range.end());
-        assertEquals(51L, range.size());
+        assertEquals(50L, range.size());
         assertTrue(range.hasRange());
 
     }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
@@ -23,8 +23,9 @@ public class RangeTest {
 
         assertEquals(5L, range.start());
         assertEquals(-1L, range.end());
-
+        assertEquals(-1L, range.size());
     }
+
     @Test
     public void testRangeParsing() {
         final Range range = Range.convert("bytes=50-100");
@@ -63,9 +64,91 @@ public class RangeTest {
         final Range range = Range.convert("something-thats-not-a-range");
 
         assertFalse(range.hasRange());
-        assertEquals(0L, range.start());
+        assertEquals(-1L, range.start());
         assertEquals(-1L, range.end());
         assertEquals(-1L, range.size());
 
+    }
+
+    @Test
+    public void testRangeIsSatisfiable1() {
+        // If we specify a start point less than the length of the file, the range is satisfiable
+        final Range range = Range.convert("bytes=0-100");
+        assertTrue(range.rangeOfLength(101).isSatisfiable());
+        assertTrue(range.rangeOfLength(5).isSatisfiable());
+        assertTrue(range.rangeOfLength(10).isSatisfiable());
+        assertTrue(range.rangeOfLength(200).isSatisfiable());
+    }
+
+    @Test
+    public void testRangeIsSatisfiable2() {
+        // If we specify a start point greater than the length of the file, the range is not satisfiable
+        final Range range = Range.convert("bytes=101-200");
+        assertFalse(range.rangeOfLength(100).isSatisfiable());
+        assertFalse(range.rangeOfLength(5).isSatisfiable());
+    }
+
+    @Test
+    public void testRangeIsSatisfiable3() {
+        final Range range = Range.convert("bytes=0-8199");
+        assertTrue(range.rangeOfLength(9040).isSatisfiable());
+    }
+
+    @Test
+    public void testRangeOfContentLength1() {
+        final Range range = Range.convert("bytes=0-100");
+        assertEquals(101, range.size());
+        final var rangeOfLength = range.rangeOfLength(200);
+        assertEquals(0, rangeOfLength.start());
+        assertEquals(100, rangeOfLength.end());
+        assertEquals(101, rangeOfLength.size());
+    }
+
+    @Test
+    public void testRangeOfContentLength2() {
+        final Range range = Range.convert("bytes=5-");
+        assertEquals(-1, range.size());
+        final var rangeOfLength = range.rangeOfLength(200);
+        assertEquals(5, rangeOfLength.start());
+        assertEquals(199, rangeOfLength.end());
+        assertEquals(195, rangeOfLength.size());
+    }
+
+    @Test
+    public void testRangeOfContentLength3() {
+        final Range range = Range.convert("bytes=-150");
+        assertEquals(150, range.size());
+        final var rangeOfLength = range.rangeOfLength(200);
+        assertEquals(50, rangeOfLength.start());
+        assertEquals(199, rangeOfLength.end());
+        assertEquals(150, rangeOfLength.size());
+    }
+
+    /**
+     * For a content size smaller than the requested range, we need to adjust the range.
+     */
+    @Test
+    public void testRangeSizeIsValid() {
+        final Range range = Range.convert("bytes=0-100");
+        assertEquals(101, range.size());
+        final var rangeOfLength = range.rangeOfLength(90);
+        assertEquals(0, rangeOfLength.start());
+        assertEquals(89, rangeOfLength.end());
+        assertEquals(90, rangeOfLength.size());
+    }
+
+    @Test
+    public void testSpecExamples() {
+        final Range range1 = Range.convert("bytes=-500");
+        final var rangeOfLength1 = range1.rangeOfLength(10000);
+        assertEquals(9500, rangeOfLength1.start());
+        assertEquals(9999, rangeOfLength1.end());
+        assertEquals(500, rangeOfLength1.size());
+
+        final Range range2 = Range.convert("bytes=9500-");
+        final var rangeOfLength2 = range2.rangeOfLength(10000);
+        assertEquals(9500, rangeOfLength2.start());
+        assertEquals(9999, rangeOfLength2.end());
+        assertEquals(500, rangeOfLength2.size());
     }
 }

--- a/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
+++ b/fcrepo-http-commons/src/test/java/org/fcrepo/http/commons/domain/RangeTest.java
@@ -151,4 +151,14 @@ public class RangeTest {
         assertEquals(9999, rangeOfLength2.end());
         assertEquals(500, rangeOfLength2.size());
     }
+
+    @Test
+    public void testZeroRange() {
+        final Range range = Range.convert("bytes=0-0");
+        final var rangeOfLength = range.rangeOfLength(100);
+        assertEquals(0, rangeOfLength.start());
+        assertEquals(0, rangeOfLength.end());
+        assertEquals(1, rangeOfLength.size());
+        assertTrue(rangeOfLength.isSatisfiable());
+    }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3955

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Fixes Fedora's handling of Range requests that are too long and if they don't specify a starting position.

# How should this be tested?

Create a binary and check it's content length.
Before this PR
Make a request for the binary with `Range: 0-<content length + 1>` get 416
Make a request for the binary with `Range: -5` get a response with `Content-Range: 0-5`
After this PR
Make a request for the binary with `Range: 0-<content length + 1>` get 206 with the full object 
Make a request for the binary with `Range: -5` get a response with `Content-Range: <content length - 5>-<content length - 1>`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
