### PR TITLE
Add some tests to search-impl

### DIFF
--- a/fcrepo-search-impl/pom.xml
+++ b/fcrepo-search-impl/pom.xml
@@ -74,5 +74,20 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb.flyway-test-extensions</groupId>
+      <artifactId>flyway-spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/DbSearchIndexImplTest.java
+++ b/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/DbSearchIndexImplTest.java
@@ -1,0 +1,668 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.search.impl;
+
+import static org.fcrepo.kernel.api.RdfLexicon.BASIC_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_BINARY;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_CONTAINER;
+import static org.fcrepo.kernel.api.RdfLexicon.FEDORA_RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.NON_RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.exception.PathNotFoundException;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.api.models.ResourceHeaders;
+import org.fcrepo.persistence.common.ResourceHeadersImpl;
+import org.fcrepo.search.api.Condition;
+import org.fcrepo.search.api.InvalidConditionExpressionException;
+import org.fcrepo.search.api.InvalidQueryException;
+import org.fcrepo.search.api.SearchParameters;
+import org.fcrepo.search.impl.utils.SearchTestConfiguration;
+import org.fcrepo.search.impl.utils.TestTransaction;
+
+import org.flywaydb.test.FlywayTestExecutionListener;
+import org.flywaydb.test.annotation.FlywayTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+/**
+ * Test class for {@link DbSearchIndexImpl}
+ *
+ * @author whikloj
+ */
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ContextConfiguration(classes = {SearchTestConfiguration.class})
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class, FlywayTestExecutionListener.class })
+public class DbSearchIndexImplTest {
+
+    @Inject
+    private DbSearchIndexImpl searchIndex;
+
+    private ResourceHeaders resourceHeaders1;
+
+    private ResourceHeaders resource1ParentHeaders;
+
+    private ResourceHeaders resourceHeaders2;
+
+    private Transaction transaction;
+
+    @Mock
+    private ResourceFactory resourceFactory;
+
+    @Mock
+    private FedoraResource resource1;
+
+    @Mock
+    private FedoraResource resource1Parent;
+
+    @Mock
+    private FedoraResource resource2;
+
+    private FedoraId testId;
+
+    private FedoraId parentId;
+
+    @BeforeEach
+    @FlywayTest
+    public void setUp() throws PathNotFoundException {
+        searchIndex.reset();
+        testId = FedoraId.create("info:fedora/parentId/testId");
+        parentId = FedoraId.create("info:fedora/parentId");
+        transaction = makeTransaction();
+        resourceHeaders1 = buildContainerResourceHeaders(testId, parentId);
+        mockContainerResource(resource1, testId.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders1.getId())).thenReturn(resource1);
+        setField(searchIndex, "resourceFactory", resourceFactory);
+    }
+
+    /**
+     * Builds a container resource headers object.
+     *
+     * @param id The resource's id
+     * @param parentId The resource's parent id
+     * @return The resource headers object
+     */
+    private ResourceHeaders buildContainerResourceHeaders(final FedoraId id, final FedoraId parentId) {
+        final var tempHeaders = new ResourceHeadersImpl();
+        tempHeaders.setId(id);
+        tempHeaders.setParent(parentId);
+        tempHeaders.setStateToken("stateToken");
+        tempHeaders.setInteractionModel("http://www.w3.org/ns/ldp#BasicContainer");
+        tempHeaders.setCreatedDate(Instant.now());
+        tempHeaders.setCreatedBy("createdBy");
+        tempHeaders.setLastModifiedDate(Instant.now());
+        tempHeaders.setLastModifiedBy("lastModifiedBy");
+        tempHeaders.setObjectRoot(true);
+        tempHeaders.setDeleted(false);
+        tempHeaders.setContentPath("fcr-container.nt");
+        return tempHeaders;
+    }
+
+    /**
+     * Mocks some container resource properties.
+     *
+     * @param resource The mock resource
+     * @param id The resource's id
+     */
+    private void mockContainerResource(final FedoraResource resource, final String id) {
+        when(resource.getId()).thenReturn(id);
+        when(resource.getTypes()).thenReturn(List.of(
+                URI.create(BASIC_CONTAINER.getURI()),
+                URI.create(FEDORA_CONTAINER.getURI()),
+                URI.create(FEDORA_RESOURCE.getURI()),
+                URI.create(RDF_SOURCE.getURI()),
+                URI.create(RESOURCE.getURI())
+        ));
+    }
+
+    /**
+     * Builds a binary resource headers object.
+     *
+     * @param id The resource's id
+     * @param parentId The resource's parent id
+     * @return The resource headers object
+     */
+    private ResourceHeaders buildBinaryResourceHeaders(final FedoraId id, final FedoraId parentId) {
+        final var tempHeaders = new ResourceHeadersImpl();
+        tempHeaders.setId(id);
+        tempHeaders.setParent(parentId);
+        tempHeaders.setStateToken("stateToken");
+        tempHeaders.setInteractionModel("http://www.w3.org/ns/ldp#NonRDFSource");
+        tempHeaders.setMimeType("text/plain");
+        tempHeaders.setFilename("filename.txt");
+        tempHeaders.setContentSize(12345L);
+        tempHeaders.setDigests(
+                Collections.singleton(
+                        URI.create("urn:sha-512:3395169e41043ec16a5a98f3716a826937e6d98a1667c8c5aa5a7e9be27958427541c" +
+                                "944a1a2a5143ddd37fdb8360b08d80094d13c0a02e0bd83308a7b50b464")
+            )
+        );
+        tempHeaders.setCreatedDate(Instant.now());
+        tempHeaders.setCreatedBy("createdBy");
+        tempHeaders.setLastModifiedDate(Instant.now());
+        tempHeaders.setLastModifiedBy("lastModifiedBy");
+        tempHeaders.setObjectRoot(true);
+        tempHeaders.setDeleted(false);
+        tempHeaders.setContentPath("some-binary");
+        return tempHeaders;
+    }
+
+    /**
+     * Mocks some binary resource properties.
+     *
+     * @param resource The mock resource
+     * @param id The resource's id
+     */
+    private void mockBinaryResource(final FedoraResource resource, final String id) {
+        when(resource.getId()).thenReturn(id);
+        when(resource.getTypes()).thenReturn(List.of(
+                URI.create(NON_RDF_SOURCE.getURI()),
+                URI.create(FEDORA_BINARY.getURI()),
+                URI.create(FEDORA_RESOURCE.getURI()),
+                URI.create(RESOURCE.getURI())
+        ));
+    }
+
+    /**
+     * Creates a transaction object.
+     * @param longLived true if the transaction is long-lived, false otherwise
+     * @return The transaction object
+     */
+    private Transaction makeTransaction(final boolean longLived) {
+        return new TestTransaction(UUID.randomUUID().toString(), !longLived);
+    }
+
+    /**
+     * Creates a transaction object.
+     * @return The transaction object
+     */
+    private Transaction makeTransaction() {
+        return makeTransaction(false);
+    }
+
+    /**
+     * Test with an invalid condition ("written")
+     */
+    @Test
+    public void testInvalidCondition() throws Exception {
+        assertThrows(InvalidConditionExpressionException.class, () -> {
+            new SearchParameters(
+                    List.of(Condition.Field.CREATED),
+                    List.of(Condition.fromExpression("written=2020-01-01T00:00:00+0000")),
+                    10,
+                    0,
+                    Condition.Field.CREATED,
+                    "asc",
+                    true
+            );
+        });
+    }
+
+    /**
+     * Test with an invalid date format, must be RFC-8601 (2020-05-01T20:05:14+00:00)
+     */
+    @Test
+    public void testInvalidDateFormat() throws Exception {
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.CREATED),
+                List.of(Condition.fromExpression("created=2020-01-01T00:00:00Z+0000")),
+                10,
+                0,
+                Condition.Field.CREATED,
+                "asc",
+                true
+        );
+        assertThrows(InvalidQueryException.class, () -> searchIndex.doSearch(parameters));
+    }
+
+    /**
+     * Test adding a resource to the index with a short lived transaction.
+     */
+    @Test
+    public void testAddToIndex() throws Exception {
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + testId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        // Search for the resource before adding it to the index
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(0, results.getPagination().getTotalResults());
+        // Add the resource to the index
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        // Search for the resource after adding it to the index
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(1, results2.getPagination().getTotalResults());
+        // Add another resource to the index
+        final var id2 = FedoraId.create(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+        // Search for the original resource
+        final var results3 = searchIndex.doSearch(parameters);
+        assertEquals(1, results3.getPagination().getTotalResults());
+        // Search for the new resource
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + id2.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results4 = searchIndex.doSearch(parameters2);
+        assertEquals(1, results4.getPagination().getTotalResults());
+        // Search for both resources
+        final var parameters3 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=*")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results5 = searchIndex.doSearch(parameters3);
+        assertEquals(2, results5.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test removing a resource from the index using a short lived transaction.
+     */
+    @Test
+    public void testRemoveFromIndex() throws Exception {
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        final var id2 = FedoraId.create(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=*")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(2, results.getPagination().getTotalResults());
+        // Remove the first resource from the index
+        searchIndex.removeFromIndex(transaction, testId);
+        // Search for the resource after removing it from the index
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(1, results2.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test adding a resource to the index using a long lived transaction.
+     */
+    @Test
+    public void testAddToIndexTransaction() throws Exception {
+        transaction = makeTransaction(true);
+        when(resourceFactory.getResource(transaction, resourceHeaders1.getId())).thenReturn(resource1);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + testId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        // Search for the resource before adding it to the index
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(0, results.getPagination().getTotalResults());
+        // Add the resource to the index using the transaction
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        // Search for the resource after adding it to the index
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(0, results2.getPagination().getTotalResults());
+        // Commit the transaction
+        searchIndex.commitTransaction(transaction);
+        final var results3 = searchIndex.doSearch(parameters);
+        assertEquals(1, results3.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test adding a resource with a long lived transaction and then rolling back the transaction.
+     */
+    @Test
+    public void testAddToIndexTransactionRollback() throws Exception {
+        transaction = makeTransaction(true);
+        when(resourceFactory.getResource(transaction, resourceHeaders1.getId())).thenReturn(resource1);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + testId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        // Search for the resource before adding it to the index
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(0, results.getPagination().getTotalResults());
+        // Add the resource to the index using the transaction
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        // Search for the resource after adding it to the index
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(0, results2.getPagination().getTotalResults());
+        // Commit the transaction
+        searchIndex.rollbackTransaction(transaction);
+        final var results3 = searchIndex.doSearch(parameters);
+        assertEquals(0, results3.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test removing a resource from the index using a long lived transaction.
+     */
+    @Test
+    public void testAddAndRemoveFromIndexTransaction() throws Exception {
+        transaction = makeTransaction(true);
+        when(resourceFactory.getResource(transaction, resourceHeaders1.getId())).thenReturn(resource1);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        final var id2 = FedoraId.create(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=*")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(0, results.getPagination().getTotalResults());
+        // Commit the transaction
+        searchIndex.commitTransaction(transaction);
+        // Check for both resources
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(2, results2.getPagination().getTotalResults());
+        // Create a new transaction
+        transaction = makeTransaction(true);
+        // Update mock when the transaction changes.
+        when(resourceFactory.getResource(transaction, resourceHeaders1.getId())).thenReturn(resource1);
+        // Remove the first resource from the index
+        searchIndex.removeFromIndex(transaction, testId);
+        // Search for the resource after removing it from the index
+        final var results3 = searchIndex.doSearch(parameters);
+        assertEquals(2, results2.getPagination().getTotalResults());
+        // Commit the transaction
+        searchIndex.commitTransaction(transaction);
+        final var results4 = searchIndex.doSearch(parameters);
+        assertEquals(1, results4.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by Fedora ID with and without a wildcard.
+     */
+    @Test
+    public void testSearchFedoraId() throws Exception {
+        final var parentResourceHeaders = buildContainerResourceHeaders(parentId, FedoraId.create(""));
+        mockContainerResource(resource1Parent, parentId.getResourceId());
+        when(resourceFactory.getResource(transaction, parentResourceHeaders.getId())).thenReturn(resource1Parent);
+        searchIndex.addUpdateIndex(transaction, parentResourceHeaders);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + testId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(1, results.getPagination().getTotalResults());
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + parentId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results2 = searchIndex.doSearch(parameters2);
+        assertEquals(1, results2.getPagination().getTotalResults());
+        final var parameters3 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + parentId.getFullId() + "*")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results3 = searchIndex.doSearch(parameters3);
+        assertEquals(2, results3.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by rdf_type
+     */
+    @Test
+    public void testSearchRdfType() throws Exception {
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("rdf_type=http://www.w3.org/ns/ldp#RDFSource")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(1, results.getPagination().getTotalResults());
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("rdf_type=http://www.w3.org/ns/ldp#NonRDFSource")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results2 = searchIndex.doSearch(parameters2);
+        assertEquals(0, results2.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by mime_type
+     */
+    @Test
+    public void testSearchMimeType() throws Exception {
+        final var id2 = parentId.resolve(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("mime_type=text/plain")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(1, results.getPagination().getTotalResults());
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("mime_type=application/json")),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results2 = searchIndex.doSearch(parameters2);
+        assertEquals(0, results2.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by created date
+     */
+    @Test
+    public void testSearchCreated() throws Exception {
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.CREATED),
+                List.of(Condition.fromExpression("created=2020-01-01T00:00:00+00:00")),
+                10,
+                0,
+                Condition.Field.CREATED,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        // Created does not exact match
+        assertEquals(0, results.getPagination().getTotalResults());
+
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.CREATED),
+                List.of(Condition.fromExpression("created=" + resourceHeaders1.getCreatedDate().toString())),
+                10,
+                0,
+                Condition.Field.CREATED,
+                "asc",
+                true
+        );
+        final var results2 = searchIndex.doSearch(parameters2);
+        // Created does exact match
+        assertEquals(1, results2.getPagination().getTotalResults());
+
+        final var parameters3 = new SearchParameters(
+                List.of(Condition.Field.CREATED),
+                List.of(Condition.fromExpression("created<=2025-01-01T00:00:00+00:00")),
+                10,
+                0,
+                Condition.Field.CREATED,
+                "asc",
+                true
+        );
+        final var results3 = searchIndex.doSearch(parameters3);
+        // Created is not less than or equal to 2025-01-01
+        assertEquals(0, results3.getPagination().getTotalResults());
+
+        final var parameters4 = new SearchParameters(
+                List.of(Condition.Field.CREATED),
+                List.of(Condition.fromExpression("created>=" + resourceHeaders1.getCreatedDate().toString())),
+                10,
+                0,
+                Condition.Field.CREATED,
+                "asc",
+                true
+        );
+        final var results4 = searchIndex.doSearch(parameters4);
+        // Created is greater than or equal to the created date
+        assertEquals(1, results4.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by content size
+     */
+    @Test
+    public void testSearchContentSize() throws Exception {
+        final var id2 = parentId.resolve(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.CONTENT_SIZE),
+                List.of(Condition.fromExpression("content_size=12345")),
+                10,
+                0,
+                Condition.Field.CONTENT_SIZE,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(1, results.getPagination().getTotalResults());
+        final var parameters2 = new SearchParameters(
+                List.of(Condition.Field.CONTENT_SIZE),
+                List.of(Condition.fromExpression("content_size=1234")),
+                10,
+                0,
+                Condition.Field.CONTENT_SIZE,
+                "asc",
+                true
+        );
+        final var results2 = searchIndex.doSearch(parameters2);
+        assertEquals(0, results2.getPagination().getTotalResults());
+    }
+
+    /**
+     * Test searching for a resource by multiple conditions
+     */
+    @Test
+    public void testComplexQuery() throws Exception {
+        final var id2 = parentId.resolve(UUID.randomUUID().toString());
+        resourceHeaders2 = buildBinaryResourceHeaders(id2, parentId);
+        mockBinaryResource(resource2, id2.getResourceId());
+        when(resourceFactory.getResource(transaction, resourceHeaders2.getId())).thenReturn(resource2);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1);
+        searchIndex.addUpdateIndex(transaction, resourceHeaders2);
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID, Condition.Field.RDF_TYPE),
+                List.of(
+                        Condition.fromExpression("fedora_id=" + parentId.getFullId() + "*"),
+                        Condition.fromExpression("created>=2025-01-01T00:00:00+00:00")
+                ),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(2, results.getPagination().getTotalResults());
+    }
+}

--- a/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/InstantParserTest.java
+++ b/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/InstantParserTest.java
@@ -1,9 +1,9 @@
+package org.fcrepo.search.impl;
 /*
  * The contents of this file are subject to the license and copyright
  * detailed in the LICENSE and NOTICE files at the root of the source
  * tree.
  */
-import org.fcrepo.search.impl.InstantParser;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/utils/SearchTestConfiguration.java
+++ b/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/utils/SearchTestConfiguration.java
@@ -1,0 +1,90 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.search.impl.utils;
+
+import javax.sql.DataSource;
+
+import org.fcrepo.config.FedoraPropsConfig;
+import org.fcrepo.config.FlywayFactory;
+import org.fcrepo.kernel.api.cache.UserTypesCache;
+import org.fcrepo.kernel.api.models.ResourceFactory;
+import org.fcrepo.kernel.impl.ContainmentIndexImpl;
+import org.fcrepo.kernel.impl.cache.UserTypesCacheImpl;
+import org.fcrepo.persistence.api.PersistentStorageSessionManager;
+import org.fcrepo.search.api.SearchIndex;
+import org.fcrepo.search.impl.DbSearchIndexImpl;
+
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Spring configuration for the search tests.
+ *
+ * @author whikloj
+ */
+public class SearchTestConfiguration {
+
+    @Bean
+    @DependsOn("dataSource")
+    public DataSourceTransactionManager getTxMgr(final DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+
+    @Bean
+    public DriverManagerDataSource dataSource() {
+        final var dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:index;DB_CLOSE_DELAY=-1");
+        return dataSource;
+    }
+
+    @Bean
+    @DependsOn({"fedoraPropsConfig", "dataSource"})
+    public ContainmentIndexImpl containmentIndex() {
+        return new ContainmentIndexImpl();
+    }
+
+    @Bean
+    @DependsOn("dataSource")
+    public FlywayFactory flywayFactory(final DataSource dataSource) {
+        final var flywayFactory = new FlywayFactory();
+        flywayFactory.setDataSource(dataSource);
+        flywayFactory.setDatabaseType("h2");
+        flywayFactory.setCleanDisabled(false);
+        return flywayFactory;
+    }
+
+    @Bean
+    @DependsOn("fedoraPropsConfig")
+    public UserTypesCache userTypesCache(final FedoraPropsConfig config) {
+        return new UserTypesCacheImpl(config);
+    }
+
+    @Bean
+    public ResourceFactory resourceFactory() {
+        return Mockito.mock(ResourceFactory.class);
+    }
+
+    @Bean
+    public PersistentStorageSessionManager persistentStorageSessionManager() {
+        return Mockito.mock(PersistentStorageSessionManager.class);
+    }
+
+    @Bean
+    @Autowired
+    public SearchIndex searchIndex() {
+        return new DbSearchIndexImpl();
+    }
+
+    @Bean
+    public FedoraPropsConfig fedoraPropsConfig() {
+        return new FedoraPropsConfig();
+    }
+}

--- a/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/utils/TestTransaction.java
+++ b/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/utils/TestTransaction.java
@@ -1,0 +1,160 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.search.impl.utils;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.identifiers.FedoraId;
+
+/**
+ * A test transaction implementation for Search Index
+ *
+ * @author whikloj
+ */
+public class TestTransaction implements Transaction {
+
+    private final String id;
+
+    private final boolean shortLived;
+
+    public TestTransaction(final String txId, final boolean shortLived) {
+        this.id = txId;
+        this.shortLived = shortLived;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isShortLived() {
+        return shortLived;
+    }
+
+    @Override
+    public void setShortLived(final boolean shortLived) {
+        // no-op
+    }
+
+    @Override
+    public void expire() {
+        // no-op
+    }
+
+    @Override
+    public boolean hasExpired() {
+        return false;
+    }
+
+    @Override
+    public Instant updateExpiry(final Duration amountToAdd) {
+        return null;
+    }
+
+    @Override
+    public Instant getExpires() {
+        return null;
+    }
+
+    @Override
+    public void refresh() {
+        // no-op
+    }
+
+    @Override
+    public void lockResource(final FedoraId resourceId) {
+        // no-op
+    }
+
+    @Override
+    public void lockResourceNonExclusive(final FedoraId resourceId) {
+        // no-op
+    }
+
+    @Override
+    public void lockResourceAndGhostNodes(final FedoraId resourceId) {
+        // no-op
+    }
+
+    @Override
+    public void releaseResourceLocksIfShortLived() {
+        // no-op
+    }
+
+    @Override
+    public void doInTx(final Runnable closure) {
+        closure.run();
+    }
+
+    @Override
+    public void setBaseUri(final String baseUri) {
+        // no-op
+    }
+
+    @Override
+    public void setUserAgent(final String userAgent) {
+        // no-op
+    }
+
+    @Override
+    public void suppressEvents() {
+        // no-op
+    }
+
+    @Override
+    public void commit() {
+        // no-op
+    }
+
+    @Override
+    public void commitIfShortLived() {
+        // no-op
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void rollback() {
+        // no-op
+    }
+
+    @Override
+    public void fail() {
+        // no-op
+    }
+
+    @Override
+    public boolean isRolledBack() {
+        return false;
+    }
+
+    @Override
+    public boolean isOpenLongRunning() {
+        return false;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public void ensureCommitting() {
+        // no-op
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+}

--- a/fcrepo-stats-api/src/main/java/org/fcrepo/stats/api/RepositoryStatsResult.java
+++ b/fcrepo-stats-api/src/main/java/org/fcrepo/stats/api/RepositoryStatsResult.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  */
 public class RepositoryStatsResult {
 
-    private Long resourceCount = 0l;
+    private Long resourceCount = 0L;
 
     public void setResourceCount(final Long resourceCount) {
         this.resourceCount = resourceCount;

--- a/pom.xml
+++ b/pom.xml
@@ -838,6 +838,11 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+          <configuration>
+            <excludes>
+              <exclude>**/SearchIndexMetrics.class</exclude>
+            </excludes>
+          </configuration>
           <executions>
             <execution>
               <id>default-prepare-agent</id>
@@ -871,9 +876,7 @@
               </goals>
               <configuration>
                 <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
-                <xml>true</xml>
-                <html>false</html>
-                <csv>false</csv>
+                <formats>XML</formats>
               </configuration>
             </execution>
             <execution>
@@ -904,7 +907,7 @@
               <configuration>
                 <dataFile>${project.build.directory}/jacoco/jacoco-merged.exec</dataFile>
                 <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
-                <xml>true</xml>
+                <formats>XML</formats>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
**JIRA Ticket**: #2178 

# What does this Pull Request do?
* Adds tests to the `fcrepo-search-impl` module, including:
    *  Spring configuration
    * A thin `Transaction` implementation as `TransactionImpl`'s constructor is protected so we can't instantiate a transaction and `TransactionManagerImpl` has a lot of dependencies.
* Excludes the `SearchIndexMetrics` class as it is just a wrapper around `DbSearchIndexImpl`

# How should this be tested?

This adds tests, so ensuring the tests make sense and cover enough of the functionality. 

I wrote some of these and then started staring at the Jacoco line counts too much. So I decided to push it up. Happy to add more tests, but wanted some other eyes on it.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
