### PR TITLE
FCREPO-3589 - Inbound references add membership and contains relations

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -191,7 +191,6 @@ import org.fcrepo.http.commons.domain.RDFMediaType;
 import org.fcrepo.http.commons.test.util.CloseableDataset;
 import org.fcrepo.kernel.api.RdfLexicon;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.springframework.test.context.TestExecutionListeners;
@@ -221,6 +220,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     private static final String BASIC_CONTAINER_LINK_HEADER = "<" + BASIC_CONTAINER.getURI() + ">; rel=\"type\"";
     private static final String INDIRECT_CONTAINER_LINK_HEADER = "<" + INDIRECT_CONTAINER.getURI() + ">; rel=\"type\"";
+    private static final String PROXY_FOR_URI = "http://www.openarchives.org/ore/terms/proxyFor";
     private static final String ARCHIVAL_GROUP_LINK_HEADER = "<" + ARCHIVAL_GROUP.getURI() + ">; rel=\"type\"";
 
     private static final String RESOURCE_LINK_HEADER = "<" + RESOURCE.getURI() + ">; rel=\"type\"";
@@ -2932,7 +2932,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
-    @Ignore("Membership/containment not included as inbound references - FCREPO-3589")
     public void testGetObjectReferencesIndirect() throws Exception {
         final String uuid = getRandomUniqueId();
         final String pid1 = uuid + "/parent";
@@ -2943,20 +2942,130 @@ public class FedoraLdpIT extends AbstractResourceIT {
         createObjectAndClose(pid3);
 
         final String memberRelation = "http://pcdm.org/models#hasMember";
+        final String memberRelation2 = "http://example.com/models#anotherMember";
 
         // create an indirect container
-        final HttpPut createContainer = new HttpPut(serverAddress + pid1 + "/members");
+        final String indirectPid1 = pid1 + "/members";
+        createIndirectContainer(indirectPid1, memberRelation, pid1);
+
+        // create proxies for the children in the indirect container
+        createProxy(pid1, indirectPid1, pid2);
+        createProxy(pid1, indirectPid1, pid3);
+
+        // create another indirect container
+        final String indirectPid2 = pid1 + "/members2";
+        createIndirectContainer(indirectPid2, memberRelation2, pid1);
+
+        // create proxies for the children in the indirect container
+        createProxy(pid1, indirectPid2, pid2);
+
+        // retrieve the parent and verify the outbound triples exist
+        final HttpGet getParent =  new HttpGet(serverAddress + pid1);
+        getParent.addHeader(ACCEPT, "application/n-triples");
+        try (final CloseableDataset dataset = getDataset(getParent)) {
+            final DatasetGraph parentGraph = dataset.asDatasetGraph();
+            assertTrue(parentGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation),
+                    createURI(serverAddress + pid2)));
+            assertTrue(parentGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation),
+                    createURI(serverAddress + pid3)));
+            assertTrue(parentGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation2),
+                    createURI(serverAddress + pid2)));
+        }
+
+        // retrieve the members container and verify the LDP triples exist
+        final HttpGet getContainer =  new HttpGet(serverAddress + pid1 + "/members");
+        getContainer.addHeader("Prefer", "return=representation;include=\"http://www.w3.org/ns/ldp#PreferMembership\"");
+        getContainer.addHeader(ACCEPT, "application/n-triples");
+        try (final CloseableDataset dataset = getDataset(getContainer)) {
+            final DatasetGraph containerGraph = dataset.asDatasetGraph();
+            assertTrue(containerGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1 + "/members"),
+                    createURI("http://www.w3.org/ns/ldp#hasMemberRelation"),
+                    createURI(memberRelation)));
+
+            assertTrue(containerGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1 + "/members"),
+                    createURI("http://www.w3.org/ns/ldp#insertedContentRelation"),
+                    createURI(PROXY_FOR_URI)));
+
+            assertTrue(containerGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1 + "/members"),
+                    createURI("http://www.w3.org/ns/ldp#membershipResource"),
+                    createURI(serverAddress + pid1)));
+        }
+
+        // retrieve the member and verify inbound triples exist
+        final HttpGet getMember =  new HttpGet(serverAddress + pid2);
+        getMember.addHeader("Prefer", "return=representation; include=\"" + INBOUND_REFERENCES.toString() + "\"");
+        getMember.addHeader(ACCEPT, "application/n-triples");
+        try (final CloseableDataset dataset = getDataset(getMember)) {
+            final DatasetGraph memberGraph = dataset.asDatasetGraph();
+            assertTrue(memberGraph.contains(Node.ANY,
+                    Node.ANY,
+                    createURI(PROXY_FOR_URI),
+                    createURI(serverAddress + pid2)));
+
+            assertTrue(memberGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation),
+                    createURI(serverAddress + pid2)));
+
+            assertTrue(memberGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation2),
+                    createURI(serverAddress + pid2)));
+
+            assertFalse("Should not contain inbound references to the other child", memberGraph.contains(Node.ANY,
+                    createURI(serverAddress + pid1),
+                    createURI(memberRelation),
+                    createURI(serverAddress + pid3)));
+        }
+    }
+
+    private static String createIndirectContainer(final String indirectPid1, final String memberRelation,
+                                                  final String memberRescPid) throws UnsupportedEncodingException {
+        final HttpPut createContainer = new HttpPut(serverAddress + indirectPid1);
         createContainer.addHeader(CONTENT_TYPE, "text/turtle");
         createContainer.addHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
+        final String membersRDF = "<> <" + HAS_MEMBER_RELATION + "> <" + memberRelation + ">; "
+            + "<" + INSERTED_CONTENT_RELATION + "> <" + PROXY_FOR_URI + ">; "
+            + "<" + MEMBERSHIP_RESOURCE + "> <" + serverAddress + memberRescPid + "> . ";
+        createContainer.setEntity(new StringEntity(membersRDF));
+
+        assertEquals(CREATED.getStatusCode(), getStatus(createContainer));
+        return serverAddress + indirectPid1;
+    }
+
+    @Test
+    public void testGetObjectReferencesDirect() throws Exception {
+        final String uuid = getRandomUniqueId();
+        final String pid1 = uuid + "/parent";
+
+        createObjectAndClose(pid1);
+
+        final String memberRelation = "http://pcdm.org/models#hasMember";
+
+        // create a direct container
+        final String directPid = pid1 + "/members";
+        final HttpPut createContainer = new HttpPut(serverAddress + directPid);
+        createContainer.addHeader(CONTENT_TYPE, "text/turtle");
+        createContainer.addHeader(LINK, DIRECT_CONTAINER_LINK_HEADER);
         final String membersRDF = "<> <http://www.w3.org/ns/ldp#hasMemberRelation> <" + memberRelation + ">; "
-            + "<http://www.w3.org/ns/ldp#insertedContentRelation> <http://www.openarchives.org/ore/terms/proxyFor>; "
-            + "<http://www.w3.org/ns/ldp#membershipResource> <" + serverAddress + pid1 + "> . ";
+                + "<http://www.w3.org/ns/ldp#membershipResource> <" + serverAddress + pid1 + "> . ";
         createContainer.setEntity(new StringEntity(membersRDF));
         assertEquals(CREATED.getStatusCode(), getStatus(createContainer));
 
-        // create proxies for the children in the indirect container
-        createProxy(pid1, pid2);
-        createProxy(pid1, pid3);
+        // create direct children
+        final String pid2 = directPid + "/child1";
+        final String pid3 = directPid + "/child2";
+        createObjectAndClose(pid2);
+        createObjectAndClose(pid3);
 
         // retrieve the parent and verify the outbound triples exist
         final HttpGet getParent =  new HttpGet(serverAddress + pid1);
@@ -2974,27 +3083,21 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
 
         // retrieve the members container and verify the LDP triples exist
-        final HttpGet getContainer =  new HttpGet(serverAddress + pid1 + "/members");
+        final HttpGet getContainer =  new HttpGet(serverAddress + directPid);
         getContainer.addHeader("Prefer", "return=representation;include=\"http://www.w3.org/ns/ldp#PreferMembership\"");
         getContainer.addHeader(ACCEPT, "application/n-triples");
         try (final CloseableDataset dataset = getDataset(getContainer)) {
             final DatasetGraph containerGraph = dataset.asDatasetGraph();
             assertTrue(containerGraph.contains(Node.ANY,
-                    createURI(serverAddress + pid1 + "/members"),
+                    createURI(serverAddress + directPid),
                     createURI("http://www.w3.org/ns/ldp#hasMemberRelation"),
                     createURI(memberRelation)));
 
             assertTrue(containerGraph.contains(Node.ANY,
-                    createURI(serverAddress + pid1 + "/members"),
-                    createURI("http://www.w3.org/ns/ldp#insertedContentRelation"),
-                    createURI("http://www.openarchives.org/ore/terms/proxyFor")));
-
-            assertTrue(containerGraph.contains(Node.ANY,
-                    createURI(serverAddress + pid1 + "/members"),
+                    createURI(serverAddress + directPid),
                     createURI("http://www.w3.org/ns/ldp#membershipResource"),
                     createURI(serverAddress + pid1)));
         }
-
 
         // retrieve the member and verify inbound triples exist
         final HttpGet getMember =  new HttpGet(serverAddress + pid2);
@@ -3002,11 +3105,6 @@ public class FedoraLdpIT extends AbstractResourceIT {
         getMember.addHeader(ACCEPT, "application/n-triples");
         try (final CloseableDataset dataset = getDataset(getMember)) {
             final DatasetGraph memberGraph = dataset.asDatasetGraph();
-            assertTrue(memberGraph.contains(Node.ANY,
-                    Node.ANY,
-                    createURI("http://www.openarchives.org/ore/terms/proxyFor"),
-                    createURI(serverAddress + pid2)));
-
             assertTrue(memberGraph.contains(Node.ANY,
                     createURI(serverAddress + pid1),
                     createURI(memberRelation),
@@ -3018,13 +3116,18 @@ public class FedoraLdpIT extends AbstractResourceIT {
                     createURI(serverAddress + pid3)));
         }
     }
-    private static void createProxy(final String parent, final String child) {
-        final HttpPost createProxy = new HttpPost(serverAddress + parent + "/members");
+
+    private static String createProxy(final String parent, final String indirectContainer, final String child)
+            throws IOException {
+        final HttpPost createProxy = new HttpPost(serverAddress + indirectContainer);
         createProxy.addHeader(CONTENT_TYPE, "text/turtle");
-        final String proxyRDF = "<> <http://www.openarchives.org/ore/terms/proxyFor> <" + serverAddress + child + ">;"
+        final String proxyRDF = "<> <" + PROXY_FOR_URI + "> <" + serverAddress + child + ">;"
             + " <http://www.openarchives.org/ore/terms/proxyIn> <" + serverAddress + parent + "> .";
         createProxy.setEntity(new StringEntity(proxyRDF, UTF_8));
-        assertEquals(CREATED.getStatusCode(), getStatus(createProxy));
+        try (final CloseableHttpResponse postResponse = execute(createProxy)) {
+            assertEquals(CREATED.getStatusCode(), getStatus(postResponse));
+            return getLocation(postResponse);
+        }
     }
 
     @Test
@@ -3767,30 +3870,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
         // Create indirect container (c0/members)
         final String indirectContainerId = containerId + "/t";
-        final String indirectContainer;
-        final String ttl = "<> <" + MEMBERSHIP_RESOURCE + "> <" + container + ">;\n"
-                + "<" + HAS_MEMBER_RELATION + "> <info:some/relation>;\n"
-                + "<" + INSERTED_CONTENT_RELATION + "> <info:proxy/for> .\n";
-        final HttpPut put = putObjMethod(containerId + "/t", "text/turtle", ttl);
-        put.setHeader(LINK, INDIRECT_CONTAINER_LINK_HEADER);
-        try (final CloseableHttpResponse response = execute(put)) {
-            indirectContainer = getLocation(response);
-        }
+        final String indirectContainer = createIndirectContainer(indirectContainerId,
+                "info:some/relation", containerId);
         assertTrue(getLinkHeaders(getObjMethod(containerId + "/t")).contains(INDIRECT_CONTAINER_LINK_HEADER));
 
         // Add indirect resource to indirect container
-        final HttpPost postIndirectResource = postObjMethod(indirectContainerId);
-        final String irRdf =
-                "<> <info:proxy/in>  <" + container + "> ;\n" +
-                        "   <info:proxy/for> <" + resource + "> .";
-        postIndirectResource.setEntity(new StringEntity(irRdf));
-        postIndirectResource.setHeader(CONTENT_TYPE, "text/turtle");
+        final String indirectResource = createProxy(containerId, indirectContainerId, resourceId);
 
-        final String indirectResource;
-        try (final CloseableHttpResponse postResponse = execute(postIndirectResource)) {
-            indirectResource = getLocation(postResponse);
-            assertEquals("Expected post to succeed", CREATED.getStatusCode(), getStatus(postResponse));
-        }
         // Ensure container has been updated with relationship... indirectly
         try (final CloseableHttpResponse getResponse = execute(new HttpGet(container));
                 final CloseableDataset dataset = getDataset(getResponse)) {
@@ -3805,7 +3891,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         assertEquals("Expected delete to succeed",
                 NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(indirectResource)));
 
-        // Ensure container has been updated with relationship... indirectly
+        // Ensure container has been updated to remove the relationship... indirectly
         try (final CloseableHttpResponse getResponse1 = execute(new HttpGet(container));
                 final CloseableDataset dataset = getDataset(getResponse1)) {
             final DatasetGraph graph = dataset.asDatasetGraph();

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ContainmentTriplesService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/ContainmentTriplesService.java
@@ -27,4 +27,13 @@ public interface ContainmentTriplesService {
      * @return A stream of containment triples for the resource.
      */
     Stream<Triple> get(Transaction tx, FedoraResource resource);
+
+    /**
+     * Retrieve containment triples which have the provided resource as the object
+     *
+     * @param tx The transaction or null if none.
+     * @param objectResource The object resource to retrieve containment triples for.
+     * @return A stream of containment triples for the resource.
+     */
+    Stream<Triple> getContainedBy(Transaction tx, FedoraResource objectResource);
 }

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/services/MembershipService.java
@@ -28,6 +28,15 @@ public interface MembershipService {
     RdfStream getMembership(final Transaction transaction, final FedoraId fedoraId);
 
     /**
+     * Return an RdfStream of membership relations of which the provided resource is the object.
+     *
+     * @param transaction transaction
+     * @param fedoraId the object resource to get membership relations for.
+     * @return RdfStream of membership relations.
+     */
+    RdfStream getMembershipByObject(final Transaction transaction, final FedoraId fedoraId);
+
+    /**
      * Update membership properties based on the creation of the specified resource
      *
      * @param transaction transaction

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -545,7 +545,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
 
     @Override
     public String getContainedBy(@Nonnull final Transaction tx, final FedoraId resource) {
-        final String resourceID = resource.isDescription() ? resource.getBaseId() : resource.getFullId();
+        final String resourceID = resource.getFullId();
         final String parentID;
         if (tx.isOpenLongRunning()) {
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS_IN_TRANSACTION, Map.of("child", resourceID,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/ContainmentIndexImpl.java
@@ -545,7 +545,7 @@ public class ContainmentIndexImpl implements ContainmentIndex {
 
     @Override
     public String getContainedBy(@Nonnull final Transaction tx, final FedoraId resource) {
-        final String resourceID = resource.getFullId();
+        final String resourceID = resource.isDescription() ? resource.getBaseId() : resource.getFullId();
         final String parentID;
         if (tx.isOpenLongRunning()) {
             parentID = jdbcTemplate.queryForList(PARENT_EXISTS_IN_TRANSACTION, Map.of("child", resourceID,

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
@@ -41,4 +41,21 @@ public class ContainmentTriplesServiceImpl implements ContainmentTriplesService 
                 new Triple(currentNode, CONTAINS.asNode(), createURI(c)));
     }
 
+    @Override
+    public Stream<Triple> getContainedBy(final Transaction tx, final FedoraResource objectResource) {
+        final var objectId = objectResource.getFedoraId();
+        final String nodeUri;
+        if (objectId.isMemento() || objectId.isDescription()) {
+            nodeUri = objectId.getBaseId();
+        } else {
+            nodeUri = objectId.getFullId();
+        }
+        final var containedBy = containmentIndex.getContainedBy(tx, objectId);
+        if (containedBy == null) {
+            return Stream.empty();
+        }
+        return Stream.of(new Triple(createURI(containedBy),
+                        CONTAINS.asNode(),
+                        createURI(nodeUri)));
+    }
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImpl.java
@@ -43,9 +43,10 @@ public class ContainmentTriplesServiceImpl implements ContainmentTriplesService 
 
     @Override
     public Stream<Triple> getContainedBy(final Transaction tx, final FedoraResource objectResource) {
-        final var objectId = objectResource.getFedoraId();
+        var objectId = objectResource.getFedoraId();
         final String nodeUri;
         if (objectId.isMemento() || objectId.isDescription()) {
+            objectId = objectId.asBaseId();
             nodeUri = objectId.getBaseId();
         } else {
             nodeUri = objectId.getFullId();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -286,6 +286,19 @@ public class MembershipServiceImpl implements MembershipService {
     }
 
     @Override
+    public RdfStream getMembershipByObject(final Transaction tx, final FedoraId fedoraId) {
+        final FedoraId objectId;
+        if (fedoraId.isDescription()) {
+            objectId = fedoraId.asBaseId();
+        } else {
+            objectId = fedoraId;
+        }
+        final var subject = NodeFactory.createURI(objectId.getBaseId());
+        final var membershipStream = indexManager.getMembershipByObject(tx, objectId);
+        return new DefaultRdfStream(subject, membershipStream);
+    }
+
+    @Override
     public void commitTransaction(final Transaction tx) {
         indexManager.commitTransaction(tx);
     }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -81,6 +81,7 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
         // Include inbound references to this object, NOT returned by default.
         if (preferences.displayReferences()) {
             streams.add(referenceService.getInboundReferences(tx, resource));
+            streams.add(membershipService.getMembershipByObject(tx, resource.getFedoraId()));
         }
 
         return streams.stream().reduce(empty(), Stream::concat);

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -82,6 +82,7 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
         if (preferences.displayReferences()) {
             streams.add(referenceService.getInboundReferences(tx, resource));
             streams.add(membershipService.getMembershipByObject(tx, resource.getFedoraId()));
+            streams.add(containmentTriplesService.getContainedBy(tx, resource));
         }
 
         return streams.stream().reduce(empty(), Stream::concat);

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -779,7 +779,7 @@ public class ContainmentIndexImplTest {
         when(child1.getFedoraId()).thenReturn(descriptionId1);
 
         containmentIndex.addContainedBy(shortLivedTx, parent1.getFedoraId(), binaryId1);
-        assertEquals(parent1.getFedoraId().getFullId(), containmentIndex.getContainedBy(shortLivedTx, descriptionId1));
+        assertNull(containmentIndex.getContainedBy(shortLivedTx, descriptionId1));
     }
 }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/ContainmentIndexImplTest.java
@@ -769,6 +769,18 @@ public class ContainmentIndexImplTest {
         // outside of the transaction, it still shouldn't show up
         assertEquals(0, containmentIndex.getContains(shortLivedTx, parent1.getFedoraId()).count());
     }
+
+    @Test
+    public void testGetContainedByBinaryDescription() {
+        stubObject("parent1");
+        stubObject("child1");
+        final var binaryId1 = child1.getFedoraId();
+        final var descriptionId1 = child1.getFedoraId().asDescription();
+        when(child1.getFedoraId()).thenReturn(descriptionId1);
+
+        containmentIndex.addContainedBy(shortLivedTx, parent1.getFedoraId(), binaryId1);
+        assertEquals(parent1.getFedoraId().getFullId(), containmentIndex.getContainedBy(shortLivedTx, descriptionId1));
+    }
 }
 
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ContainmentTriplesServiceImplTest.java
@@ -152,7 +152,7 @@ public class ContainmentTriplesServiceImplTest {
     }
 
     @Test
-    public void testGetContainedBasicContainer() {
+    public void testGetContainedByBasicContainer() {
         final FedoraId childId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraResource childResource = mock(FedoraResource.class);
         when(childResource.getFedoraId()).thenReturn(childId);
@@ -166,17 +166,17 @@ public class ContainmentTriplesServiceImplTest {
     }
 
     @Test
-    public void testGetContainedNoParent() {
+    public void testGetContainedByNoParent() {
         assertEquals(0, containmentTriplesService.getContainedBy(transaction, parentResource).count());
     }
 
     @Test
-    public void testGetContainedBasicContainerMemento() {
+    public void testGetContainedByBasicContainerMemento() {
         final FedoraId childId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId childMementoId = childId.asMemento(Instant.now());
         final FedoraResource mementoResc = mock(FedoraResource.class);
         when(mementoResc.getFedoraId()).thenReturn(childMementoId);
-        containmentIndex.addContainedBy(transaction, parentResource.getFedoraId(), childMementoId);
+        containmentIndex.addContainedBy(transaction, parentResource.getFedoraId(), childId);
         assertEquals(1, containmentTriplesService.getContainedBy(transaction, mementoResc).count());
         final Model expectedModel = ModelFactory.createDefaultModel();
         expectedModel.add(createResource(parentResource.getFedoraId().getFullId()), CONTAINS,
@@ -186,7 +186,7 @@ public class ContainmentTriplesServiceImplTest {
     }
 
     @Test
-    public void testGetContainedBinaryDescription() {
+    public void testGetContainedByBinaryDescription() {
         final FedoraId childId = FedoraId.create(UUID.randomUUID().toString());
         final FedoraId descriptionId = childId.asDescription();
         final FedoraResource descriptionResc = mock(FedoraResource.class);
@@ -198,6 +198,29 @@ public class ContainmentTriplesServiceImplTest {
                 createResource(childId.getFullId()));
         final Model received = containmentTriplesService.getContainedBy(transaction, descriptionResc)
                 .collect(toModel());
+        matchModels(expectedModel, received);
+    }
+
+    @Test
+    public void testGetContainedByBinaryDescriptionMemento() {
+        final var now = Instant.now();
+        final FedoraId childId = FedoraId.create(UUID.randomUUID().toString());
+        final FedoraId childMementoId = childId.asMemento(now);
+        final FedoraResource mementoResc = mock(FedoraResource.class);
+        when(mementoResc.getFedoraId()).thenReturn(childMementoId);
+
+        final FedoraId descriptionId = childId.asDescription();
+        final FedoraId descriptionMementoId = descriptionId.asMemento(Instant.now());
+        final FedoraResource mementoDescResc = mock(FedoraResource.class);
+        when(mementoDescResc.getFedoraId()).thenReturn(descriptionMementoId);
+
+        containmentIndex.addContainedBy(transaction, parentResource.getFedoraId(), childId);
+
+        assertEquals(1, containmentTriplesService.getContainedBy(transaction, mementoDescResc).count());
+        final var expectedModel = ModelFactory.createDefaultModel();
+        expectedModel.add(createResource(parentResource.getFedoraId().getFullId()), CONTAINS,
+                createResource(childId.getFullId()));
+        final var received = containmentTriplesService.getContainedBy(transaction, mementoDescResc).collect(toModel());
         matchModels(expectedModel, received);
     }
 

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/MembershipServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/MembershipServiceImplTest.java
@@ -6,6 +6,7 @@
 package org.fcrepo.kernel.impl.services;
 
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.vocabulary.VOID.property;
 import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
 import static org.fcrepo.kernel.api.rdf.DefaultRdfStream.fromModel;
 import static org.junit.Assert.assertEquals;
@@ -652,6 +653,14 @@ public class MembershipServiceImplTest {
 
         assertCommittedMembershipCount(membershipRescId, 0);
         assertUncommittedMembershipCount(transaction, membershipRescId, 3);
+
+        // Asserting membership can be found from the perspective of each member
+        assertCommittedMembershipByObjectCount(outerMemberId, 0);
+        assertUncommittedMembershipByObjectCount(transaction, outerMemberId, 1);
+        assertCommittedMembershipByObjectCount(nestedDcId, 0);
+        assertUncommittedMembershipByObjectCount(transaction, nestedDcId, 1);
+        assertCommittedMembershipByObjectCount(nestedMemberId, 0);
+        assertUncommittedMembershipByObjectCount(transaction, nestedMemberId, 1);
 
         membershipService.commitTransaction(transaction);
 
@@ -1451,6 +1460,46 @@ public class MembershipServiceImplTest {
         assertHasMembersNoTx(membershipRescId, OTHER_HAS_MEMBER, member1Id);
     }
 
+
+    @Test
+    public void getMembership_MemberProxiedInMultipleIDCs() throws Exception {
+        mockGetHeaders(populateHeaders(membershipRescId, BASIC_CONTAINER));
+        membershipService.resourceCreated(transaction, membershipRescId);
+
+        // Create the target which will be member of two IDCs
+        final var member1Id = createDCMember(rootId, BASIC_CONTAINER);
+
+        // Create first IDC
+        final var idcId = createIndirectContainer(membershipRescId, RdfLexicon.LDP_MEMBER, false);
+        membershipService.resourceCreated(transaction, idcId);
+
+        createProxy(idcId, member1Id, CREATED_DATE, true);
+
+        assertUncommittedMembershipCount(transaction, membershipRescId, 1);
+        assertCommittedMembershipCount(membershipRescId, 0);
+        membershipService.commitTransaction(transaction);
+        assertCommittedMembershipCount(membershipRescId, 1);
+
+        final var idcId2 = createIndirectContainer(membershipRescId, OTHER_HAS_MEMBER, false);
+        membershipService.resourceCreated(transaction, idcId2);
+
+        createProxy(idcId2, member1Id, CREATED_DATE, true);
+
+        assertUncommittedMembershipCount(transaction, membershipRescId, 2);
+        assertCommittedMembershipCount(membershipRescId, 1);
+        membershipService.commitTransaction(transaction);
+        assertCommittedMembershipCount(membershipRescId, 2);
+
+        // Two relations to the same member. They have different properties, but we aren't checking that here
+        assertHasMembersNoTx(membershipRescId, null, member1Id, member1Id);
+
+        // Verify that membership from the objects perspective returns relations from both IDCs
+        final var membershipByObjectList = getMembershipListByObject(transaction, member1Id);
+        assertEquals(2, membershipByObjectList.size());
+        assertContainsMembership(membershipByObjectList, membershipRescId, RdfLexicon.LDP_MEMBER, member1Id);
+        assertContainsMembership(membershipByObjectList, membershipRescId, OTHER_HAS_MEMBER, member1Id);
+    }
+
     private void mockListVersion(final FedoraId fedoraId, final Instant... versions) {
         when(psSession.listVersions(fedoraId.asResourceId())).thenReturn(Arrays.asList(versions));
     }
@@ -1467,6 +1516,14 @@ public class MembershipServiceImplTest {
         final var subjectId = membershipRescId.asBaseId();
         for (final FedoraId memberId : memberIds) {
             assertContainsMembership(membershipList, subjectId, hasMemberRelation, memberId);
+            final FedoraId memberIdMemento;
+            if (membershipRescId.isMemento()) {
+                memberIdMemento = memberId.asMemento(membershipRescId.getMementoInstant());
+            } else {
+                memberIdMemento = memberId;
+            }
+            final var membershipByObjectList = getMembershipListByObject(transaction, memberIdMemento);
+            assertContainsMembership(membershipByObjectList, subjectId, hasMemberRelation, memberId);
         }
     }
 
@@ -1484,6 +1541,11 @@ public class MembershipServiceImplTest {
 
     private List<Triple> getMembershipList(final Transaction transaction, final FedoraId fedoraId) {
         final var results = membershipService.getMembership(transaction, fedoraId);
+        return results.collect(Collectors.toList());
+    }
+
+    private List<Triple> getMembershipListByObject(final Transaction transaction, final FedoraId objectId) {
+        final var results = membershipService.getMembershipByObject(transaction, objectId);
         return results.collect(Collectors.toList());
     }
 
@@ -1656,9 +1718,9 @@ public class MembershipServiceImplTest {
         final var subjectNode = NodeFactory.createURI(subjectId.getFullId());
         final var objectNode = NodeFactory.createURI(objectId.getFullId());
 
-        assertTrue("Membership set did not contain: " + subjectId + " " + property.getURI() + " " + objectId,
+        assertTrue("Membership set did not contain: " + subjectId + " " + property + " " + objectId,
                 membershipList.stream().anyMatch(t -> t.getSubject().equals(subjectNode)
-                        && t.getPredicate().equals(property.asNode())
+                        && (property == null || t.getPredicate().equals(property.asNode()))
                         && t.getObject().equals(objectNode)));
     }
 
@@ -1668,11 +1730,25 @@ public class MembershipServiceImplTest {
                 expected, results.count());
     }
 
+    private void assertCommittedMembershipByObjectCount(final FedoraId objectId, final int expected) {
+        final var results = membershipService.getMembershipByObject(shortLivedTx, objectId);
+        assertEquals("Incorrect number of committed membership properties for object " + objectId,
+                expected, results.count());
+    }
+
     private void assertUncommittedMembershipCount(final Transaction transaction,
                                                   final FedoraId subjectId,
                                                   final int expected) {
         final var results = membershipService.getMembership(transaction, subjectId);
         assertEquals("Incorrect number of uncommitted membership properties for " + subjectId,
+                expected, results.count());
+    }
+
+    private void assertUncommittedMembershipByObjectCount(final Transaction transaction,
+                                                  final FedoraId objectId,
+                                                  final int expected) {
+        final var results = membershipService.getMembershipByObject(transaction, objectId);
+        assertEquals("Incorrect number of uncommitted membership properties for object " + objectId,
                 expected, results.count());
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3589

# What does this Pull Request do?
Restores inclusion of membership relations in GET responses when preferring inbound references. This was present in fedora 4 and 5.

When requesting inbound references, the `ldp:contains` relation from the parent to the child will now appear. I believe this is a new behavior, but it seems consistent and there was consensus for it on the ticket.

I also expanded the existing integration test for verifying this behavior to also demonstrate it works with resources that are contained by multiple indirect containers. Added a test to verify the behavior for direct containers, and did a little DRYing up related to indirect containers.

# How should this be tested?
Test the following against main and then this branch:

Steps to setup a direct container
```
curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/membership_resc

curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/direct_container -H'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"'

echo "
<> <http://www.w3.org/ns/ldp#membershipResource> <http://localhost:8080/rest/membership_resc> .
<> <http://www.w3.org/ns/ldp#hasMemberRelation> <http://example.com/hasMember> .
" |
curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/direct_container -H'Link: <http://www.w3.org/ns/ldp#DirectContainer>;rel="type"' -H"Content-Type: text/turtle" --data-binary "@-"


curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/direct_container/member1

# Request to get the member without inbound, should be no membership
curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/direct_container/member1

# Request to get the member with inbound, should include the hasMember relation
curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/direct_container/member1 -H "Prefer: return=representation; include=\"http://fedora.info/definitions/fcrepo#PreferInboundReferences\""
```

Steps to setup an indirect container with a proxy pointing at the same membership resource and member as was used by the direct container:
```
echo "
<> <http://www.w3.org/ns/ldp#membershipResource> <http://localhost:8080/rest/membership_resc>;
   <http://www.w3.org/ns/ldp#hasMemberRelation> <http://example.com/hasIndirectMember>;
   <http://www.w3.org/ns/ldp#insertedContentRelation> <http://example.com/proxyFor>
" |
curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/indirect_container -H'Link: <http://www.w3.org/ns/ldp#IndirectContainer>;rel="type"' -H"Content-Type: text/turtle" --data-binary "@-"


echo "
<> <http://example.com/proxyFor> <http://localhost:8080/rest/direct_container/member1>" |
curl -ufedoraAdmin:fedoraAdmin -XPUT http://localhost:8080/rest/indirect_container/proxy1 -H"Content-Type: text/turtle" --data-binary "@-"


# Request to get the member without inbound, should be no membership
curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/direct_container/member1

# Request to get the member with inbound, should include the hasMember and hasIndirectMember relations
curl -ufedoraAdmin:fedoraAdmin http://localhost:8080/rest/direct_container/member1 -H "Prefer: return=representation; include=\"http://fedora.info/definitions/fcrepo#PreferInboundReferences\""
```

At the end, on this branch you should see membership and contains relations that do not appear on main:
```
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
@prefix ldp: <http://www.w3.org/ns/ldp#> .

<http://localhost:8080/rest/direct_container/member1>
        fedora:created         "2025-01-02T20:23:12.991190Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:lastModified    "2025-01-02T20:23:12.991190Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
        fedora:createdBy       "fedoraAdmin" ;
        fedora:lastModifiedBy  "fedoraAdmin" ;
        rdf:type               ldp:BasicContainer ;
        rdf:type               ldp:Resource ;
        rdf:type               fedora:Resource ;
        rdf:type               ldp:RDFSource ;
        rdf:type               ldp:Container ;
        rdf:type               fedora:Container .

<http://localhost:8080/rest/indirect_container/proxy1>
        <http://example.com/proxyFor>  <http://localhost:8080/rest/direct_container/member1> .

<http://localhost:8080/rest/membership_resc>
        <http://example.com/hasIndirectMember>  <http://localhost:8080/rest/direct_container/member1> ;
        <http://example.com/hasMember>  <http://localhost:8080/rest/direct_container/member1> .

<http://localhost:8080/rest/direct_container>
        ldp:contains  <http://localhost:8080/rest/direct_container/member1> .
```


# Interested parties
@fcrepo/committers
