### PR TITLE
2157 - Update logback to 1.4 and slf4j to 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jgroups.version>5.1.9.Final</jgroups.version>
     <jsonld.version>0.13.6</jsonld.version>
-    <logback.version>1.5.18</logback.version>
+    <logback.version>1.4.14</logback.version>
     <micrometer.version>1.7.4</micrometer.version>
     <netty.version>4.1.68.Final</netty.version>
     <ocfl-java.version>2.2.1</ocfl-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
     <jetty.version>9.4.44.v20210927</jetty.version>
     <jgroups.version>5.1.9.Final</jgroups.version>
     <jsonld.version>0.13.6</jsonld.version>
-    <logback.version>1.2.13</logback.version>
+    <logback.version>1.5.18</logback.version>
     <micrometer.version>1.7.4</micrometer.version>
     <netty.version>4.1.68.Final</netty.version>
     <ocfl-java.version>2.2.1</ocfl-java.version>
     <prometheus.version>0.10.0</prometheus.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <shiro.version>1.13.0</shiro.version>
-    <slf4j.version>1.7.32</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <spring.version>5.3.39</spring.version>
     <xerces.version>2.12.2</xerces.version>
     <xml-apis.version>1.4.01</xml-apis.version>


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2157

# What does this Pull Request do?
Updates logback to most recent 1.4.x and slf4j to most recent 2.0.x

Note: 1.5.x is the most recent logback series, but it conflicts with dependencies in the older version of jetty we are currently using, causing some ITs to fail. So we can circle back to logback after updating jetty in 
