### PR TITLE
FCREPO-3967 - Minimal codecov and jacoco setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ name: Build
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         java: ['11']
         experimental: [false]
         # JDK 17  build testing. Allowed to fail as marked experimental
-        include:
-          - java: 17
-            os: ubuntu-latest
-            experimental: true
+#        include:
+#          - java: 17
+#            os: ubuntu-latest
+#            experimental: true
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true
@@ -45,7 +45,7 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
       with:
-        verbose: true
+        dry_run: true
 #  postgres-itest:
 #    runs-on: ubuntu-latest
 #    strategy:
@@ -83,6 +83,8 @@ jobs:
 #      uses: codecov/codecov-action@v5
 #      env:
 #        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+#      with:
+#        verbose: true
 #  mariadb-itest:
 #    runs-on: ubuntu-latest
 #    strategy:
@@ -159,43 +161,43 @@ jobs:
 #      uses: codecov/codecov-action@v5
 #      env:
 #        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: [build, postgres-itest, mariadb-itest, mysql-itest]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git support longpaths
-        run: git config --global core.longpaths true
-      - name: Checkout fcrepo
-        uses: actions/checkout@v4
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 11
-          server-id: sonatype-nexus-snapshots
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          # https://github.com/actions/setup-java/issues/43
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
-      - name: Publish package
-        run: mvn -U -B -DskipTests=true deploy
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Checkout fcrepo-docker
-        uses: actions/checkout@v4
-        with:
-          repository: fcrepo-exts/fcrepo-docker
-          path: fcrepo-docker
-      - name: Deploy Docker image
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: |
-          FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
-          cd fcrepo-docker
-          echo "build and push image to dockerhub"
-          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}
+#  deploy:
+#    if: github.ref == 'refs/heads/main'
+#    needs: [build, postgres-itest, mariadb-itest, mysql-itest]
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Git support longpaths
+#        run: git config --global core.longpaths true
+#      - name: Checkout fcrepo
+#        uses: actions/checkout@v4
+#      - name: Set up JDK 11
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: 'temurin'
+#          java-version: 11
+#          server-id: sonatype-nexus-snapshots
+#          server-username: MAVEN_USERNAME
+#          server-password: MAVEN_PASSWORD
+#          # https://github.com/actions/setup-java/issues/43
+#          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+#          gpg-passphrase: GPG_PASSPHRASE
+#      - name: Publish package
+#        run: mvn -U -B -DskipTests=true deploy
+#        env:
+#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+#          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+#      - name: Checkout fcrepo-docker
+#        uses: actions/checkout@v4
+#        with:
+#          repository: fcrepo-exts/fcrepo-docker
+#          path: fcrepo-docker
+#      - name: Deploy Docker image
+#        env:
+#          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#        run: |
+#          FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+#          cd fcrepo-docker
+#          echo "build and push image to dockerhub"
+#          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U clean install
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
   postgres-itest:
     runs-on: ubuntu-latest
     strategy:
@@ -72,6 +76,10 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U -Dfcrepo.db.url="jdbc:postgresql://localhost:5432/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
   mariadb-itest:
     runs-on: ubuntu-latest
     strategy:
@@ -106,6 +114,10 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U -Dfcrepo.db.url="jdbc:mariadb://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
   mysql-itest:
     runs-on: ubuntu-latest
     strategy:
@@ -140,6 +152,10 @@ jobs:
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -U -Dfcrepo.db.url="jdbc:mysql://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [build, postgres-itest, mariadb-itest, mysql-itest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,10 @@ name: Build
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
 jobs:
   build:
