### PR TITLE
Switch fcrepo-kernel-api to Junit5

### DIFF
--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -71,8 +71,8 @@
 
     <!-- test gear -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfCollectorsTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfCollectorsTest.java
@@ -7,7 +7,7 @@ package org.fcrepo.kernel.api;
 
 import static java.util.Arrays.asList;
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -15,7 +15,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author acoburn

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/RdfLexiconTest.java
@@ -9,10 +9,10 @@ import static org.apache.jena.vocabulary.DC_11.title;
 import static org.fcrepo.kernel.api.RdfLexicon.CREATED_BY;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_MESSAGE_DIGEST;
 import static org.fcrepo.kernel.api.RdfLexicon.isManagedPredicate;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>RdfLexiconTest class.</p>

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/identifiers/FedoraIdTest.java
@@ -11,10 +11,11 @@ import static org.fcrepo.kernel.api.FedoraTypes.FCR_TOMBSTONE;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_VERSIONS;
 import static org.fcrepo.kernel.api.FedoraTypes.FEDORA_ID_PREFIX;
 import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_LABEL_FORMATTER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -25,7 +26,7 @@ import org.fcrepo.kernel.api.FedoraTypes;
 import org.fcrepo.kernel.api.exception.InvalidMementoPathException;
 import org.fcrepo.kernel.api.exception.InvalidResourceIdentifierException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author pwinckles
