### PR TITLE
FCREPO-3980 - Update tests in fcrepo-auth-common to junit 5

### DIFF
--- a/fcrepo-auth-common/pom.xml
+++ b/fcrepo-auth-common/pom.xml
@@ -69,8 +69,8 @@
 
     <!-- test gear -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   
     <!-- This dependency is for compile-time: it keeps this module independent 
@@ -170,7 +170,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
@@ -6,9 +6,9 @@
 package org.fcrepo.auth.common;
 
 import static com.google.common.collect.Sets.newHashSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,8 +19,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -36,13 +37,20 @@ public class ContainerRolesPrincipalProviderTest {
 
     private ContainerRolesPrincipalProvider provider;
 
+    private AutoCloseable closeable;
+
     /**
      * Sets up ContainerRolesPrincipalProviderTest's tests.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         provider = new ContainerRolesPrincipalProvider();
+    }
+
+    @AfterEach
+    public void close() throws Exception {
+        closeable.close();
     }
 
     /**
@@ -56,7 +64,7 @@ public class ContainerRolesPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(1, principals.size());
-        assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
+        assertTrue(principals.contains(new ContainerRolesPrincipal("a")), "The principals should contain 'a'");
     }
 
     /**
@@ -71,8 +79,8 @@ public class ContainerRolesPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
-        assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
-        assertTrue("The principals should contain 'b'", principals.contains(new ContainerRolesPrincipal("b")));
+        assertTrue(principals.contains(new ContainerRolesPrincipal("a")), "The principals should contain 'a'");
+        assertTrue(principals.contains(new ContainerRolesPrincipal("b")), "The principals should contain 'b'");
     }
 
     /**
@@ -87,8 +95,8 @@ public class ContainerRolesPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
-        assertTrue("The principals should contain 'a'", principals.contains(new ContainerRolesPrincipal("a")));
-        assertTrue("The principals should contain 'b'", principals.contains(new ContainerRolesPrincipal("b")));
+        assertTrue(principals.contains(new ContainerRolesPrincipal("a")), "The principals should contain 'a'");
+        assertTrue(principals.contains(new ContainerRolesPrincipal("b")), "The principals should contain 'b'");
     }
 
     /**
@@ -97,7 +105,7 @@ public class ContainerRolesPrincipalProviderTest {
     @Test
     public void testNoConfigedRoleNames() {
         final Set<Principal> principals = provider.getPrincipals(request);
-        assertTrue("Empty set expected when no role names configured", principals.isEmpty());
+        assertTrue(principals.isEmpty(), "Empty set expected when no role names configured");
     }
 
     /**
@@ -108,7 +116,7 @@ public class ContainerRolesPrincipalProviderTest {
         provider.setRoleNames(newHashSet("a"));
 
         final Set<Principal> principals = provider.getPrincipals(null);
-        assertTrue("Empty set expected when no request supplied", principals.isEmpty());
+        assertTrue(principals.isEmpty(), "Empty set expected when no request supplied");
 
     }
 
@@ -123,7 +131,7 @@ public class ContainerRolesPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
         final Principal principal = principals.iterator().next();
 
-        assertNotEquals("Principals should not be equal if not the same class", principal, mock(Principal.class));
+        assertNotEquals(principal, mock(Principal.class), "Principals should not be equal if not the same class");
     }
 
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ContainerRolesPrincipalProviderTest.java
@@ -7,7 +7,7 @@ package org.fcrepo.auth.common;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -130,8 +130,12 @@ public class ContainerRolesPrincipalProviderTest {
 
         final Set<Principal> principals = provider.getPrincipals(request);
         final Principal principal = principals.iterator().next();
+        final Principal principalWithDifferentClass = mock(Principal.class);
+        when(principalWithDifferentClass.getName()).thenReturn("a");
 
-        assertNotEquals(principal, mock(Principal.class), "Principals should not be equal if not the same class");
+        // This test is verifying that the .equals method rejects any principal class other than HttpHeaderPrincipal
+        assertFalse(principal.equals(principalWithDifferentClass),
+                "Principals should not be equal if not the same class");
     }
 
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/DelegateHeaderPrincipalProviderTest.java
@@ -5,24 +5,24 @@
  */
 package org.fcrepo.auth.common;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.http.HttpServletRequest;
 
 import static org.fcrepo.auth.common.DelegateHeaderPrincipalProvider.DELEGATE_HEADER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 /**
  * @author awoods
  * @since 10/31/15
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DelegateHeaderPrincipalProviderTest {
 
     private final DelegateHeaderPrincipalProvider provider = new DelegateHeaderPrincipalProvider();
@@ -33,14 +33,14 @@ public class DelegateHeaderPrincipalProviderTest {
     @Test
     public void testGetDelegate0() {
         when(request.getHeader(DELEGATE_HEADER)).thenReturn(null);
-        assertNull("No delegates should return null", provider.getDelegate(request));
+        assertNull(provider.getDelegate(request), "No delegates should return null");
     }
 
     @Test
     public void testGetDelegate1() {
         final String user = "user1";
         when(request.getHeader(DELEGATE_HEADER)).thenReturn(user);
-        assertNotNull("Should be a delegate!", provider.getDelegate(request));
+        assertNotNull(provider.getDelegate(request), "Should be a delegate!");
         assertEquals(user, provider.getDelegate(request).getName());
     }
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
@@ -5,9 +5,9 @@
  */
 package org.fcrepo.auth.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,8 +18,9 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.fcrepo.auth.common.HttpHeaderPrincipalProvider.HttpHeaderPrincipal;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -35,11 +36,18 @@ public class HttpHeaderPrincipalProviderTest {
 
     private HttpHeaderPrincipalProvider provider;
 
-    @Before
+    private AutoCloseable closeable;
+
+    @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         provider = new HttpHeaderPrincipalProvider();
+    }
+
+    @AfterEach
+    public void close() throws Exception {
+        closeable.close();
     }
 
     @Test
@@ -53,10 +61,10 @@ public class HttpHeaderPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
-        assertTrue("The principals should contain 'a'", principals
-                .contains(new HttpHeaderPrincipal("a")));
-        assertTrue("The principals should contain 'b'", principals
-                .contains(new HttpHeaderPrincipal("b")));
+        assertTrue(principals.contains(new HttpHeaderPrincipal("a")),
+                "The principals should contain 'a'");
+        assertTrue(principals.contains(new HttpHeaderPrincipal("b")),
+                "The principals should contain 'b'");
 
     }
 