@@ -43,119 +44,121 @@ jobs:
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-  postgres-itest:
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        java: ['11']
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: fcrepo-user
-          POSTGRES_PASSWORD: fcrepo-pw
-          POSTGRES_DB: fcrepo
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    steps:
-    - name: Git support longpaths
-      run: git config --global core.longpaths true
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
       with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B -U -Dfcrepo.db.url="jdbc:postgresql://localhost:5432/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-  mariadb-itest:
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        java: ['11']
-    services:
-      postgres:
-        image: mariadb:10.5
-        env:
-          MYSQL_ROOT_PASSWORD: root-pw
-          MYSQL_DATABASE: fcrepo
-          MYSQL_USER: fcrepo-user
-          MYSQL_PASSWORD: fcrepo-pw
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-        ports:
-          - 3306:3306
-    steps:
-    - name: Git support longpaths
-      run: git config --global core.longpaths true
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B -U -Dfcrepo.db.url="jdbc:mariadb://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-  mysql-itest:
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        java: ['11']
-    services:
-      postgres:
-        image: mysql:8
-        env:
-          MYSQL_ROOT_PASSWORD: root-pw
-          MYSQL_DATABASE: fcrepo
-          MYSQL_USER: fcrepo-user
-          MYSQL_PASSWORD: fcrepo-pw
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-        ports:
-          - 3306:3306
-    steps:
-    - name: Git support longpaths
-      run: git config --global core.longpaths true
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: ${{ matrix.java }}
-        cache: 'maven'
-    - name: Build with Maven
-      run: mvn -B -U -Dfcrepo.db.url="jdbc:mysql://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+        verbose: true
+#  postgres-itest:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      max-parallel: 1
+#      matrix:
+#        java: ['11']
+#    services:
+#      postgres:
+#        image: postgres:12
+#        env:
+#          POSTGRES_USER: fcrepo-user
+#          POSTGRES_PASSWORD: fcrepo-pw
+#          POSTGRES_DB: fcrepo
+#        options: >-
+#          --health-cmd pg_isready
+#          --health-interval 10s
+#          --health-timeout 5s
+#          --health-retries 5
+#        ports:
+#          - 5432:5432
+#    steps:
+#    - name: Git support longpaths
+#      run: git config --global core.longpaths true
+#    - name: Checkout
+#      uses: actions/checkout@v4
+#    - name: Set up JDK ${{ matrix.java }}
+#      uses: actions/setup-java@v4
+#      with:
+#        distribution: 'temurin'
+#        java-version: ${{ matrix.java }}
+#        cache: 'maven'
+#    - name: Build with Maven
+#      run: mvn -B -U -Dfcrepo.db.url="jdbc:postgresql://localhost:5432/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@v5
+#      env:
+#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+#  mariadb-itest:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      max-parallel: 1
+#      matrix:
+#        java: ['11']
+#    services:
+#      postgres:
+#        image: mariadb:10.5
+#        env:
+#          MYSQL_ROOT_PASSWORD: root-pw
+#          MYSQL_DATABASE: fcrepo
+#          MYSQL_USER: fcrepo-user
+#          MYSQL_PASSWORD: fcrepo-pw
+#        options: >-
+#          --health-cmd="mysqladmin ping"
+#          --health-interval=10s
+#          --health-timeout=5s
+#          --health-retries=5
+#        ports:
+#          - 3306:3306
+#    steps:
+#    - name: Git support longpaths
+#      run: git config --global core.longpaths true
+#    - name: Checkout
+#      uses: actions/checkout@v4
+#    - name: Set up JDK ${{ matrix.java }}
+#      uses: actions/setup-java@v4
+#      with:
+#        distribution: 'temurin'
+#        java-version: ${{ matrix.java }}
+#        cache: 'maven'
+#    - name: Build with Maven
+#      run: mvn -B -U -Dfcrepo.db.url="jdbc:mariadb://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@v5
+#      env:
+#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+#  mysql-itest:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      max-parallel: 1
+#      matrix:
+#        java: ['11']
+#    services:
+#      postgres:
+#        image: mysql:8
+#        env:
+#          MYSQL_ROOT_PASSWORD: root-pw
+#          MYSQL_DATABASE: fcrepo
+#          MYSQL_USER: fcrepo-user
+#          MYSQL_PASSWORD: fcrepo-pw
+#        options: >-
+#          --health-cmd="mysqladmin ping"
+#          --health-interval=10s
+#          --health-timeout=5s
+#          --health-retries=5
+#        ports:
+#          - 3306:3306
+#    steps:
+#    - name: Git support longpaths
+#      run: git config --global core.longpaths true
+#    - name: Checkout
+#      uses: actions/checkout@v4
+#    - name: Set up JDK ${{ matrix.java }}
+#      uses: actions/setup-java@v4
+#      with:
+#        distribution: 'temurin'
+#        java-version: ${{ matrix.java }}
+#        cache: 'maven'
+#    - name: Build with Maven
+#      run: mvn -B -U -Dfcrepo.db.url="jdbc:mysql://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+#    - name: Upload coverage to Codecov
+#      uses: codecov/codecov-action@v5
+#      env:
+#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [build, postgres-itest, mariadb-itest, mysql-itest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         java: ['11']
         experimental: [false]
         # JDK 17  build testing. Allowed to fail as marked experimental
