### PR TITLE
FCREPO-3952 - Cleanup transactions around application restarts

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/ContainmentIndex.java
@@ -106,6 +106,11 @@ public interface ContainmentIndex {
     void rollbackTransaction(final Transaction tx);
 
     /**
+     * Clear all transactions in the containment index.
+     */
+    void clearAllTransactions();
+
+    /**
      * Check if the resourceID exists in the containment index. Which should mean it exists.
      *
      * @param tx The transaction, or null if no transaction

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
@@ -80,6 +80,11 @@ public interface MembershipService {
     void rollbackTransaction(final Transaction transaction);
 
     /**
+     * Clear all transactions in the membership index.
+     */
+    void clearAllTransactions();
+
+    /**
      * Truncates the membership index. This should only be called when rebuilding the index.
      */
     void reset();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ReferenceService.java
@@ -57,6 +57,11 @@ public interface ReferenceService {
     void rollbackTransaction(final Transaction tx);
 
     /**
+     * Clear all transactions in the reference index.
+     */
+    void clearAllTransactions();
+
+    /**
      * Truncates the reference index. This should only be called when rebuilding the index.
      */
     void reset();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -804,6 +804,11 @@ public class ContainmentIndexImpl implements ContainmentIndex {
     }
 
     @Override
+    public void clearAllTransactions() {
+        jdbcTemplate.update(TRUNCATE_TABLE + TRANSACTION_OPERATIONS_TABLE, Collections.emptyMap());
+    }
+
+    @Override
     public boolean resourceExists(@Nonnull final Transaction tx, final FedoraId fedoraId,
                                   final boolean includeDeleted) {
         // Get the containing ID because fcr:metadata will not exist here but MUST exist if the containing resource does

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexMetrics.java
@@ -56,6 +56,8 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
             DB, CONTAINMENT, OPERATION, "getContainerIdByPath");
     private static final Timer resetTimer = Metrics.timer(METRIC_NAME,
             DB, CONTAINMENT, OPERATION, "reset");
+    private static final Timer clearAllTransactionsTimer = Metrics.timer(METRIC_NAME,
+            DB, CONTAINMENT, OPERATION, "clearAllTransactions");
     private static final Timer hasResourcesStartingWithTimer = Metrics.timer(METRIC_NAME,
             DB, CONTAINMENT, OPERATION, "hasResourcesStartingWith");
     private static final Timer containmentLastUpdateTimer = Metrics.timer(METRIC_NAME, DB, CONTAINMENT, OPERATION,
@@ -131,6 +133,13 @@ public class ContainmentIndexMetrics implements ContainmentIndex {
     public void rollbackTransaction(final Transaction tx) {
         rollbackTransactionTimer.record(() -> {
             containmentIndexImpl.rollbackTransaction(tx);
+        });
+    }
+
+    @Override
+    public void clearAllTransactions() {
+        clearAllTransactionsTimer.record(() -> {
+            containmentIndexImpl.clearAllTransactions();
         });
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -148,6 +150,39 @@ public class TransactionManagerImpl implements TransactionManager {
             return transaction;
         } else {
             throw new TransactionNotFoundException("No Transaction found with transactionId: " + transactionId);
+        }
+    }
+
+    @PreDestroy
+    public void cleanupAllTransactions() {
+        LOGGER.debug("Shutting down transaction manager, attempt to rollback any incomplete transactions");
+        final var txIt = transactions.entrySet().iterator();
+        while (txIt.hasNext()) {
+            final var txEntry = txIt.next();
+            final var tx = txEntry.getValue();
+
+            if ((tx.isOpen() || tx.hasExpired()) && !tx.isRolledBack()) {
+                LOGGER.debug("Rolling back transaction as part of shutdown {}", tx.getId());
+                try {
+                    tx.rollback();
+                    pSessionManager.removeSession(tx.getId());
+                } catch (final RuntimeException e) {
+                    LOGGER.error("Failed to rollback transaction {}", tx.getId(), e);
+                }
+            }
+        }
+        LOGGER.debug("Finished rollback of all incomplete transactions as part of shut down");
+    }
+
+    @PostConstruct
+    public void preCleanTransactions() {
+        LOGGER.debug("TransactionManagerImpl initialized, cleaning up leftover transaction entries");
+
+        // Clean up any leftover transaction database entries immediately after startup
+        synchronized (transactions) {
+            containmentIndex.clearAllTransactions();
+            membershipService.clearAllTransactions();
+            referenceService.clearAllTransactions();
         }
     }
 

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/TransactionManagerImpl.java
@@ -7,7 +7,6 @@ package org.fcrepo.kernel.impl;
 
 import org.fcrepo.common.db.DbTransactionExecutor;
 import org.fcrepo.config.FedoraPropsConfig;
-import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.TransactionManager;
@@ -30,12 +29,6 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -85,9 +78,6 @@ public class TransactionManagerImpl implements TransactionManager {
 
     @Inject
     private UserTypesCache userTypesCache;
-
-    @Inject
-    private OcflPropsConfig ocflPropsConfig;
 
     TransactionManagerImpl() {
         transactions = new ConcurrentHashMap<>();
@@ -193,37 +183,10 @@ public class TransactionManagerImpl implements TransactionManager {
             containmentIndex.clearAllTransactions();
             membershipService.clearAllTransactions();
             referenceService.clearAllTransactions();
-            try {
-                deleteStagingDirectories();
-            } catch (IOException e) {
-                LOGGER.error("Failed to delete staging directories", e);
-            }
+            searchIndex.clearAllTransactions();
+            // Also clear any leftover ocfl sessions and staged files
+            pSessionManager.clearAllSessions();
         }
-    }
-
-    /**
-     * Deletes all of the staging directories within the root staging directory
-     * @throws IOException
-     */
-    private void deleteStagingDirectories() throws IOException {
-        // Delete
-        Files.walkFileTree(ocflPropsConfig.getFedoraOcflStaging(), new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
-                // Delete the file
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
-                // Delete the directory after its contents have been deleted, excluding the root staging directory
-                if (!dir.equals(ocflPropsConfig.getFedoraOcflStaging())) {
-                    Files.delete(dir);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-        });
     }
 
     protected PersistentStorageSessionManager getPersistentStorageSessionManager() {

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipIndexManager.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipIndexManager.java
@@ -760,6 +760,10 @@ public class MembershipIndexManager {
         jdbcTemplate.update(TRUNCATE_MEMBERSHIP_TX, Map.of());
     }
 
+    public void clearAllTransactions() {
+        jdbcTemplate.update(TRUNCATE_MEMBERSHIP_TX, Map.of());
+    }
+
     /**
      * Log all membership entries, for debugging usage only
      */

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -411,6 +411,11 @@ public class MembershipServiceImpl implements MembershipService {
         return changeEntries;
     }
 
+    @Override
+    public void clearAllTransactions() {
+        indexManager.clearAllTransactions();
+    }
+
     /**
      * The properties of a Direct or Indirect Container at a point in time.
      * @author bbpennel

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -161,6 +161,7 @@ public class ReferenceServiceImpl implements ReferenceService {
             TRANSACTION_COLUMN + " = :transactionId";
 
     private static final String TRUNCATE_TABLE = "TRUNCATE TABLE " + TABLE_NAME;
+    private static final String TRUNCATE_TX_TABLE = "TRUNCATE TABLE " + TRANSACTION_TABLE;
 
     @PostConstruct
     public void setUp() {
@@ -319,9 +320,15 @@ public class ReferenceServiceImpl implements ReferenceService {
     }
 
     @Override
+    public void clearAllTransactions() {
+        jdbcTemplate.update(TRUNCATE_TX_TABLE, Map.of());
+    }
+
+    @Override
     public void reset() {
         try {
             jdbcTemplate.update(TRUNCATE_TABLE, Map.of());
+            jdbcTemplate.update(TRUNCATE_TX_TABLE, Map.of());
         } catch (final Exception e) {
             LOGGER.warn("Unable to reset reference index: {}", e.getMessage());
             throw new RepositoryRuntimeException("Unable to reset reference index", e);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceMetrics.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceMetrics.java
@@ -43,6 +43,8 @@ public class ReferenceServiceMetrics implements ReferenceService {
             DB, REFERENCE, OPERATION, "rollbackTransaction");
     private static final Timer resetTimer = Metrics.timer(METRIC_NAME,
             DB, REFERENCE, OPERATION, "reset");
+    private static final Timer clearAllTransactionsTimer = Metrics.timer(METRIC_NAME,
+            DB, REFERENCE, OPERATION, "clearAllTransactions");
 
     @Autowired
     @Qualifier("referenceServiceImpl")
@@ -83,6 +85,13 @@ public class ReferenceServiceMetrics implements ReferenceService {
     public void rollbackTransaction(final Transaction tx) {
         rollbackTransactionTimer.record(() -> {
             referenceServiceImpl.rollbackTransaction(tx);
+        });
+    }
+
+    @Override
+    public void clearAllTransactions() {
+        clearAllTransactionsTimer.record(() -> {
+            referenceServiceImpl.clearAllTransactions();
         });
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -569,6 +569,34 @@ public class ContainmentIndexImplTest {
     }
 
     @Test
+    public void clearAllTransactions() {
+        stubObject("parent1");
+        stubObject("child1");
+        stubObject("transaction1");
+        stubObject("parent2");
+        stubObject("child2");
+        stubObject("transaction2");
+
+        // Create two hierarchies, one in a committed transaction and the other in an uncommitted one
+        containmentIndex.addContainedBy(transaction1, parent1.getFedoraId(), child1.getFedoraId());
+        containmentIndex.addContainedBy(transaction2, parent2.getFedoraId(), child2.getFedoraId());
+        containmentIndex.commitTransaction(transaction1);
+
+        assertTrue(containmentIndex.resourceExists(shortLivedTx, child1.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction1, child1.getFedoraId(), false));
+
+        assertFalse(containmentIndex.resourceExists(shortLivedTx, child2.getFedoraId(), false));
+        assertTrue(containmentIndex.resourceExists(transaction2, child2.getFedoraId(), false));
+
+        containmentIndex.clearAllTransactions();
+
+        // Committed containment should persist, but uncommitted should not
+        assertTrue(containmentIndex.resourceExists(shortLivedTx, child1.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(shortLivedTx, child2.getFedoraId(), false));
+        assertFalse(containmentIndex.resourceExists(transaction2, child2.getFedoraId(), false));
+    }
+
+    @Test
     public void testHasResourcesStartingFailure() {
         stubObject("parent1");
         stubObject("child1");

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -7,6 +7,7 @@ package org.fcrepo.kernel.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -230,5 +231,44 @@ public class TransactionManagerImplTest {
         } catch (final TransactionNotFoundException e) {
             //expected
         }
+    }
+
+    @Test
+    public void testCleanupAllTransactions() {
+        final var commitTx = testTxManager.create();
+        commitTx.commit();
+        final var continuingTx = testTxManager.create();
+        final var rollbackTx = testTxManager.create();
+        rollbackTx.rollback();
+        final var expiredTx = testTxManager.create();
+        expiredTx.expire();
+        final var expiredAndRolledBackTx = testTxManager.create();
+        expiredAndRolledBackTx.expire();
+        expiredAndRolledBackTx.rollback();
+
+        testTxManager.cleanupAllTransactions();
+
+        // All transactions must now be gone
+        assertThrows(TransactionClosedException.class, () -> testTxManager.get(commitTx.getId()));
+        assertThrows(TransactionClosedException.class, () -> testTxManager.get(rollbackTx.getId()));
+        assertThrows(TransactionClosedException.class, () -> testTxManager.get(continuingTx.getId()));
+        assertThrows(TransactionClosedException.class, () -> testTxManager.get(expiredTx.getId()));
+        // Committed transaction does not get rolled back
+        verify(pssManager, never()).removeSession(commitTx.getId());
+        // Rolled back transactions does not get rolled back (again)
+        verify(pssManager, never()).removeSession(rollbackTx.getId());
+        // Open and expired transactions get rolled back
+        verify(pssManager).removeSession(continuingTx.getId());
+        verify(pssManager).removeSession(expiredTx.getId());
+        // Unless the expired transaction is already rolled back
+        verify(pssManager, never()).removeSession(expiredAndRolledBackTx.getId());
+    }
+
+    @Test
+    public void testPreCleanTransactions() {
+        testTxManager.preCleanTransactions();
+        verify(containmentIndex).clearAllTransactions();
+        verify(membershipService).clearAllTransactions();
+        verify(referenceService).clearAllTransactions();
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/TransactionManagerImplTest.java
@@ -6,7 +6,6 @@
 package org.fcrepo.kernel.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
@@ -17,14 +16,10 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 
 import org.fcrepo.common.db.DbTransactionExecutor;
 import org.fcrepo.config.FedoraPropsConfig;
-import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.cache.UserTypesCache;
 import org.fcrepo.kernel.api.exception.TransactionClosedException;
@@ -38,13 +33,10 @@ import org.fcrepo.persistence.api.PersistentStorageSessionManager;
 
 import org.fcrepo.search.api.SearchIndex;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * <p>TransactionTest class.</p>
@@ -80,19 +72,10 @@ public class TransactionManagerImplTest {
     private SearchIndex searchIndex;
 
     @Mock
-    private PlatformTransactionManager platformTransactionManager;
-
-    @Mock
     private ResourceLockManager resourceLockManager;
 
     @Mock
     private UserTypesCache userTypesCache;
-
-    @Mock
-    private OcflPropsConfig ocflPropsConfig;
-
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private FedoraPropsConfig fedoraPropsConfig;
 
@@ -112,7 +95,6 @@ public class TransactionManagerImplTest {
         setField(testTxManager, "fedoraPropsConfig", fedoraPropsConfig);
         setField(testTxManager, "resourceLockManager", resourceLockManager);
         setField(testTxManager, "userTypesCache", userTypesCache);
-        setField(testTxManager, "ocflPropsConfig", ocflPropsConfig);
         testTx = (TransactionImpl) testTxManager.create();
     }
 
@@ -281,18 +263,11 @@ public class TransactionManagerImplTest {
 
     @Test
     public void testPreCleanTransactions() throws IOException {
-        final var stagingPath = tempFolder.newFolder("staging").toPath();
-        final var stagedPath = stagingPath.resolve("path/to/staged");
-        Files.createDirectories(stagedPath);
-        Files.createFile(stagedPath.resolve("file1.txt"));
-        when(ocflPropsConfig.getFedoraOcflStaging()).thenReturn(stagingPath);
-
         testTxManager.preCleanTransactions();
         verify(containmentIndex).clearAllTransactions();
         verify(membershipService).clearAllTransactions();
         verify(referenceService).clearAllTransactions();
-        try (DirectoryStream<Path> directory = Files.newDirectoryStream(stagingPath)) {
-            assertFalse("Staging directory must be empty", directory.iterator().hasNext());
-        }
+        verify(searchIndex).clearAllTransactions();
+        verify(pssManager).clearAllSessions();
     }
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/MembershipServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/MembershipServiceImplTest.java
@@ -1141,6 +1141,33 @@ public class MembershipServiceImplTest {
     }
 
     @Test
+    public void clearAllTransactionsMembershipIndex() throws Exception {
+        mockGetHeaders(populateHeaders(membershipRescId, BASIC_CONTAINER));
+        membershipService.resourceCreated(transaction, membershipRescId);
+
+        final var dcId = createDirectContainer(membershipRescId, RdfLexicon.LDP_MEMBER, false);
+        membershipService.resourceCreated(transaction, dcId);
+
+        final var member1Id = createDCMember(dcId, BASIC_CONTAINER);
+
+        membershipService.commitTransaction(transaction);
+
+        assertHasMembersNoTx(membershipRescId, RdfLexicon.LDP_MEMBER, member1Id);
+        assertCommittedMembershipCount(membershipRescId, 1);
+
+        final var member2Id = createDCMember(dcId, RdfLexicon.NON_RDF_SOURCE);
+
+        assertHasMembers(transaction, membershipRescId, RdfLexicon.LDP_MEMBER, member1Id, member2Id);
+        assertUncommittedMembershipCount(transaction, membershipRescId, 2);
+
+        membershipService.clearAllTransactions();
+
+        assertUncommittedMembershipCount(transaction, membershipRescId, 1);
+        assertCommittedMembershipCount(membershipRescId, 1);
+        assertHasMembers(transaction, membershipRescId, RdfLexicon.LDP_MEMBER, member1Id);
+    }
+
+    @Test
     public void populateMembershipHistory_DC_DeletedMember() throws Exception {
         mockGetHeaders(populateHeaders(membershipRescId, BASIC_CONTAINER));
         membershipService.resourceCreated(transaction, membershipRescId);

--- a/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSessionManager.java
+++ b/fcrepo-persistence-api/src/main/java/org/fcrepo/persistence/api/PersistentStorageSessionManager.java
@@ -40,4 +40,8 @@ public interface PersistentStorageSessionManager {
      */
     PersistentStorageSession removeSession(final String sessionId);
 
+    /**
+     * Clears all sessions. This is useful for cleaning up after a shutdown when sessions were not able to rollback.
+     */
+    void clearAllSessions();
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
@@ -76,5 +76,9 @@ public interface FedoraToOcflObjectIndex {
      */
     void rollback(@Nonnull final Transaction session);
 
+    /**
+     * Clear all transactions in the ocfl index.
+     */
+    void clearAllTransactions();
 }
 

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/DbFedoraToOcflObjectIndex.java
@@ -375,4 +375,12 @@ public class DbFedoraToOcflObjectIndex implements FedoraToOcflObjectIndex {
         }
     }
 
+    @Override
+    public void clearAllTransactions() {
+        try {
+            jdbcTemplate.update(TRUNCATE_TRANSACTIONS, Collections.emptyMap());
+        } catch (final Exception e) {
+            throw new RepositoryRuntimeException("Failed to truncate FedoraToOcfl transactions index tables", e);
+        }
+    }
 }

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOcflObjectIndexMetrics.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/FedoraToOcflObjectIndexMetrics.java
@@ -41,6 +41,8 @@ public class FedoraToOcflObjectIndexMetrics implements FedoraToOcflObjectIndex {
             DB, OCFL, OPERATION, "commit");
     private static final Timer rollbackTimer = Metrics.timer(METRIC_NAME,
             DB, OCFL, OPERATION, "rollback");
+    private static final Timer clearAllTransactionsTimer = Metrics.timer(METRIC_NAME,
+            DB, OCFL, OPERATION, "clearAllTransactions");
 
     @Autowired
     private FedoraToOcflObjectIndex ocflIndexImpl;
@@ -92,6 +94,13 @@ public class FedoraToOcflObjectIndexMetrics implements FedoraToOcflObjectIndex {
     public void rollback(final Transaction session) {
         rollbackTimer.record(() -> {
             ocflIndexImpl.rollback(session);
+        });
+    }
+
+    @Override
+    public void clearAllTransactions() {
+        clearAllTransactionsTimer.record(() -> {
+            ocflIndexImpl.clearAllTransactions();
         });
     }
 

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManagerTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentSessionManagerTest.java
@@ -5,6 +5,7 @@
  */
 package org.fcrepo.persistence.ocfl.impl;
 
+import org.fcrepo.config.OcflPropsConfig;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.operations.ResourceOperation;
 import org.fcrepo.persistence.api.PersistentStorageSession;
@@ -12,16 +13,23 @@ import org.fcrepo.persistence.api.exceptions.PersistentStorageException;
 import org.fcrepo.persistence.ocfl.api.FedoraToOcflObjectIndex;
 import org.fcrepo.storage.ocfl.OcflObjectSessionFactory;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static java.util.UUID.randomUUID;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -32,6 +40,8 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class OcflPersistentSessionManagerTest {
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     private OcflPersistentSessionManager sessionManager;
 
@@ -53,6 +63,9 @@ public class OcflPersistentSessionManagerTest {
     @Mock
     private Transaction transaction;
 
+    @Mock
+    private OcflPropsConfig ocflPropsConfig;
+
     @Before
     public void setUp() throws IOException {
         this.sessionManager = new OcflPersistentSessionManager();
@@ -60,6 +73,7 @@ public class OcflPersistentSessionManagerTest {
         readWriteSession = this.sessionManager.getSession(transaction);
         setField(sessionManager, "objectSessionFactory", objectSessionFactory);
         setField(sessionManager, "ocflIndex", index);
+        setField(sessionManager, "ocflPropsConfig", ocflPropsConfig);
         readOnlySession = this.sessionManager.getReadOnlySession();
     }
 
@@ -83,6 +97,22 @@ public class OcflPersistentSessionManagerTest {
         final var session = sessionManager.removeSession(testSessionId);
         assertSame(readWriteSession, session);
         assertNull(sessionManager.removeSession(testSessionId));
+    }
+
+    @Test
+    public void clearAllSessions() throws Exception {
+        final var stagingPath = tempFolder.newFolder("staging").toPath();
+        final var stagedPath = stagingPath.resolve("path/to/staged");
+        Files.createDirectories(stagedPath);
+        Files.createFile(stagedPath.resolve("file1.txt"));
+        when(ocflPropsConfig.getFedoraOcflStaging()).thenReturn(stagingPath);
+
+        sessionManager.clearAllSessions();
+
+        verify(index).clearAllTransactions();
+        try (DirectoryStream<Path> directory = Files.newDirectoryStream(stagingPath)) {
+            assertFalse("Staging directory must be empty", directory.iterator().hasNext());
+        }
     }
 
 }

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +26,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -463,6 +465,8 @@ public class OcflPersistentStorageSessionTest {
             session1.rollback();
             fail("session1.rollback(...) invocation should fail.");
         }
+
+        verify(index).rollback(any(Transaction.class));
     }
 
     @Test
@@ -533,7 +537,7 @@ public class OcflPersistentStorageSessionTest {
         session1.rollback();
     }
 
-    @Test(expected = PersistentStorageException.class)
+    @Test
     public void rollbackSucceedsOnUncommittedChanges() throws Exception {
         mockMappingAndIndex(OCFL_RESOURCE_ID, RESOURCE_ID, ROOT_OBJECT_ID, mapping);
         mockResourceOperation(rdfSourceOperation, RESOURCE_ID);
@@ -548,11 +552,11 @@ public class OcflPersistentStorageSessionTest {
         }
         //verify that the resource cannot be found now (since it wasn't committed).
         final OcflPersistentStorageSession newSession = createSession(index, objectSessionFactory);
-        newSession.getTriples(RESOURCE_ID, null);
-        fail("second session.getTriples(...) invocation should have failed.");
+        assertThrows(PersistentStorageException.class, () -> newSession.getTriples(RESOURCE_ID, null));
+        verify(index).rollback(any(Transaction.class));
     }
 
-    @Test(expected = PersistentStorageException.class)
+    @Test
     public void rollbackFailsWhenAlreadyRolledBack() throws Exception {
         mockNoIndex(RESOURCE_ID);
         mockResourceOperation(rdfSourceOperation, RESOURCE_ID);
@@ -579,7 +583,9 @@ public class OcflPersistentStorageSessionTest {
             fail("Operation should not fail.");
         }
 
-        session1.rollback();
+        assertThrows(PersistentStorageException.class, () -> session1.rollback());
+
+        verify(index).rollback(any(Transaction.class));
     }
 
     @Test

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistentStorageSessionTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/TestOcflObjectIndex.java
@@ -82,4 +82,9 @@ public class TestOcflObjectIndex implements FedoraToOcflObjectIndex {
 
     }
 
+    @Override
+    public void clearAllTransactions() {
+
+    }
+
 }

--- a/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchIndex.java
+++ b/fcrepo-search-api/src/main/java/org/fcrepo/search/api/SearchIndex.java
@@ -58,4 +58,8 @@ public interface SearchIndex {
      */
     void rollbackTransaction(final Transaction tx);
 
+    /**
+     * Clear all transactions in the search index.
+     */
+    void clearAllTransactions();
 }

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexMetrics.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/SearchIndexMetrics.java
@@ -45,6 +45,8 @@ public class SearchIndexMetrics implements SearchIndex {
             DB, SEARCH, OPERATION, "commitTransaction");
     private static final Timer rollbackTransactionTimer = Metrics.timer(METRIC_NAME,
             DB, SEARCH, OPERATION, "rollbackTransaction");
+    private static final Timer clearAllTransactionsTimer = Metrics.timer(METRIC_NAME,
+            DB, SEARCH, OPERATION, "clearAllTransactions");
 
     @Autowired
     @Qualifier("searchIndexImpl")
@@ -92,6 +94,13 @@ public class SearchIndexMetrics implements SearchIndex {
     public void rollbackTransaction(final Transaction tx) {
         rollbackTransactionTimer.record(() -> {
             searchIndexImpl.rollbackTransaction(tx);
+        });
+    }
+
+    @Override
+    public void clearAllTransactions() {
+        clearAllTransactionsTimer.record(() -> {
+            searchIndexImpl.clearAllTransactions();
         });
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3952

# What does this Pull Request do?

When shutting down fedora, the application will attempt to rollback all active or expired-but-not-rolledback transactions, along with associated OCFL sessions. This should result in no leftover staged files or residual transaction database entries.

If the application shuts down in a non-graceful manner, the transaction tables also get truncated during startup and any leftover files in the staging directory are cleaned up.

ReferenceIndexService `reset` method now also clears the transaction table, which I'm guessing was overlooked before.

This PR also cleans up session information in the OCFL index when an OCFL session is rolled back (previously only committed OCFL sessions would roll back)

# How should this be tested?

This can be tested using `mvn jetty:run` and the h2 client which can be downloaded here:
http://h2database.com/html/download.html
You cannot connect to h2 at the same time that fedora is running. Use h2.sh found in the extracted h2 client directory, and the connection URL is `jdbc:h2:/path/to/fcrepo/fcrepo-webapp/target/fcrepo-home/data/fcrepo-h2;FILE_LOCK=SOCKET` with no username or password.

Or you can use a different database that is easier to connect to.

## Replicate issue
Prior to checking out this branch, to replicate the issue do the following steps:
```
curl -i -X POST "http://localhost:8080/rest/fcr:tx" -ufedoraAdmin:fedoraAdmin

# update the tx id based on the previous response
curl -H"Atomic-ID: http://localhost:8080/rest/fcr:tx/0a3ef984-4e8a-446e-9cdf-1a8f8b69d464" -X POST "http://localhost:8080/rest" -H"Slug: newone" -ufedoraAdmin:fedoraAdmin
```

Then shut down fedora and connect to h2. You should see the entries in the `CONTAINMENT_TRANSACTIONS` table. They will still be there even if you start up fedora and shut it down again. There will also be files in `/path/to/fcrepo/fcrepo-webapp/target/fcrepo-home/data/staging`.

## Verify fix with graceful shutdown
Then rebuild with this branch and start up fedora. If you checked h2 now `CONTAINMENT_TRANSACTIONS` would be empty. Now repeat the curl commands above and then shut down fedora. The `CONTAINMENT_TRANSACTIONS` table should be empty, along with the `staging` folder.

## Verify fix with hard shutdown
Now start fedora up again and perform the same curl calls. Then find the process id of fedora and kill it with `kill -9 <processid>`. Connect to h2 and you'll see entries in `CONTAINMENT_TRANSACTIONS`. Now start fedora up again, and if using h2 then shut down fedora again, connect to h2, and verify that `CONTAINMENT_TRANSACTIONS` is now empty, along with the staging folder.

## Testing with other types of content

You might also want to verify that references or membership get cleaned up from their respective transaction tables. I did test the membership table locally with an IndirectContainer based off [pcdm in action](https://github.com/awead/ldp-pcdm), which unfortunately needs some updating to work with fedora 6). 

It would also probably be prudent to verify that no committed database entries get cleaned up, by creating a few resources in fedora outside of a transaction prior to doing the testing steps above. (I also verified this)

# Interested parties
@fcrepo/committers