@@ -52,10 +53,10 @@ public class FedoraIdTest {
         assertResource(fedoraID, "NORMAL", testID, testID);
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testEmptyPath() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object//second-object";
-        FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -65,10 +66,10 @@ public class FedoraIdTest {
         assertResource(fedoraID, "ACL", testID, FEDORA_ID_PREFIX + "/first-object");
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testNormalAclException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_ACL + "/garbage";
-        FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -78,10 +79,10 @@ public class FedoraIdTest {
         assertResource(fedoraID, "METADATA", testID, FEDORA_ID_PREFIX + "/first-object");
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testNormalDescriptionException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/test-garbage";
-        FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -102,31 +103,31 @@ public class FedoraIdTest {
         assertEquals(mementoInstant, fedoraID.getMementoInstant());
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testNormalMementoException() throws Exception {
         final String mementoString = "00001221010304";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString;
-        FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testNormalMementoException2() throws Exception {
         final String mementoString = "other-text";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString;
-        FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testMetadataAcl() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL;
-        FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testMetadataAclException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL + "/garbage";
-        FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -168,10 +169,10 @@ public class FedoraIdTest {
     }
 
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testAclWithHashException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_ACL + "/garbage#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -182,19 +183,16 @@ public class FedoraIdTest {
         assertEquals("hashURI", fedoraID.getHashUri());
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testMetadataAclWithHash() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL + "#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
-        assertResource(fedoraID, Arrays.asList("HASH", "METADATA", "ACL"), testID, FEDORA_ID_PREFIX +
-                "/first-object");
-        assertEquals("hashURI", fedoraID.getHashUri());
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testMetadataAclWithHashException() throws Exception {
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_ACL + "/garbage#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidResourceIdentifierException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -218,18 +216,18 @@ public class FedoraIdTest {
         assertEquals(mementoInstant, fedoraID.getMementoInstant());
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testMementoWithHashException() throws Exception {
         final String mementoString = "00001221010304";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString + "#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testMementoWithHashException2() throws Exception {
         final String mementoString = "test-garbage";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_VERSIONS + "/" + mementoString + "#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -255,20 +253,20 @@ public class FedoraIdTest {
         assertEquals(mementoInstant, fedoraID.getMementoInstant());
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testMetadataMementoWithHashException() throws Exception {
         final String mementoString = "00001221010304";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_VERSIONS + "/" +
                 mementoString + "#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
-    @Test(expected = InvalidMementoPathException.class)
+    @Test
     public void testMetadataMementoWithHashException1() throws Exception {
         final String mementoString = "test-garbage";
         final String testID = FEDORA_ID_PREFIX + "/first-object/" + FCR_METADATA + "/" + FCR_VERSIONS + "/" +
                 mementoString + "#hashURI";
-        final FedoraId fedoraID = FedoraId.create(testID);
+        assertThrows(InvalidMementoPathException.class, () -> FedoraId.create(testID));
     }
 
     @Test
@@ -320,21 +318,22 @@ public class FedoraIdTest {
                 fedoraId1.getFullId());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testResolveBlank() {
         final FedoraId fedoraId = FedoraId.create("core-object");
-        fedoraId.resolve(null);
+        assertThrows(IllegalArgumentException.class, () -> fedoraId.resolve(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testResolveEmptyString() {
         final FedoraId fedoraId = FedoraId.create("core-object");
-        fedoraId.resolve("");
+        assertThrows(IllegalArgumentException.class, () -> fedoraId.resolve(""));
     }
 
-    @Test(expected = InvalidResourceIdentifierException.class)
+    @Test
     public void testDoubleAcl() {
-        FedoraId.create("core-object/" + FCR_ACL + "/" + FCR_ACL);
+        assertThrows(InvalidResourceIdentifierException.class,
+                () -> FedoraId.create("core-object/" + FCR_ACL + "/" + FCR_ACL));
     }
 
     @Test

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/observer/EventTypeTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/observer/EventTypeTest.java
@@ -5,9 +5,9 @@
  */
 package org.fcrepo.kernel.api.observer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>EventTypeTest class.</p>

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/rdf/DefaultRdfStreamTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/rdf/DefaultRdfStreamTest.java
@@ -9,14 +9,14 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.of;
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.RdfStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/services/functions/ConfigurableHierarchicalSupplierTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/services/functions/ConfigurableHierarchicalSupplierTest.java
@@ -5,12 +5,10 @@
  */
 package org.fcrepo.kernel.api.services.functions;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.fcrepo.config.FedoraPropsConfig;;
 
 /**
@@ -20,14 +18,13 @@ import org.fcrepo.config.FedoraPropsConfig;;
  *
  * @author rdfloyd
  */
-@RunWith(MockitoJUnitRunner.Silent.class)
 public class ConfigurableHierarchicalSupplierTest {
 
     private final FedoraPropsConfig propsConfig = new FedoraPropsConfig();
 
     private final UniqueValueSupplier defaultPidMinter = new ConfigurableHierarchicalSupplier();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // Need to set the defaults
         propsConfig.setFcrepoPidMinterLength(0);

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/ContentDigestTest.java
@@ -9,11 +9,11 @@ import static java.net.URI.create;
 import static org.fcrepo.config.DigestAlgorithm.SHA1;
 import static org.fcrepo.kernel.api.utils.ContentDigest.asURI;
 import static org.fcrepo.kernel.api.utils.ContentDigest.getAlgorithm;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.fcrepo.config.DigestAlgorithm;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>ContentDigestTest class.</p>
@@ -24,32 +24,32 @@ public class ContentDigestTest {
 
     @Test
     public void testSHA_1() {
-        assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha1:fake"), asURI(SHA1.getAlgorithm(), "fake"));
+        assertEquals(create("urn:sha1:fake"), asURI(SHA1.getAlgorithm(), "fake"),
+                "Failed to produce a proper content digest URI!");
     }
 
     @Test
     public void testSHA1() {
-        assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha1:fake"), asURI("SHA", "fake"));
+        assertEquals(create("urn:sha1:fake"), asURI("SHA", "fake"),
+                "Failed to produce a proper content digest URI!");
     }
 
     @Test
     public void testGetAlgorithm() {
-        assertEquals("Failed to produce a proper digest algorithm!", SHA1.getAlgorithm(),
-                getAlgorithm(asURI(SHA1.getAlgorithm(), "fake")));
+        assertEquals(SHA1.getAlgorithm(), getAlgorithm(asURI(SHA1.getAlgorithm(), "fake")),
+                "Failed to produce a proper digest algorithm!");
     }
 
     @Test
     public void testSHA256() {
-        assertEquals("Failed to produce a proper content digest URI!",
-                create("urn:sha-256:fake"), asURI("SHA-256", "fake"));
+        assertEquals(create("urn:sha-256:fake"), asURI("SHA-256", "fake"),
+                "Failed to produce a proper content digest URI!");
     }
 
     @Test
     public void testMissingAlgorithm() {
-        assertEquals("Failed to produce a proper content digest URI!",
-                create("missing:fake"), asURI("SHA-819", "fake"));
+        assertEquals(create("missing:fake"), asURI("SHA-819", "fake"),
+                "Failed to produce a proper content digest URI!");
     }
 
     @Test

--- a/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/GraphDifferencerTest.java
+++ b/fcrepo-kernel-api/src/test/java/org/fcrepo/kernel/api/utils/GraphDifferencerTest.java
@@ -13,13 +13,13 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.graph.GraphFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.stream.Stream.of;
 import static org.apache.jena.graph.NodeFactory.createLiteral;
 import static org.apache.jena.graph.NodeFactory.createURI;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>DifferencingIteratorTest class.</p>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <awaitility.version>4.1.0</awaitility.version>
     <grizzly.version>2.4.4</grizzly.version>
     <junit.version>4.13.2</junit.version>
+    <junit5.version>5.11.4</junit5.version>
     <system-rules.version>1.19.0</system-rules.version>
     <mockito.version>3.12.4</mockito.version>
     <!-- fcrepo5-specific plugins -->
@@ -611,6 +612,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit5.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3973

# What does this Pull Request do?
Switch from `junit:junit` to `org.jupiter.junit:junit-jupiter` in `fcrepo-kernel-api`

# How should this be tested?

Tests should still run and pass as before

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