@@ -71,10 +79,10 @@ public class HttpHeaderPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         assertEquals(2, principals.size());
-        assertTrue("The principals should contain 'a'", principals
-                .contains(new HttpHeaderPrincipal("a")));
-        assertTrue("The principals should contain 'b'", principals
-                .contains(new HttpHeaderPrincipal("b")));
+        assertTrue(principals.contains(new HttpHeaderPrincipal("a")),
+                "The principals should contain 'a'");
+        assertTrue(principals.contains(new HttpHeaderPrincipal("b")),
+                "The principals should contain 'b'");
 
     }
 
@@ -83,7 +91,7 @@ public class HttpHeaderPrincipalProviderTest {
 
         final Set<Principal> principals = provider.getPrincipals(request);
 
-        assertTrue("Empty set expected when no header name configured", principals.isEmpty());
+        assertTrue(principals.isEmpty(), "Empty set expected when no header name configured");
 
     }
 
@@ -94,7 +102,7 @@ public class HttpHeaderPrincipalProviderTest {
 
         final Set<Principal> principals = provider.getPrincipals(request);
 
-        assertTrue("Empty set expected when no separator name configured", principals.isEmpty());
+        assertTrue(principals.isEmpty(), "Empty set expected when no separator name configured");
 
     }
 
@@ -106,7 +114,7 @@ public class HttpHeaderPrincipalProviderTest {
 
         final Set<Principal> principals = provider.getPrincipals(null);
 
-        assertTrue("Empty set expected when no request supplied", principals.isEmpty());
+        assertTrue(principals.isEmpty(), "Empty set expected when no request supplied");
 
     }
 
@@ -122,8 +130,8 @@ public class HttpHeaderPrincipalProviderTest {
 
         final Principal principal = principals.iterator().next();
 
-        assertNotEquals("Principals should not be equal if not the same class",
-                principal, mock(Principal.class));
+        assertNotEquals(principal, mock(Principal.class),
+                "Principals should not be equal if not the same class");
 
     }
 

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/HttpHeaderPrincipalProviderTest.java
@@ -6,7 +6,7 @@
 package org.fcrepo.auth.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -129,10 +129,12 @@ public class HttpHeaderPrincipalProviderTest {
         final Set<Principal> principals = provider.getPrincipals(request);
 
         final Principal principal = principals.iterator().next();
+        final Principal principalWithDifferentClass = mock(Principal.class);
+        when(principalWithDifferentClass.getName()).thenReturn("a");
 
-        assertNotEquals(principal, mock(Principal.class),
+        // This test is verifying that the .equals method rejects any principal class other than HttpHeaderPrincipal
+        assertFalse(principal.equals(principalWithDifferentClass),
                 "Principals should not be equal if not the same class");
-
     }
 
 }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticatingRealmTest.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/common/ServletContainerAuthenticatingRealmTest.java
@@ -5,7 +5,7 @@
  */
 package org.fcrepo.auth.common;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.apache.http.auth.BasicUserPrincipal;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.fcrepo.auth.common.ContainerRolesPrincipalProvider.ContainerRolesPrincipal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author peichman

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/AbstractResourceIT.java
@@ -14,14 +14,14 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -37,13 +37,13 @@ import org.fcrepo.kernel.api.auth.ACLHandle;
  *
  * @author gregjan
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration("/spring-test/test-container.xml")
 public abstract class AbstractResourceIT {
 
     private Logger logger;
 
-    @Before
+    @BeforeEach
     public void setLogger() {
         logger = LoggerFactory.getLogger(this.getClass());
     }

--- a/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/ServletContainerAuthenticatingRealmIT.java
+++ b/fcrepo-auth-common/src/test/java/org/fcrepo/auth/integration/ServletContainerAuthenticatingRealmIT.java
@@ -5,14 +5,14 @@
  */
 package org.fcrepo.auth.integration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.message.AbstractHttpMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author peichman
@@ -32,7 +32,7 @@ public class ServletContainerAuthenticatingRealmIT extends AbstractResourceIT {
         method.setHeader("Authorization", basic);
     }
 
-   @Test
+    @Test
     public void testUserWithoutRoles() throws IOException {
         // make sure this doesn't cause Shiro to explode
         final HttpGet request = new HttpGet(serverAddress);

--- a/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
+++ b/fcrepo-auth-common/src/test/resources/spring-test/test-container.xml
@@ -15,7 +15,7 @@
 
   <bean id="containerWrapper"
     class="org.fcrepo.http.commons.test.util.ContainerWrapper"
-    init-method="start" destroy-method="stop" p:port="${fcrepo.dynamic.test.port:8080}"
+    init-method="start" destroy-method="stop"
     p:configLocation="classpath:web.xml"/> 
 
 </beans>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3980

* Update tests in fcrepo-auth-common to junit 5. 
* Remove port param from containerWrapper so that tests will pass in an IDE by default, bringing it in line with other test-container.xml files in the project

# Interested parties
@fcrepo/committers
