### PR TITLE
Allow encoded forward slashes

### DIFF
--- a/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
+++ b/fcrepo-webapp/src/main/java/org/fcrepo/webapp/AuthConfig.java
@@ -186,6 +186,7 @@ public class AuthConfig {
         final var filter = new InvalidRequestFilter();
         filter.setBlockNonAscii(false);
         filter.setBlockBackslash(false);
+        filter.setBlockEncodedForwardSlash(false);
         filter.setBlockSemicolon(false);
         return filter;
     }

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/SanityCheckIT.java
@@ -6,6 +6,7 @@
 package org.fcrepo.integration;
 
 import static java.lang.Integer.MAX_VALUE;
+import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
@@ -180,5 +181,12 @@ public class SanityCheckIT {
         executeAndVerify(put, SC_CREATED);
 
         executeAndVerify(new HttpGet(url), SC_OK);
+    }
+
+    @Test
+    public void testEncodedSlash() throws IOException {
+        final String targetResource = serverAddress + "/rest/" + randomUUID() + "/admin_set%2Fdefault";
+        final var putTest = new HttpPut(targetResource);
+        executeAndVerify(putTest, SC_CREATED);
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3933

# What does this Pull Request do?
Change configuration to allow encoded forward slashes (`%2F`) in the path since Shiro 1.13

# How should this be tested?

There is a test in fcrepo-webapp and this does seem to appear only with Tomcat.

Build the WAR before this PR and deploy it to Tomcat.
Perform a PUT with an encoded slash
```
curl -ufedoraAdmin:fedoraAdmin  -XPUT -d" @prefix dc: <http://purl.org/dc/elements/1.1/> . <> dc:title 'Some object' ." -H"Content-type: text/turtle" "http://localhost:8080/fcrepo/rest/admin_set%2Fdefault" -i
```

See a 400 Bad Request

Build with this PR, and try again. Get a 201 Created or 204 No Content (depending on if it exists already).


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
