### PR TITLE
2164 - Test coverage for fcrepo-configs

### DIFF
--- a/fcrepo-configs/pom.xml
+++ b/fcrepo-configs/pom.xml
@@ -63,6 +63,29 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb.flyway-test-extensions</groupId>
+      <artifactId>flyway-spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/DigestAlgorithm.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/DigestAlgorithm.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Digest Algorith enum
+ * Digest Algorithm enum
  * @author cbeer
  *
  * Moved to its own class for Fedora 6.0.0

--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -171,8 +171,11 @@ public class OcflPropsConfig extends BasePropsConfig {
             LOGGER.info("Fedora OCFL root: {}", ocflRepoRoot);
             createDirectories(ocflRepoRoot);
         } else if (storage == Storage.OCFL_S3) {
-            Objects.requireNonNull(ocflS3Bucket,
-                    String.format("The property %s must be set when OCFL S3 storage is used", FCREPO_OCFL_S3_BUCKET));
+            if (ocflS3Bucket == null || ocflS3Bucket.isBlank()) {
+                throw new IllegalArgumentException(
+                        String.format("The property %s must be set when OCFL S3 storage is used",
+                                FCREPO_OCFL_S3_BUCKET));
+            }
 
             LOGGER.info("Fedora AWS access key: {}", awsAccessKey);
             LOGGER.info("Fedora AWS secret key set: {}", Objects.isNull(awsSecretKey));

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/AuthPropsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/AuthPropsConfigTest.java
@@ -1,0 +1,71 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+/**
+ * @author bbpennel
+ */
+public class AuthPropsConfigTest {
+
+    private AuthPropsConfig config;
+
+    @BeforeEach
+    public void setUp() {
+        config = new AuthPropsConfig();
+        // Set default values that would normally be set by Spring's @Value annotations
+        ReflectionTestUtils.setField(config, "rootAuthAclPath", null);
+        ReflectionTestUtils.setField(config, "userAgentBaseUri", null);
+        ReflectionTestUtils.setField(config, "groupAgentBaseUri", null);
+        ReflectionTestUtils.setField(config, "authPrincipalDelegateEnabled", true);
+        ReflectionTestUtils.setField(config, "authPrincipalHeaderEnabled", false);
+        ReflectionTestUtils.setField(config, "authPrincipalHeaderName", "some-header");
+        ReflectionTestUtils.setField(config, "authPrincipalHeaderSeparator", ",");
+        ReflectionTestUtils.setField(config, "authPrincipalRolesEnabled", false);
+        ReflectionTestUtils.setField(config, "authPrincipalRolesList", Arrays.asList("role-1", "role-2"));
+    }
+
+    @Test
+    public void testDefaultValues() {
+        assertNull(config.getRootAuthAclPath());
+        assertNull(config.getUserAgentBaseUri());
+        assertNull(config.getGroupAgentBaseUri());
+        assertTrue(config.isAuthPrincipalDelegateEnabled());
+        assertFalse(config.isAuthPrincipalHeaderEnabled());
+        assertEquals("some-header", config.getAuthPrincipalHeaderName());
+        assertEquals(",", config.getAuthPrincipalHeaderSeparator());
+        assertFalse(config.isAuthPrincipalRolesEnabled());
+        assertEquals(Arrays.asList("role-1", "role-2"), config.getAuthPrincipalRolesList());
+    }
+
+    @Test
+    public void testSetRootAuthAclPath() {
+        final Path testPath = Paths.get("/test/path.acl");
+        config.setRootAuthAclPath(testPath);
+        assertEquals(testPath, config.getRootAuthAclPath());
+    }
+
+    @Test
+    public void testStaticConstants() {
+        // Verify static constant values
+        assertEquals("fcrepo.auth.enabled", AuthPropsConfig.FCREPO_AUTH_ENABLED);
+        assertEquals("fcrepo.auth.principal.header.enabled", AuthPropsConfig.FCREPO_AUTH_PRINCIPAL_HEADER_ENABLED);
+        assertEquals("fcrepo.auth.principal.roles.enabled", AuthPropsConfig.FCREPO_AUTH_PRINCIPAL_ROLES_ENABLED);
+        assertEquals("fcrepo.auth.principal.delegate.enabled", AuthPropsConfig.FCREPO_AUTH_PRINCIPAL_DELEGATE_ENABLED);
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/ConditionOnPropertyFalseTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/ConditionOnPropertyFalseTest.java
@@ -1,0 +1,93 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Test for {@link ConditionOnPropertyFalse}
+ *
+ * @author bbpennel
+ */
+public class ConditionOnPropertyFalseTest {
+
+    private ConditionContext context;
+    private Environment environment;
+    private AnnotatedTypeMetadata metadata;
+
+    @BeforeEach
+    public void setUp() {
+        context = mock(ConditionContext.class);
+        environment = mock(Environment.class);
+        when(context.getEnvironment()).thenReturn(environment);
+        metadata = mock(AnnotatedTypeMetadata.class);
+    }
+
+    /**
+     * Concrete implementation of ConditionOnPropertyFalse for testing
+     */
+    private static class TestConditionOnPropertyFalse extends ConditionOnPropertyFalse {
+        public TestConditionOnPropertyFalse(final String name, final boolean defaultValue) {
+            super(name, defaultValue);
+        }
+
+        // No-arg constructor required by the interface contract
+        public TestConditionOnPropertyFalse() {
+            this("test.property", true);
+        }
+    }
+
+    @Test
+    public void testMatchesWhenPropertyIsFalse() {
+        final TestConditionOnPropertyFalse condition = new TestConditionOnPropertyFalse("test.property", true);
+        when(environment.getProperty("test.property", Boolean.class, true)).thenReturn(false);
+
+        assertTrue(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testDoesNotMatchWhenPropertyIsTrue() {
+        final TestConditionOnPropertyFalse condition = new TestConditionOnPropertyFalse("test.property", true);
+        when(environment.getProperty("test.property", Boolean.class, true)).thenReturn(true);
+
+        assertFalse(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testMatchesWithDefaultValueFalse() {
+        final TestConditionOnPropertyFalse condition = new TestConditionOnPropertyFalse("test.property", false);
+        // Property not set, so default will be used
+        when(environment.getProperty("test.property", Boolean.class, false)).thenReturn(false);
+
+        assertTrue(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testDoesNotMatchWithDefaultValueTrue() {
+        final TestConditionOnPropertyFalse condition = new TestConditionOnPropertyFalse("test.property", true);
+        // Property not set, so default will be used
+        when(environment.getProperty("test.property", Boolean.class, true)).thenReturn(true);
+
+        assertFalse(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testConfigurationPhase() {
+        final TestConditionOnPropertyFalse condition = new TestConditionOnPropertyFalse();
+        assertEquals(ConfigurationCondition.ConfigurationPhase.REGISTER_BEAN, condition.getConfigurationPhase());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/ConditionOnPropertyTrueTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/ConditionOnPropertyTrueTest.java
@@ -1,0 +1,93 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Test for {@link ConditionOnPropertyTrue}
+ *
+ * @author bbpennel
+ */
+public class ConditionOnPropertyTrueTest {
+
+    private ConditionContext context;
+    private Environment environment;
+    private AnnotatedTypeMetadata metadata;
+
+    @BeforeEach
+    public void setUp() {
+        context = mock(ConditionContext.class);
+        environment = mock(Environment.class);
+        when(context.getEnvironment()).thenReturn(environment);
+        metadata = mock(AnnotatedTypeMetadata.class);
+    }
+
+    /**
+     * Concrete implementation of ConditionOnPropertyTrue for testing
+     */
+    private static class TestConditionOnPropertyTrue extends ConditionOnPropertyTrue {
+        public TestConditionOnPropertyTrue(final String name, final boolean defaultValue) {
+            super(name, defaultValue);
+        }
+
+        // No-arg constructor required by the interface contract
+        public TestConditionOnPropertyTrue() {
+            this("test.property", false);
+        }
+    }
+
+    @Test
+    public void testMatchesWhenPropertyIsTrue() {
+        final TestConditionOnPropertyTrue condition = new TestConditionOnPropertyTrue("test.property", false);
+        when(environment.getProperty("test.property", Boolean.class, false)).thenReturn(true);
+
+        assertTrue(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testDoesNotMatchWhenPropertyIsFalse() {
+        final TestConditionOnPropertyTrue condition = new TestConditionOnPropertyTrue("test.property", false);
+        when(environment.getProperty("test.property", Boolean.class, false)).thenReturn(false);
+
+        assertFalse(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testMatchesWithDefaultValueTrue() {
+        final TestConditionOnPropertyTrue condition = new TestConditionOnPropertyTrue("test.property", true);
+        // Property not set, so default will be used
+        when(environment.getProperty("test.property", Boolean.class, true)).thenReturn(true);
+
+        assertTrue(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testDoesNotMatchWithDefaultValueFalse() {
+        final TestConditionOnPropertyTrue condition = new TestConditionOnPropertyTrue("test.property", false);
+        // Property not set, so default will be used
+        when(environment.getProperty("test.property", Boolean.class, false)).thenReturn(false);
+
+        assertFalse(condition.matches(context, metadata));
+    }
+
+    @Test
+    public void testConfigurationPhase() {
+        final TestConditionOnPropertyTrue condition = new TestConditionOnPropertyTrue();
+        assertEquals(ConfigurationCondition.ConfigurationPhase.REGISTER_BEAN, condition.getConfigurationPhase());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/DatabaseConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/DatabaseConfigTest.java
@@ -1,0 +1,182 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.test.FlywayTestExecutionListener;
+import org.flywaydb.test.annotation.FlywayTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/**
+ * @author bbpennel
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {DatabaseConfigTest.TestConfig.class})
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class, FlywayTestExecutionListener.class})
+public class DatabaseConfigTest {
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public FedoraPropsConfig fedoraPropsConfig() {
+            return new FedoraPropsConfig();
+        }
+
+        @Bean
+        public DatabaseConfig databaseConfig() {
+            return new DatabaseConfig();
+        }
+
+        @Bean
+        public DriverManagerDataSource dataSource() {
+            final var dataSource = new DriverManagerDataSource();
+            dataSource.setDriverClassName("org.h2.Driver");
+            dataSource.setUrl("jdbc:h2:mem:index;DB_CLOSE_DELAY=-1");
+            return dataSource;
+        }
+
+        @Bean
+        @DependsOn("dataSource")
+        public FlywayFactory flywayFactory(final DataSource dataSource) {
+            final var flywayFactory = new FlywayFactory();
+            flywayFactory.setDataSource(dataSource);
+            flywayFactory.setDatabaseType("h2");
+            flywayFactory.setCleanDisabled(false);
+            return flywayFactory;
+        }
+    }
+
+    @Autowired
+    private DatabaseConfig databaseConfig;
+
+    @TempDir
+    public Path tmpDir;
+
+    @BeforeEach
+    @FlywayTest
+    public void setUp() {
+        setField(databaseConfig, "dbUrl", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
+        setField(databaseConfig, "flywayCleanDisabled", false);
+        setField(databaseConfig, "customDbProperties", null);
+    }
+
+    @Test
+    public void testDataSource() throws Exception {
+        final DataSource dataSource = databaseConfig.dataSource();
+        assertNotNull(dataSource);
+        assertTrue(dataSource instanceof HikariDataSource);
+        
+        final HikariDataSource hikariDs = (HikariDataSource) dataSource;
+        assertEquals("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", hikariDs.getJdbcUrl());
+        assertEquals("org.h2.Driver", hikariDs.getDriverClassName());
+    }
+    
+    @Test
+    public void testTxManager() throws Exception {
+        final DataSource dataSource = databaseConfig.dataSource();
+        final PlatformTransactionManager txManager = databaseConfig.txManager(dataSource);
+        assertNotNull(txManager);
+    }
+    
+    @Test
+    public void testTxTemplate() throws Exception {
+        final DataSource dataSource = databaseConfig.dataSource();
+        final PlatformTransactionManager txManager = databaseConfig.txManager(dataSource);
+        final TransactionTemplate txTemplate = databaseConfig.txTemplate(txManager);
+        assertNotNull(txTemplate);
+    }
+    
+    @Test
+    public void testFlyway() throws Exception {
+        final DataSource dataSource = databaseConfig.dataSource();
+        final Flyway flyway = databaseConfig.flyway(dataSource);
+        assertNotNull(flyway);
+    }
+
+    @Test
+    public void testDataSourceInvalidDbType() {
+        setField(databaseConfig, "dbUrl", "failtime");
+        assertThrows(IllegalArgumentException.class, () -> databaseConfig.dataSource());
+    }
+
+    @Test
+    public void testDataSourceDriverNotFound() {
+        setField(databaseConfig, "dbUrl", "oh:no");
+        assertThrows(IllegalStateException.class, () -> databaseConfig.dataSource());
+    }
+
+    @Test
+    public void testDataSourceWithCustomDbProperties() throws Exception {
+        final var propertiesPath = tmpDir.resolve("db.properties");
+
+        // Write basic properties to the file
+        Properties props = new Properties();
+        props.setProperty("driverClassName", "org.h2.Driver");
+        props.setProperty("maximumPoolSize", "15");
+        props.setProperty("connectionTimeout", "4000");
+
+        try (final OutputStream out = Files.newOutputStream(propertiesPath)) {
+            props.store(out, "Test hikari properties");
+        }
+
+        // Set the custom properties file path
+        setField(databaseConfig, "customDbProperties", propertiesPath.toString());
+
+        // Test the datasource creation with custom properties file
+        final DataSource dataSource = databaseConfig.dataSource();
+        assertNotNull(dataSource);
+        assertTrue(dataSource instanceof HikariDataSource);
+
+        final HikariDataSource hikariDs = (HikariDataSource) dataSource;
+        assertEquals("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", hikariDs.getJdbcUrl());
+        assertEquals("org.h2.Driver", hikariDs.getDriverClassName());
+        assertEquals(15, hikariDs.getMaximumPoolSize());
+        assertEquals(4000, hikariDs.getConnectionTimeout());
+    }
+    
+    @Test
+    public void testCustomPropertiesConfiguration() throws Exception {
+        setField(databaseConfig, "maxPoolSize", 20);
+        setField(databaseConfig, "checkoutTimeout", 5000);
+        
+        final DataSource dataSource = databaseConfig.dataSource();
+        assertNotNull(dataSource);
+        assertTrue(dataSource instanceof HikariDataSource);
+        
+        final HikariDataSource hikariDs = (HikariDataSource) dataSource;
+        assertEquals(20, hikariDs.getMaximumPoolSize());
+        assertEquals(5000, hikariDs.getConnectionTimeout());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/DatabaseConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/DatabaseConfigTest.java
@@ -97,19 +97,19 @@ public class DatabaseConfigTest {
         final DataSource dataSource = databaseConfig.dataSource();
         assertNotNull(dataSource);
         assertTrue(dataSource instanceof HikariDataSource);
-        
+
         final HikariDataSource hikariDs = (HikariDataSource) dataSource;
         assertEquals("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", hikariDs.getJdbcUrl());
         assertEquals("org.h2.Driver", hikariDs.getDriverClassName());
     }
-    
+
     @Test
     public void testTxManager() throws Exception {
         final DataSource dataSource = databaseConfig.dataSource();
         final PlatformTransactionManager txManager = databaseConfig.txManager(dataSource);
         assertNotNull(txManager);
     }
-    
+
     @Test
     public void testTxTemplate() throws Exception {
         final DataSource dataSource = databaseConfig.dataSource();
@@ -117,7 +117,7 @@ public class DatabaseConfigTest {
         final TransactionTemplate txTemplate = databaseConfig.txTemplate(txManager);
         assertNotNull(txTemplate);
     }
-    
+
     @Test
     public void testFlyway() throws Exception {
         final DataSource dataSource = databaseConfig.dataSource();
@@ -142,7 +142,7 @@ public class DatabaseConfigTest {
         final var propertiesPath = tmpDir.resolve("db.properties");
 
         // Write basic properties to the file
-        Properties props = new Properties();
+        final Properties props = new Properties();
         props.setProperty("driverClassName", "org.h2.Driver");
         props.setProperty("maximumPoolSize", "15");
         props.setProperty("connectionTimeout", "4000");
@@ -165,16 +165,16 @@ public class DatabaseConfigTest {
         assertEquals(15, hikariDs.getMaximumPoolSize());
         assertEquals(4000, hikariDs.getConnectionTimeout());
     }
-    
+
     @Test
     public void testCustomPropertiesConfiguration() throws Exception {
         setField(databaseConfig, "maxPoolSize", 20);
         setField(databaseConfig, "checkoutTimeout", 5000);
-        
+
         final DataSource dataSource = databaseConfig.dataSource();
         assertNotNull(dataSource);
         assertTrue(dataSource instanceof HikariDataSource);
-        
+
         final HikariDataSource hikariDs = (HikariDataSource) dataSource;
         assertEquals(20, hikariDs.getMaximumPoolSize());
         assertEquals(5000, hikariDs.getConnectionTimeout());

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/DigestAlgorithmTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/DigestAlgorithmTest.java
@@ -1,0 +1,141 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link DigestAlgorithm}
+ *
+ * @author bbpennel
+ */
+public class DigestAlgorithmTest {
+
+    @Test
+    public void testGetScheme() {
+        // Test standard algorithm names
+        assertEquals("urn:sha1", DigestAlgorithm.getScheme("SHA"));
+        assertEquals("urn:sha-256", DigestAlgorithm.getScheme("SHA-256"));
+        assertEquals("urn:sha-512", DigestAlgorithm.getScheme("SHA-512"));
+        assertEquals("urn:sha-512/256", DigestAlgorithm.getScheme("SHA-512/256"));
+        assertEquals("urn:md5", DigestAlgorithm.getScheme("MD5"));
+
+        // Test case insensitivity
+        assertEquals("urn:sha1", DigestAlgorithm.getScheme("sha"));
+        assertEquals("urn:sha-256", DigestAlgorithm.getScheme("sha-256"));
+
+        // Test without dashes
+        assertEquals("urn:sha-256", DigestAlgorithm.getScheme("SHA256"));
+        assertEquals("urn:sha-512", DigestAlgorithm.getScheme("SHA512"));
+
+        // Test unsupported algorithm
+        assertEquals("missing", DigestAlgorithm.getScheme("UNKNOWN"));
+    }
+
+    @Test
+    public void testFromScheme() {
+        // Test standard schemes
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromScheme("urn:sha1"));
+        assertEquals(DigestAlgorithm.SHA256, DigestAlgorithm.fromScheme("urn:sha-256"));
+        assertEquals(DigestAlgorithm.SHA512, DigestAlgorithm.fromScheme("urn:sha-512"));
+        assertEquals(DigestAlgorithm.SHA512256, DigestAlgorithm.fromScheme("urn:sha-512/256"));
+        assertEquals(DigestAlgorithm.MD5, DigestAlgorithm.fromScheme("urn:md5"));
+
+        // Test case insensitivity
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromScheme("URN:SHA1"));
+        assertEquals(DigestAlgorithm.SHA256, DigestAlgorithm.fromScheme("URN:SHA-256"));
+
+        // Test unsupported scheme
+        assertEquals(DigestAlgorithm.MISSING, DigestAlgorithm.fromScheme("urn:unknown"));
+    }
+
+    @Test
+    public void testFromAlgorithm() {
+        // Test standard algorithm names
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("SHA"));
+        assertEquals(DigestAlgorithm.SHA256, DigestAlgorithm.fromAlgorithm("SHA-256"));
+        assertEquals(DigestAlgorithm.SHA512, DigestAlgorithm.fromAlgorithm("SHA-512"));
+        assertEquals(DigestAlgorithm.SHA512256, DigestAlgorithm.fromAlgorithm("SHA-512/256"));
+        assertEquals(DigestAlgorithm.MD5, DigestAlgorithm.fromAlgorithm("MD5"));
+
+        // Test aliases
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("sha1"));
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("sha-1"));
+        assertEquals(DigestAlgorithm.SHA256, DigestAlgorithm.fromAlgorithm("sha256"));
+        assertEquals(DigestAlgorithm.SHA512, DigestAlgorithm.fromAlgorithm("sha512"));
+        assertEquals(DigestAlgorithm.SHA512256, DigestAlgorithm.fromAlgorithm("sha512/256"));
+
+        // Test case insensitivity
+        assertEquals(DigestAlgorithm.SHA1, DigestAlgorithm.fromAlgorithm("sha"));
+        assertEquals(DigestAlgorithm.SHA256, DigestAlgorithm.fromAlgorithm("Sha-256"));
+
+        // Test unsupported algorithm
+        assertEquals(DigestAlgorithm.MISSING, DigestAlgorithm.fromAlgorithm("UNKNOWN"));
+    }
+
+    @Test
+    public void testIsSupportedAlgorithm() {
+        // Test supported algorithms
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA-256"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA-512"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA-512/256"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("MD5"));
+
+        // Test case insensitivity
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("sha"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("sha-256"));
+
+        // Test without dashes
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA256"));
+        assertTrue(DigestAlgorithm.isSupportedAlgorithm("SHA512"));
+
+        // Test unsupported algorithm
+        assertFalse(DigestAlgorithm.isSupportedAlgorithm("UNKNOWN"));
+    }
+
+    @Test
+    public void testGetAliases() {
+        // SHA1 should have aliases: sha, sha1, sha-1
+        final var sha1Aliases = DigestAlgorithm.SHA1.getAliases();
+        assertTrue(sha1Aliases.contains("sha"));
+        assertTrue(sha1Aliases.contains("sha1"));
+        assertTrue(sha1Aliases.contains("sha-1"));
+
+        // SHA256 should have aliases: sha-256, sha256
+        final var sha256Aliases = DigestAlgorithm.SHA256.getAliases();
+        assertTrue(sha256Aliases.contains("sha-256"));
+        assertTrue(sha256Aliases.contains("sha256"));
+
+        // SHA512 should have aliases: sha-512, sha512
+        final var sha512Aliases = DigestAlgorithm.SHA512.getAliases();
+        assertTrue(sha512Aliases.contains("sha-512"));
+        assertTrue(sha512Aliases.contains("sha512"));
+
+        // SHA512256 should have aliases: sha-512/256, sha512/256
+        final var sha512256Aliases = DigestAlgorithm.SHA512256.getAliases();
+        assertTrue(sha512256Aliases.contains("sha-512/256"));
+        assertTrue(sha512256Aliases.contains("sha512/256"));
+
+        // MD5 should have alias: md5
+        final var md5Aliases = DigestAlgorithm.MD5.getAliases();
+        assertTrue(md5Aliases.contains("md5"));
+    }
+
+    @Test
+    public void testGetAlgorithm() {
+        assertEquals("SHA", DigestAlgorithm.SHA1.getAlgorithm());
+        assertEquals("SHA-256", DigestAlgorithm.SHA256.getAlgorithm());
+        assertEquals("SHA-512", DigestAlgorithm.SHA512.getAlgorithm());
+        assertEquals("SHA-512/256", DigestAlgorithm.SHA512256.getAlgorithm());
+        assertEquals("MD5", DigestAlgorithm.MD5.getAlgorithm());
+        assertEquals("NONE", DigestAlgorithm.MISSING.getAlgorithm());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/FedoraPropsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/FedoraPropsConfigTest.java
@@ -1,0 +1,221 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+/**
+ * @author bbpennel
+ */
+public class FedoraPropsConfigTest {
+
+    private FedoraPropsConfig config;
+    private GenericApplicationContext context;
+    private MockEnvironment env;
+
+    @BeforeEach
+    public void setUp() {
+        config = new FedoraPropsConfig();
+        env = new MockEnvironment();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    private void initializeContext() {
+        context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(env);
+        context.registerBean(FedoraPropsConfig.class);
+    }
+
+    private void initializeConfig() {
+        context.refresh();
+        config = context.getBean(FedoraPropsConfig.class);
+    }
+
+    @Test
+    public void testDefaultValues() {
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(Paths.get("fcrepo-home"), config.getFedoraHome());
+        assertEquals(Paths.get("fcrepo-home/data"), config.getFedoraData());
+        assertEquals(Paths.get("fcrepo-home/logs"), config.getFedoraLogs());
+        assertEquals("localhost", config.getJmsHost());
+        assertEquals("61616", config.getJmsPort());
+        assertEquals("61613", config.getStompPort());
+        assertNotNull(config.getActiveMQConfiguration());
+        assertEquals(Paths.get("fcrepo-home/data/ActiveMQ/kahadb").toAbsolutePath().toString(),
+                config.getActiveMqDirectory());
+        assertEquals("classpath:/namespaces.yml", config.getNamespaceRegistry());
+        assertNull(config.getExternalContentAllowed());
+        assertEquals(Duration.ofMillis(180000), config.getSessionTimeout());
+        assertEquals(Paths.get("fcrepo-home/logs/velocity.log"), config.getVelocityLog());
+        assertTrue(config.isRebuildValidation());
+        assertFalse(config.isRebuildFixityCheck());
+        assertFalse(config.isRebuildOnStart());
+        assertFalse(config.isRebuildContinue());
+        assertNull(config.getJmsBaseUrl());
+        assertEquals(ServerManagedPropsMode.STRICT, config.getServerManagedPropsMode());
+        assertEquals(JmsDestination.TOPIC, config.getJmsDestinationType());
+        assertEquals("fedora", config.getJmsDestinationName());
+        assertEquals(1, config.getEventBusThreads());
+        assertEquals(1024L, config.getContainmentCacheSize());
+        assertEquals(10L, config.getContainmentCacheTimeout());
+        assertEquals(1024L, config.getUserTypesCacheSize());
+        assertEquals(10L, config.getUserTypesCacheTimeout());
+        assertEquals(1024L, config.getWebacCacheSize());
+        assertEquals(10L, config.getWebacCacheTimeout());
+        assertTrue(config.getBannerEnabled());
+        assertEquals(0, config.getFcrepoPidMinterLength());
+        assertEquals(0, config.getFcrepoPidMinterCount());
+        assertFalse(config.includeTransactionOnConflict());
+    }
+
+    @Test
+    public void testSetters() {
+        // Test setFedoraHome
+        final Path newHome = Paths.get("/new/home");
+        config.setFedoraHome(newHome);
+        assertEquals(newHome, config.getFedoraHome());
+
+        // Test setFedoraData
+        final Path newData = Paths.get("/new/data");
+        config.setFedoraData(newData);
+        assertEquals(newData, config.getFedoraData());
+
+        // Test setSessionTimeout
+        final Duration newTimeout = Duration.ofSeconds(30);
+        config.setSessionTimeout(newTimeout);
+        assertEquals(newTimeout, config.getSessionTimeout());
+
+        // Test setRebuildOnStart
+        config.setRebuildOnStart(true);
+        assertTrue(config.isRebuildOnStart());
+
+        // Test setRebuildContinue
+        config.setRebuildContinue(true);
+        assertTrue(config.isRebuildContinue());
+
+        // Test setServerManagedPropsMode
+        config.setServerManagedPropsMode(ServerManagedPropsMode.RELAXED);
+        assertEquals(ServerManagedPropsMode.RELAXED, config.getServerManagedPropsMode());
+
+        // Test setUserTypesCacheSize
+        config.setUserTypesCacheSize(2048L);
+        assertEquals(2048L, config.getUserTypesCacheSize());
+
+        // Test setUserTypesCacheTimeout
+        config.setUserTypesCacheTimeout(20L);
+        assertEquals(20L, config.getUserTypesCacheTimeout());
+
+        // Test setFcrepoPidMinterLength
+        config.setFcrepoPidMinterLength(8);
+        assertEquals(8, config.getFcrepoPidMinterLength());
+
+        // Test setFcrepoPidMinterCount
+        config.setFcrepoPidMinterCount(2);
+        assertEquals(2, config.getFcrepoPidMinterCount());
+
+        // Test setIncludeTransactionOnConflict
+        config.setIncludeTransactionOnConflict(true);
+        assertTrue(config.includeTransactionOnConflict());
+    }
+
+    @Test
+    public void testCheckRebuildPropsValidationFalse() {
+        // Valid case - both false
+        env.setProperty("fcrepo.rebuild.validation", "false");
+        env.setProperty("fcrepo.rebuild.validation.fixity", "false");
+        initializeContext();
+        initializeConfig();
+
+        assertFalse(config.isRebuildValidation());
+        assertFalse(config.isRebuildFixityCheck());
+    }
+
+    @Test
+    public void testCheckRebuildPropsValidationTrue() {
+        // Valid case - both false
+        env.setProperty("fcrepo.rebuild.validation", "true");
+        env.setProperty("fcrepo.rebuild.validation.fixity", "true");
+        initializeContext();
+        initializeConfig();
+
+        assertTrue(config.isRebuildValidation());
+        assertTrue(config.isRebuildFixityCheck());
+    }
+
+    @Test
+    public void testCheckRebuildPropsValidationFixityTrueValidationFalse() {
+        // Invalid case - validation must be true if fixity is true
+        env.setProperty("fcrepo.rebuild.validation", "false");
+        env.setProperty("fcrepo.rebuild.validation.fixity", "true");
+        initializeContext();
+        final var exception = assertThrows(BeanCreationException.class, this::initializeConfig);
+        assertInstanceOf(IllegalStateException.class, exception.getCause());
+    }
+
+    @Test
+    public void testCheckRebuildPropsValidationFixityFalseValidationTrue() {
+        // Valid case
+        env.setProperty("fcrepo.rebuild.validation", "true");
+        env.setProperty("fcrepo.rebuild.validation.fixity", "false");
+        initializeContext();
+        initializeConfig();
+        assertTrue(config.isRebuildValidation());
+        assertFalse(config.isRebuildFixityCheck());
+    }
+
+    @Test
+    public void testEventBusThreadsWithZero() {
+        env.setProperty("fcrepo.event.threads", "0");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(1, config.getEventBusThreads());
+    }
+
+    @Test
+    public void testEventBusThreadsWitNegative() {
+        env.setProperty("fcrepo.event.threads", "-1");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(1, config.getEventBusThreads());
+    }
+
+    @Test
+    public void testEventBusThreadsWitPositive() {
+        env.setProperty("fcrepo.event.threads", "5");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(5, config.getEventBusThreads());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/MetricsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/MetricsConfigTest.java
@@ -1,0 +1,114 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author bbpennel
+ */
+public class MetricsConfigTest {
+
+    private MetricsConfig config;
+    private GenericApplicationContext context;
+    private MockEnvironment env;
+
+    @BeforeEach
+    public void setUp() {
+        env = new MockEnvironment();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    private void initializeContext() {
+        context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(env);
+        context.registerBean(MetricsConfig.class);
+    }
+
+    private void initializeConfig() {
+        context.refresh();
+        config = context.getBean(MetricsConfig.class);
+    }
+
+    @Test
+    public void testDefaultMetricsDisabled() {
+        // Default state should have metrics disabled
+        initializeContext();
+        initializeConfig();
+
+        assertFalse(config.isMetricsEnabled());
+
+        // When metrics are disabled, a SimpleMeterRegistry should be returned
+        final MeterRegistry registry = context.getBean(MeterRegistry.class);
+        assertNotNull(registry);
+        assertInstanceOf(SimpleMeterRegistry.class, registry);
+
+        // CollectorRegistry should default to the default registry
+        final CollectorRegistry collectorRegistry = context.getBean(CollectorRegistry.class);
+        assertNotNull(collectorRegistry);
+        assertEquals(CollectorRegistry.defaultRegistry, collectorRegistry);
+    }
+
+    @Test
+    public void testMetricsEnabled() {
+        env.setProperty("fcrepo.metrics.enable", "true");
+        initializeContext();
+        initializeConfig();
+
+        assertTrue(config.isMetricsEnabled());
+
+        // When metrics are enabled, a PrometheusMeterRegistry should be returned
+        final MeterRegistry registry = context.getBean(MeterRegistry.class);
+        assertNotNull(registry);
+        assertInstanceOf(PrometheusMeterRegistry.class, registry);
+
+        // CollectorRegistry should be the Prometheus registry
+        final CollectorRegistry collectorRegistry = context.getBean(CollectorRegistry.class);
+        assertNotNull(collectorRegistry);
+        assertEquals(((PrometheusMeterRegistry) registry).getPrometheusRegistry(), collectorRegistry);
+
+        // Verify the registry has the JVM metrics registered
+        assertFalse(registry.getMeters().isEmpty());
+    }
+
+    @Test
+    public void testTimerMetricsConfiguration() {
+        env.setProperty("fcrepo.metrics.enable", "true");
+        initializeContext();
+        initializeConfig();
+
+        final MeterRegistry registry = context.getBean(MeterRegistry.class);
+        assertInstanceOf(PrometheusMeterRegistry.class, registry);
+
+        // Create a timer to test the configuration
+        registry.timer("test.timer");
+
+        // Timer should be created and present in the registry
+        assertNotNull(registry.find("test.timer").timer());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/OcflPropsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/OcflPropsConfigTest.java
@@ -1,0 +1,235 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Test for {@link OcflPropsConfig}
+ *
+ * @author bbpennel
+ */
+public class OcflPropsConfigTest {
+
+    private OcflPropsConfig config;
+    private GenericApplicationContext context;
+    private MockEnvironment env;
+
+    @BeforeEach
+    public void setUp() {
+        config = new OcflPropsConfig();
+        env = new MockEnvironment();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    private void initializeContext() {
+        context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(env);
+        context.registerBean(FedoraPropsConfig.class);
+        context.registerBean(OcflPropsConfig.class);
+    }
+
+    private void initializeConfig() {
+        context.refresh();
+        config = context.getBean(OcflPropsConfig.class);
+    }
+
+    @Test
+    public void testDefaultValues() {
+        env.setProperty("fcrepo.home", "fcrepo-home");
+        initializeContext();
+        initializeConfig();
+
+        // Default paths
+        assertEquals(Paths.get("fcrepo-home/data/staging"), config.getFedoraOcflStaging());
+        assertEquals(Paths.get("fcrepo-home/data/ocfl-root"), config.getOcflRepoRoot());
+        assertEquals(Paths.get("fcrepo-home/data/ocfl-temp"), config.getOcflTemp());
+
+        // Default configurations
+        assertTrue(config.isAutoVersioningEnabled());
+        assertEquals(Storage.OCFL_FILESYSTEM, config.getStorage());
+        assertTrue(config.isResourceHeadersCacheEnabled());
+        assertEquals(512, config.getResourceHeadersCacheMaxSize());
+        assertEquals(600, config.getResourceHeadersCacheExpireAfterSeconds());
+        assertTrue(config.isReindexFailOnError());
+        assertEquals(100, config.getReindexBatchSize());
+        assertEquals(DigestAlgorithm.SHA512, config.getDefaultDigestAlgorithm());
+        assertFalse(config.isPathStyleAccessEnabled());
+        assertTrue(config.isOcflS3DbEnabled());
+        assertFalse(config.isUnsafeWriteEnabled());
+        assertEquals(1024, config.getFedoraToOcflCacheSize());
+        assertEquals(30, config.getFedoraToOcflCacheTimeout());
+        assertFalse(config.isOcflUpgradeOnWrite());
+        assertTrue(config.verifyInventory());
+        assertEquals(60, config.getS3ConnectionTimeout());
+        assertEquals(60, config.getS3WriteTimeout());
+        assertEquals(60, config.getS3ReadTimeout());
+        assertEquals(100, config.getS3MaxConcurrency());
+        assertTrue(config.isOcflS3ChecksumEnabled());
+        assertFalse(config.isShowPath());
+    }
+
+    @Test
+    public void testSetters() {
+        // Test path setters
+        final Path newStaging = Paths.get("/new/staging");
+        config.setFedoraOcflStaging(newStaging);
+        assertEquals(newStaging, config.getFedoraOcflStaging());
+
+        final Path newRoot = Paths.get("/new/root");
+        config.setOcflRepoRoot(newRoot);
+        assertEquals(newRoot, config.getOcflRepoRoot());
+
+        final Path newTemp = Paths.get("/new/temp");
+        config.setOcflTemp(newTemp);
+        assertEquals(newTemp, config.getOcflTemp());
+
+        // Test config setters
+        config.setAutoVersioningEnabled(false);
+        assertFalse(config.isAutoVersioningEnabled());
+
+        config.setStorage(Storage.OCFL_S3);
+        assertEquals(Storage.OCFL_S3, config.getStorage());
+
+        config.setAwsAccessKey("testAccessKey");
+        assertEquals("testAccessKey", config.getAwsAccessKey());
+
+        config.setAwsSecretKey("testSecretKey");
+        assertEquals("testSecretKey", config.getAwsSecretKey());
+
+        config.setAwsRegion("us-west-2");
+        assertEquals("us-west-2", config.getAwsRegion());
+
+        config.setOcflS3Bucket("test-bucket");
+        assertEquals("test-bucket", config.getOcflS3Bucket());
+
+        config.setOcflS3Prefix("test-prefix");
+        assertEquals("test-prefix", config.getOcflS3Prefix());
+
+        config.setResourceHeadersCacheEnabled(false);
+        assertFalse(config.isResourceHeadersCacheEnabled());
+
+        config.setResourceHeadersCacheMaxSize(1000);
+        assertEquals(1000, config.getResourceHeadersCacheMaxSize());
+
+        config.setResourceHeadersCacheExpireAfterSeconds(1800);
+        assertEquals(1800, config.getResourceHeadersCacheExpireAfterSeconds());
+
+        config.setReindexingThreads(5);
+        assertEquals(5, config.getReindexingThreads());
+
+        config.setReindexBatchSize(200);
+        assertEquals(200, config.getReindexBatchSize());
+
+        config.setReindexFailOnError(false);
+        assertFalse(config.isReindexFailOnError());
+    }
+
+    @Test
+    public void testReindexThreadsWithZero() {
+        env.setProperty("fcrepo.ocfl.reindex.threads", "0");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(1, config.getReindexingThreads());
+    }
+
+    @Test
+    public void testReindexThreadsWithNegative() {
+        env.setProperty("fcrepo.ocfl.reindex.threads", "-1");
+        initializeContext();
+        initializeConfig();
+
+        // Should be set to default value (CPU cores - 1, minimum 1)
+        final long expected = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
+        assertEquals(expected, config.getReindexingThreads());
+    }
+
+    @Test
+    public void testReindexThreadsWithPositive() {
+        env.setProperty("fcrepo.ocfl.reindex.threads", "5");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(5, config.getReindexingThreads());
+    }
+
+    @Test
+    public void testS3StorageWithoutBucket() {
+        env.setProperty("fcrepo.storage", "ocfl-s3");
+        initializeContext();
+
+        // Should throw exception when S3 storage is configured without a bucket
+        final var exception = assertThrows(BeanCreationException.class, this::initializeConfig);
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    }
+
+    @Test
+    public void testS3StorageWithBucket() {
+        env.setProperty("fcrepo.storage", "ocfl-s3");
+        env.setProperty("fcrepo.ocfl.s3.bucket", "test-bucket");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(Storage.OCFL_S3, config.getStorage());
+        assertEquals("test-bucket", config.getOcflS3Bucket());
+    }
+
+    @Test
+    public void testInvalidDigestAlgorithm() {
+        env.setProperty("fcrepo.persistence.defaultDigestAlgorithm", "md5");
+        initializeContext();
+
+        // Should throw exception when an invalid digest algorithm is provided
+        final var exception = assertThrows(BeanCreationException.class, this::initializeConfig);
+        assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    }
+
+    @Test
+    public void testValidDigestAlgorithm() {
+        env.setProperty("fcrepo.persistence.defaultDigestAlgorithm", "sha256");
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(DigestAlgorithm.SHA256, config.getDefaultDigestAlgorithm());
+    }
+
+    @Test
+    public void testOverrideDefaultPaths() {
+        env.setProperty("fcrepo.home", "custom/home");
+        env.setProperty("fcrepo.ocfl.staging", "custom/staging");
+        env.setProperty("fcrepo.ocfl.root", "custom/root");
+        env.setProperty("fcrepo.ocfl.temp", "custom/temp");
+
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(Paths.get("custom/staging"), config.getFedoraOcflStaging());
+        assertEquals(Paths.get("custom/root"), config.getOcflRepoRoot());
+        assertEquals(Paths.get("custom/temp"), config.getOcflTemp());
+    }
+}

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/SystemInfoConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/SystemInfoConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author bbpennel
+ */
+public class SystemInfoConfigTest {
+
+    private SystemInfoConfig config;
+    private GenericApplicationContext context;
+    private MockEnvironment env;
+
+    @BeforeEach
+    public void setUp() {
+        env = new MockEnvironment();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    private void initializeContext() {
+        context = new AnnotationConfigApplicationContext();
+        context.setEnvironment(env);
+        context.registerBean(SystemInfoConfig.class);
+    }
+
+    private void initializeConfig() {
+        context.refresh();
+        config = context.getBean(SystemInfoConfig.class);
+    }
+
+    @Test
+    public void testDefaultValues() {
+        initializeContext();
+        initializeConfig();
+
+        assertEquals("", config.getGitCommit());
+        assertNotNull(config.getImplementationVersion());
+    }
+
+    @Test
+    public void testGitCommitProperty() {
+        final String testCommit = "abc1234";
+        env.setProperty(SystemInfoConfig.GIT_COMMIT, testCommit);
+
+        initializeContext();
+        initializeConfig();
+
+        assertEquals(testCommit, config.getGitCommit());
+    }
+
+    @Test
+    public void testImplementationVersion() {
+        initializeContext();
+        initializeConfig();
+
+        // This method should never return null, but may return empty string in test context
+        assertNotNull(config.getImplementationVersion());
+    }
+
+    /**
+     * Mock implementation to test the behavior when package has an implementation version
+     */
+    @Test
+    public void testImplementationVersionWithMock() {
+        // Create a custom subclass to override the getImplementationVersion method
+        // to simulate a case where the package has a version
+        class MockSystemInfoConfig extends SystemInfoConfig {
+            @Override
+            public String getImplementationVersion() {
+                return "1.2.3";
+            }
+        }
+
+        final MockSystemInfoConfig mockConfig = new MockSystemInfoConfig();
+        assertEquals("1.2.3", mockConfig.getImplementationVersion());
+    }
+}


### PR DESCRIPTION

**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2164

# What does this Pull Request do?
Adds test coverage for fcrepo-configs

Minor adjustment to validation of s3 properties so it will disallow blank ocflS3Bucket when s3 is enabled. In tests, ocflS3Bucket was defaulting to "" rather than null.

# How should this be tested?

Run the tests.
