### PR TITLE
Add testing for more versions of DB and Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,16 +85,17 @@ jobs:
         java: ['11', '21']
         mariadb: ['11.4']
     services:
-      postgres:
+      mariadb:
         image: mariadb:${{ matrix.mariadb }}
         env:
-          MYSQL_ROOT_PASSWORD: root-pw
-          MYSQL_DATABASE: fcrepo
-          MYSQL_USER: fcrepo-user
-          MYSQL_PASSWORD: fcrepo-pw
+          MARIADB_ROOT_PASSWORD: root-pw
+          MARIADB_DATABASE: fcrepo
+          MARIADB_USER: fcrepo-user
+          MARIADB_PASSWORD: fcrepo-pw
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval=10s
+          --health-start-period=10s
           --health-timeout=5s
           --health-retries=5
         ports:
@@ -124,7 +125,7 @@ jobs:
         java: ['11', '21']
         mysql: ['8.0']
     services:
-      postgres:
+      mysql:
         image: mysql:${{ matrix.mysql }}
         env:
           MYSQL_ROOT_PASSWORD: root-pw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['11']
+        java: ['11', '21']
         experimental: [false]
-        # JDK 17  build testing. Allowed to fail as marked experimental
-        include:
-          - java: 17
-            os: ubuntu-latest
-            experimental: true
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true
@@ -49,10 +44,11 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java: ['11']
+        java: ['11', '21']
+        postgres: ['13', '14', '15', '16']
     services:
       postgres:
-        image: postgres:12
+        image: postgres:${{ matrix.postgres }}
         env:
           POSTGRES_USER: fcrepo-user
           POSTGRES_PASSWORD: fcrepo-pw
@@ -86,10 +82,11 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java: ['11']
+        java: ['11', '21']
+        mariadb: ['11.4']
     services:
       postgres:
-        image: mariadb:10.5
+        image: mariadb:${{ matrix.mariadb }}
         env:
           MYSQL_ROOT_PASSWORD: root-pw
           MYSQL_DATABASE: fcrepo
@@ -124,10 +121,11 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java: ['11']
+        java: ['11', '21']
+        mysql: ['8.0']
     services:
       postgres:
-        image: mysql:8
+        image: mysql:${{ matrix.mysql }}
         env:
           MYSQL_ROOT_PASSWORD: root-pw
           MYSQL_DATABASE: fcrepo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
       max-parallel: 1
       matrix:
         java: ['11', '21']
-        mariadb: ['11.4']
+        mariadb: ['10', 'lts']
     services:
       mariadb:
         image: mariadb:${{ matrix.mariadb }}
@@ -93,7 +93,7 @@ jobs:
           MARIADB_USER: fcrepo-user
           MARIADB_PASSWORD: fcrepo-pw
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
           --health-interval=10s
           --health-start-period=10s
           --health-timeout=5s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,8 +98,14 @@ jobs:
           --health-start-period=10s
           --health-timeout=5s
           --health-retries=5
+          --ulimit memlock=262144
         ports:
           - 3306:3306
+        healthcheck:
+          test: ["CMD", "mysqladmin", "ping"]
+          interval: 10s
+          timeout: 5s
+          retries: 5
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,11 +101,6 @@ jobs:
           --ulimit memlock=262144
         ports:
           - 3306:3306
-        healthcheck:
-          test: ["CMD", "mysqladmin", "ping"]
-          interval: 10s
-          timeout: 5s
-          retries: 5
     steps:
     - name: Git support longpaths
       run: git config --global core.longpaths true


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3994

# What does this Pull Request do?
Updates the Github actions to test more database versions as well as to also compile against Java 21

**Note**: 
* PostgreSQL doesn't seem to have a LTS policy
* MariaDB has 11.4 as LTS and 11.8 (to be released in Q2 2025)
* MySQL is a little unclear, based on [this blog post](https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/) it sounds like 8.0 will be LTS and 8.x (i.e. 8.1, 8.2, 8.n) will be the Innovation branch.

Additionally I compiled the existing `main` branch and ran it with Java 21. So I added that on here.

# How should this be tested?

All automated tests should pass.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
