### PR TITLE
Add fedora:hasParent

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -82,6 +82,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.HAS_MEMBER_RELATION;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_PARENT;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.INBOUND_REFERENCES;
 import static org.fcrepo.kernel.api.RdfLexicon.INDIRECT_CONTAINER;
@@ -5293,6 +5294,40 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(model.contains(createResource(location), schemaAbout, wikiCat));
             assertTrue(model.contains(createResource(location), schemaName, createPlainLiteral("The description")));
             assertTrue(model.contains(wikiCat, schemaName, createPlainLiteral("Cat")));
+        }
+    }
+
+    /**
+     * Ensure there is a fedora:hasParent triple unless server managed triples are omitted.
+     */
+    @Test
+    public void testHasParent() throws IOException {
+        final String parentLocation;
+        final String childLocation;
+        try (final var response = execute(postObjMethod())) {
+            assertEquals(SC_CREATED, response.getStatusLine().getStatusCode());
+            parentLocation = getLocation(response);
+        }
+        final HttpPost childPost = new HttpPost(parentLocation);
+        try (final var response = execute(childPost)) {
+            assertEquals(SC_CREATED, response.getStatusLine().getStatusCode());
+            childLocation = getLocation(response);
+        }
+        final var preferGet = new HttpGet(childLocation);
+        preferGet.addHeader("Prefer", "return=representation; omit=\"" + PREFER_SERVER_MANAGED + "\"");
+        try (final var dataset = getDataset(preferGet)) {
+            final var model = dataset.getDefaultModel();
+            assertFalse(model.contains(createResource(childLocation), HAS_PARENT, createResource(parentLocation)));
+        }
+        final var preferGet2 = new HttpGet(childLocation);
+        preferGet2.addHeader("Prefer", "return=representation; include=\"" + PREFER_SERVER_MANAGED + "\"");
+        try (final var dataset = getDataset(preferGet2)) {
+            final var model = dataset.getDefaultModel();
+            assertTrue(model.contains(createResource(childLocation), HAS_PARENT, createResource(parentLocation)));
+        }
+        try (final var dataset = getDataset(new HttpGet(childLocation))) {
+            final var model = dataset.getDefaultModel();
+            assertTrue(model.contains(createResource(childLocation), HAS_PARENT, createResource(parentLocation)));
         }
     }
 

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -109,6 +109,8 @@ public final class RdfLexicon {
             createProperty(REPOSITORY_NAMESPACE + "lastModified");
     public static final Property LAST_MODIFIED_BY =
             createProperty(REPOSITORY_NAMESPACE + "lastModifiedBy");
+    public static final Property HAS_PARENT =
+            createProperty(REPOSITORY_NAMESPACE + "hasParent");
 
     public static final Resource FEDORA_CONTAINER =
             createResource(REPOSITORY_NAMESPACE + "Container");

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImpl.java
@@ -15,6 +15,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MIME_TYPE;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_ORIGINAL_NAME;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_PARENT;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
@@ -23,13 +24,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.apache.jena.graph.Triple;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
 import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.TimeMap;
 import org.fcrepo.kernel.api.models.Tombstone;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
+
+import org.apache.jena.graph.Triple;
 import org.springframework.stereotype.Component;
 
 /**
@@ -101,6 +104,14 @@ public class ManagedPropertiesServiceImpl implements ManagedPropertiesService {
             triples.add(Triple.create(subject, type.asNode(), createURI(triple.toString())));
         });
 
+        if (!resource.getFedoraId().isRepositoryRoot()) {
+            try {
+                final var parent = resource.getParent();
+                triples.add(Triple.create(subject, HAS_PARENT.asNode(), createURI(resolveId(parent))));
+            } catch (final PathNotFoundException e) {
+                // no parent.
+            }
+        }
         return new DefaultRdfStream(subject, triples.stream());
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ManagedPropertiesServiceImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.kernel.impl.services;
+
+import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.CREATED_DATE;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_PARENT;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_BY;
+import static org.fcrepo.kernel.api.RdfLexicon.LAST_MODIFIED_DATE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.fcrepo.kernel.api.RdfCollectors.toModel;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.RDFNode;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test the ManagedPropertiesServiceImpl
+ * @author whikloj
+ */
+public class ManagedPropertiesServiceImplTest {
+
+    ManagedPropertiesServiceImpl managedPropertiesServiceImpl = new ManagedPropertiesServiceImpl();
+    FedoraResource resource = mock(FedoraResource.class);
+    final Instant created_date = Instant.now();
+
+    @Before
+    public void setUp() {
+        when(resource.getFedoraId()).thenReturn(FedoraId.create("resource"));
+        when(resource.getId()).thenReturn("info:fedora/resource");
+        when(resource.getDescribedResource()).thenReturn(resource);
+        when(resource.getCreatedBy()).thenReturn("createdBy");
+        when(resource.getCreatedDate()).thenReturn(created_date);
+        when(resource.getLastModifiedBy()).thenReturn("lastModifiedBy");
+        when(resource.getLastModifiedDate()).thenReturn(created_date);
+    }
+
+    @Test
+    public void testGetNoParent() throws PathNotFoundException {
+        when(resource.getParent()).thenThrow(PathNotFoundException.class);
+        final Stream<Triple> result = managedPropertiesServiceImpl.get(resource);
+        assertNotNull(result);
+        final var model = result.collect(toModel());
+        assertTrue(model.contains(null, CREATED_BY, model.createLiteral("createdBy")));
+        assertTrue(model.contains(null, CREATED_DATE, model.createTypedLiteral(created_date.toString(), XSDdateTime)));
+        assertTrue(model.contains(null, LAST_MODIFIED_BY, model.createLiteral("lastModifiedBy")));
+        assertTrue(model.contains(
+                null,
+                LAST_MODIFIED_DATE,
+                model.createTypedLiteral(created_date.toString(), XSDdateTime)
+        ));
+        assertFalse(model.contains(null, HAS_PARENT, (RDFNode) null));
+    }
+
+    @Test
+    public void testGetParent() throws PathNotFoundException {
+        final FedoraResource parent = mock(FedoraResource.class);
+        when(parent.getId()).thenReturn("info:fedora/parent");
+        when(resource.getParent()).thenReturn(parent);
+        when(parent.getFedoraId()).thenReturn(FedoraId.create("parent"));
+        final Stream<Triple> result = managedPropertiesServiceImpl.get(resource);
+        assertNotNull(result);
+        final var model = result.collect(toModel());
+        assertTrue(model.contains(null, CREATED_BY, model.createLiteral("createdBy")));
+        assertTrue(model.contains(null, CREATED_DATE, model.createTypedLiteral(created_date.toString(), XSDdateTime)));
+        assertTrue(model.contains(null, LAST_MODIFIED_BY, model.createLiteral("lastModifiedBy")));
+        assertTrue(model.contains(
+                null,
+                LAST_MODIFIED_DATE,
+                model.createTypedLiteral(created_date.toString(), XSDdateTime)
+        ));
+        assertTrue(model.contains(null, HAS_PARENT, model.createResource(URI.create("info:fedora/parent").toString())));
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3959

# What does this Pull Request do?
Adds a new server managed triple with `http://fedora.info/definitions/v4/repository#hasParent` pointing from a resource to the resource that contains it. It does not appear at the repositoryRoot.

# How should this be tested?

Create a container and then create a container inside it.
Get the child and see a new `fedora:hasParent` triple.
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/parent/child 

@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/parent/child>
        fedora:created         "2024-11-22T19:41:44.102902Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2024-11-22T19:41:44.102902Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container ;
        fedora:hasParent       <http://localhost:8080/rest/parent> .
```
You can omit it with the rest of the server managed triples
```
curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/parent/child/ -H"Prefer: return=representation; omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\""

```
Parent will have a `fedora:hasParent` to the repository root
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/parent                                                                                           
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/parent>
        fedora:created         "2024-11-22T19:41:31.436402Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2024-11-22T19:41:31.436402Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container ;
        fedora:hasParent       <http://localhost:8080/rest/> ;
        ldp:contains           <http://localhost:8080/rest/parent/child> ;
        ldp:contains           <http://localhost:8080/rest/parent/child2> .
```
and the repository root will _not_ have the triple
```
> curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest       
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .
@prefix dc: <http://purl.org/dc/elements/1.1/> .

<http://localhost:8080/rest/>
        dc:title                       "Some object" ;
        fedora:created                 "2024-10-01T15:20:41.544241Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified            "2024-11-12T23:01:58.953396Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModifiedBy          "fedoraAdmin" ;
        rdf:type                       ldp:BasicContainer ;
        rdf:type                       ldp:Resource ;
        rdf:type                       fedora:Resource ;
        rdf:type                       fedora:RepositoryRoot ;
        rdf:type                       ldp:RDFSource ;
        rdf:type                       ldp:Container ;
        rdf:type                       fedora:Container ;
        ldp:contains                   <http://localhost:8080/rest/parent> ;
        fedora:hasTransactionProvider  <http://localhost:8080/rest/fcr:tx> .
```
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
