### PR TITLE
upgrade fcrepo-event-serialization to JUnit5

### DIFF
--- a/fcrepo-event-serialization/pom.xml
+++ b/fcrepo-event-serialization/pom.xml
@@ -72,13 +72,21 @@
 
     <!-- test gear -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTest.java
@@ -6,7 +6,7 @@
 
 package org.fcrepo.event.serialization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
@@ -5,7 +5,6 @@
  */
 
 package org.fcrepo.event.serialization;
-import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,6 +25,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -44,6 +45,7 @@ import org.mockito.Mock;
  * @author dbernstein
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EventSerializerTestBase {
 
     @Mock

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/EventSerializerTestBase.java
@@ -5,6 +5,9 @@
  */
 
 package org.fcrepo.event.serialization;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
@@ -14,8 +17,6 @@ import static org.fcrepo.kernel.api.RdfLexicon.ACTIVITY_STREAMS_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
@@ -23,6 +24,8 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -30,9 +33,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.SimpleSelector;
 import org.fcrepo.kernel.api.observer.Event;
 import org.fcrepo.kernel.api.observer.EventType;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * <p>
@@ -42,7 +43,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author acoburn
  * @author dbernstein
  */
-@RunWith(MockitoJUnitRunner.Silent.class)
+@ExtendWith(MockitoExtension.class)
 public class EventSerializerTestBase {
 
     @Mock

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/JsonLDSerializerTest.java
@@ -5,12 +5,14 @@
  */
 
 package org.fcrepo.event.serialization;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.jena.rdf.model.Model;
 import org.fcrepo.kernel.api.observer.EventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,8 +24,6 @@ import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
 import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.PROV_NAMESPACE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * <p>

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/TurtleSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/TurtleSerializerTest.java
@@ -5,10 +5,12 @@
  */
 
 package org.fcrepo.event.serialization;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>

--- a/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/TurtleSerializerTest.java
+++ b/fcrepo-event-serialization/src/test/java/org/fcrepo/event/serialization/TurtleSerializerTest.java
@@ -6,9 +6,6 @@
 
 package org.fcrepo.event.serialization;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
**upgrade fcrepo-event-serialization to JUnit5**
* * *

**JIRA Ticket**: https://fedora-repository.atlassian.net/jira/software/c/projects/FCREPO/issues/FCREPO-3976

# What does this Pull Request do?
updates namespaces and syntax for JUnit5

# How should this be tested?
* ensure tests pass as expected

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