-#        include:
-#          - java: 17
-#            os: ubuntu-latest
-#            experimental: true
+        include:
+          - java: 17
+            os: ubuntu-latest
+            experimental: true
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true
@@ -44,160 +44,156 @@ jobs:
       uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+  postgres-itest:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        java: ['11']
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: fcrepo-user
+          POSTGRES_PASSWORD: fcrepo-pw
+          POSTGRES_DB: fcrepo
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+    - name: Git support longpaths
+      run: git config --global core.longpaths true
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
       with:
-        dry_run: true
-#  postgres-itest:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      max-parallel: 1
-#      matrix:
-#        java: ['11']
-#    services:
-#      postgres:
-#        image: postgres:12
-#        env:
-#          POSTGRES_USER: fcrepo-user
-#          POSTGRES_PASSWORD: fcrepo-pw
-#          POSTGRES_DB: fcrepo
-#        options: >-
-#          --health-cmd pg_isready
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
-#        ports:
-#          - 5432:5432
-#    steps:
-#    - name: Git support longpaths
-#      run: git config --global core.longpaths true
-#    - name: Checkout
-#      uses: actions/checkout@v4
-#    - name: Set up JDK ${{ matrix.java }}
-#      uses: actions/setup-java@v4
-#      with:
-#        distribution: 'temurin'
-#        java-version: ${{ matrix.java }}
-#        cache: 'maven'
-#    - name: Build with Maven
-#      run: mvn -B -U -Dfcrepo.db.url="jdbc:postgresql://localhost:5432/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-#    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v5
-#      env:
-#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-#      with:
-#        verbose: true
-#  mariadb-itest:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      max-parallel: 1
-#      matrix:
-#        java: ['11']
-#    services:
-#      postgres:
-#        image: mariadb:10.5
-#        env:
-#          MYSQL_ROOT_PASSWORD: root-pw
-#          MYSQL_DATABASE: fcrepo
-#          MYSQL_USER: fcrepo-user
-#          MYSQL_PASSWORD: fcrepo-pw
-#        options: >-
-#          --health-cmd="mysqladmin ping"
-#          --health-interval=10s
-#          --health-timeout=5s
-#          --health-retries=5
-#        ports:
-#          - 3306:3306
-#    steps:
-#    - name: Git support longpaths
-#      run: git config --global core.longpaths true
-#    - name: Checkout
-#      uses: actions/checkout@v4
-#    - name: Set up JDK ${{ matrix.java }}
-#      uses: actions/setup-java@v4
-#      with:
-#        distribution: 'temurin'
-#        java-version: ${{ matrix.java }}
-#        cache: 'maven'
-#    - name: Build with Maven
-#      run: mvn -B -U -Dfcrepo.db.url="jdbc:mariadb://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-#    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v5
-#      env:
-#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-#  mysql-itest:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      max-parallel: 1
-#      matrix:
-#        java: ['11']
-#    services:
-#      postgres:
-#        image: mysql:8
-#        env:
-#          MYSQL_ROOT_PASSWORD: root-pw
-#          MYSQL_DATABASE: fcrepo
-#          MYSQL_USER: fcrepo-user
-#          MYSQL_PASSWORD: fcrepo-pw
-#        options: >-
-#          --health-cmd="mysqladmin ping"
-#          --health-interval=10s
-#          --health-timeout=5s
-#          --health-retries=5
-#        ports:
-#          - 3306:3306
-#    steps:
-#    - name: Git support longpaths
-#      run: git config --global core.longpaths true
-#    - name: Checkout
-#      uses: actions/checkout@v4
-#    - name: Set up JDK ${{ matrix.java }}
-#      uses: actions/setup-java@v4
-#      with:
-#        distribution: 'temurin'
-#        java-version: ${{ matrix.java }}
-#        cache: 'maven'
-#    - name: Build with Maven
-#      run: mvn -B -U -Dfcrepo.db.url="jdbc:mysql://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
-#    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v5
-#      env:
-#        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
-#  deploy:
-#    if: github.ref == 'refs/heads/main'
-#    needs: [build, postgres-itest, mariadb-itest, mysql-itest]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Git support longpaths
-#        run: git config --global core.longpaths true
-#      - name: Checkout fcrepo
-#        uses: actions/checkout@v4
-#      - name: Set up JDK 11
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: 'temurin'
-#          java-version: 11
-#          server-id: sonatype-nexus-snapshots
-#          server-username: MAVEN_USERNAME
-#          server-password: MAVEN_PASSWORD
-#          # https://github.com/actions/setup-java/issues/43
-#          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          gpg-passphrase: GPG_PASSPHRASE
-#      - name: Publish package
-#        run: mvn -U -B -DskipTests=true deploy
-#        env:
-#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-#          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-#      - name: Checkout fcrepo-docker
-#        uses: actions/checkout@v4
-#        with:
-#          repository: fcrepo-exts/fcrepo-docker
-#          path: fcrepo-docker
-#      - name: Deploy Docker image
-#        env:
-#          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-#          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-#        run: |
-#          FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
-#          cd fcrepo-docker
-#          echo "build and push image to dockerhub"
-#          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B -U -Dfcrepo.db.url="jdbc:postgresql://localhost:5432/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+  mariadb-itest:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        java: ['11']
+    services:
+      postgres:
+        image: mariadb:10.5
+        env:
+          MYSQL_ROOT_PASSWORD: root-pw
+          MYSQL_DATABASE: fcrepo
+          MYSQL_USER: fcrepo-user
+          MYSQL_PASSWORD: fcrepo-pw
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 3306:3306
+    steps:
+    - name: Git support longpaths
+      run: git config --global core.longpaths true
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B -U -Dfcrepo.db.url="jdbc:mariadb://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+  mysql-itest:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        java: ['11']
+    services:
+      postgres:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root-pw
+          MYSQL_DATABASE: fcrepo
+          MYSQL_USER: fcrepo-user
+          MYSQL_PASSWORD: fcrepo-pw
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 3306:3306
+    steps:
+    - name: Git support longpaths
+      run: git config --global core.longpaths true
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B -U -Dfcrepo.db.url="jdbc:mysql://localhost:3306/fcrepo" -Dfcrepo.db.user="fcrepo-user" -Dfcrepo.db.password="fcrepo-pw" clean install -P db-test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: [build, postgres-itest, mariadb-itest, mysql-itest]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git support longpaths
+        run: git config --global core.longpaths true
+      - name: Checkout fcrepo
+        uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          server-id: sonatype-nexus-snapshots
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          # https://github.com/actions/setup-java/issues/43
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+      - name: Publish package
+        run: mvn -U -B -DskipTests=true deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Checkout fcrepo-docker
+        uses: actions/checkout@v4
+        with:
+          repository: fcrepo-exts/fcrepo-docker
+          path: fcrepo-docker
+      - name: Deploy Docker image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          cd fcrepo-docker
+          echo "build and push image to dockerhub"
+          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/fcrepo/fcrepo/workflows/Build/badge.svg)
+![Build](https://github.com/fcrepo/fcrepo/workflows/Build/badge.svg) [![codecov](https://codecov.io/github/fcrepo/fcrepo/graph/badge.svg?token=GcgUWil0ni)](https://codecov.io/github/fcrepo/fcrepo)
 
 [JavaDocs](http://docs.fcrepo.org/) | 
 [Fedora Wiki](https://wiki.lyrasis.org/display/FF) | 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
@@ -17,7 +17,6 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.Link;
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,7 +25,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * @author bbpennel
  */
-@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class ExternalContentHandlerFactoryTest {
 
@@ -44,9 +42,9 @@ public class ExternalContentHandlerFactoryTest {
     @Test
     public void testValidLinkHeader() {
         final ExternalContentHandler handler = factory.createFromLinks(
-                makeLinks("https://fedora.info/"));
+                makeLinks("https://example.com/"));
 
-        assertEquals("https://fedora.info/", handler.getURL());
+        assertEquals("https://example.com/", handler.getURL());
         assertEquals("text/plain", handler.getContentType());
         assertEquals("proxy", handler.getHandling());
     }
@@ -55,12 +53,12 @@ public class ExternalContentHandlerFactoryTest {
     public void testValidationFailure() {
         doThrow(new ExternalMessageBodyException("")).when(validator).validate(anyString());
 
-        factory.createFromLinks(makeLinks("https://fedora.info/"));
+        factory.createFromLinks(makeLinks("https://example.com/"));
     }
 
     @Test(expected = ExternalMessageBodyException.class)
     public void testMultipleExtLinkHeaders() {
-        final List<String> links = makeLinks("https://fedora.info/", "https://fedora.info/");
+        final List<String> links = makeLinks("https://example.com/", "https://example.com/");
 
         factory.createFromLinks(links);
     }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/http/api/ExternalContentHandlerFactoryTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.Link;
 import org.fcrepo.kernel.api.exception.ExternalMessageBodyException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -25,6 +26,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * @author bbpennel
  */
+@Ignore
 @RunWith(MockitoJUnitRunner.class)
 public class ExternalContentHandlerFactoryTest {
 

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -47,7 +47,7 @@
     <github-site.plugin.version>0.12</github-site.plugin.version>
     <gpg.plugin.version>3.0.1</gpg.plugin.version>
     <install.plugin.version>2.5.2</install.plugin.version>
-    <jacoco.plugin.version>0.8.7</jacoco.plugin.version>
+    <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
     <jar.plugin.version>3.2.0</jar.plugin.version>
     <javadoc.plugin.version>3.3.1</javadoc.plugin.version>
     <jxr.plugin.version>3.1.1</jxr.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -826,21 +826,71 @@
         <artifactId>jacoco-maven-plugin</artifactId>
           <executions>
             <execution>
-              <id>prepare-agent</id>
+              <id>default-prepare-agent</id>
               <goals>
                 <goal>prepare-agent</goal>
               </goals>
+              <configuration>
+                <propertyName>jacoco.agent.unit.arg</propertyName>
+                <append>true</append>
+              </configuration>
             </execution>
             <execution>
-              <id>prepare-agent-integration</id>
+              <id>default-prepare-agent-integration</id>
               <goals>
                 <goal>prepare-agent-integration</goal>
               </goals>
               <configuration>
+                <propertyName>jacoco.agent.it.arg</propertyName>
+                <append>true</append>
                 <excludes>
                   <exclude>**/*CSS3ParserTokenManager*</exclude>
                   <exclude>**/*StyleAttributes*</exclude>
                 </excludes>
+              </configuration>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
+                <xml>true</xml>
+                <html>false</html>
+                <csv>false</csv>
+              </configuration>
+            </execution>
+            <execution>
+              <id>merge-coverage</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>merge</goal>
+              </goals>
+              <configuration>
+                <fileSets>
+                  <fileSet>
+                    <directory>${project.build.directory}</directory>
+                    <includes>
+                      <include>jacoco.exec</include>
+                      <include>jacoco-it.exec</include>
+                    </includes>
+                  </fileSet>
+                </fileSets>
+                <destFile>${project.build.directory}/jacoco/jacoco-merged.exec</destFile>
+              </configuration>
+            </execution>
+            <execution>
+              <id>generate-report</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+              <configuration>
+                <dataFile>${project.build.directory}/jacoco/jacoco-merged.exec</dataFile>
+                <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
+                <xml>true</xml>
               </configuration>
             </execution>
           </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -826,43 +826,22 @@
         <artifactId>jacoco-maven-plugin</artifactId>
           <executions>
             <execution>
-              <id>default-prepare-agent</id>
+              <id>prepare-agent</id>
               <goals>
                 <goal>prepare-agent</goal>
               </goals>
-
-              <configuration>
-                <destFile>${sonar.jacoco.reportPath}</destFile>
-                <propertyName>jacoco.agent.unit.arg</propertyName>
-                <append>true</append>
-              </configuration>
             </execution>
             <execution>
-              <id>default-prepare-agent-integration</id>
+              <id>prepare-agent-integration</id>
               <goals>
                 <goal>prepare-agent-integration</goal>
               </goals>
               <configuration>
-                <destFile>${sonar.jacoco.itReportPath}</destFile>
-                <propertyName>jacoco.agent.it.arg</propertyName>
-                <append>true</append>
                 <excludes>
                   <exclude>**/*CSS3ParserTokenManager*</exclude>
                   <exclude>**/*StyleAttributes*</exclude>
                 </excludes>
               </configuration>
-            </execution>
-            <execution>
-              <id>default-report</id>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>default-report-integration</id>
-              <goals>
-                <goal>report-integration</goal>
-              </goals>
             </execution>
           </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -798,7 +798,7 @@
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <argLine>-XX:MaxMetaspaceSize=512m ${jacoco.agent.it.arg}</argLine>
+          <argLine>-XX:MaxMetaspaceSize=512m --add-opens=java.base/java.lang=ALL-UNNAMED ${jacoco.agent.it.arg}</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3967

# What does this Pull Request do?
* Configures CodeCov for fcrepo, so that coverage reports will get uploaded and hopefully displayed in PRs
* Changes a test that referenced fedora.info to point to example.com instead, since the former is moving
* Updates jacoco to the most recent version and adjusts config to work with codecov, and merge unit and IT coverage
* During a PR, only the "pull_request" set of builds will run now. The "push" set of builds will only run after a merge into main. This should significantly reduce the amount of time waiting for a PR to build.
* Adds a codecov badge to the readme

# How should this be tested?

There aren't any functional changes to test. Looking at the results in codecov is about the best we can do

# Interested parties
@fcrepo/committers
