### PR TITLE
2152 - Upgrade to hamcrest 3

### DIFF
--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -108,12 +108,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>

--- a/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/fcrepo-auth-webac/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -58,9 +58,7 @@ import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 
 import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -95,9 +93,6 @@ public class WebACRolesProviderTest {
 
     @Mock
     private FedoraResource mockAgentClassResource;
-
-    @Rule
-    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     private AuthPropsConfig propsConfig;
 

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -98,7 +98,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fcrepo-stats-api/pom.xml
+++ b/fcrepo-stats-api/pom.xml
@@ -28,13 +28,13 @@
 
     <!-- test gear -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <flyway.test.version>9.5.0</flyway.test.version>
     <guava.version>32.0.0-jre</guava.version>
     <h2database.version>2.2.220</h2database.version>
+    <hamcrest.version>3.0</hamcrest.version>
     <hikari.version>5.0.0</hikari.version>
     <hk2.version>2.6.1</hk2.version>
     <htmlunit.version>2.53.0</htmlunit.version>
@@ -74,11 +75,10 @@
     <mysql.version>8.0.28</mysql.version>
     <mariadb.version>2.7.4</mariadb.version>
     <!-- test gear -->
-    <awaitility.version>4.1.0</awaitility.version>
+    <awaitility.version>4.3.0</awaitility.version>
     <grizzly.version>2.4.4</grizzly.version>
     <junit.version>4.13.2</junit.version>
     <junit5.version>5.11.4</junit5.version>
-    <system-rules.version>1.19.0</system-rules.version>
     <mockito.version>5.17.0</mockito.version>
     <mockito.junit5.version>5.17.0</mockito.junit5.version>
     <!-- fcrepo5-specific plugins -->
@@ -623,14 +623,8 @@
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-all</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.github.stefanbirkner</groupId>
-        <artifactId>system-rules</artifactId>
-        <version>${system-rules.version}</version>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -650,14 +644,6 @@
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
-        <exclusions>
-          <!-- mockito-core depends on hamcrest-core-1.0, but junit pulls
-            in the more recent 1.3 -->
-          <exclusion>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2152

# What does this Pull Request do?
* Upgrade to hamcrest 3. 
* Remove system-rules which was no longer doing anything and pulling in old hamcrest. 
* Update awaitility

Note: there are still a few dependencies that pull in hamcrest 1.3, mainly jersey-test-framework-provider-grizzly2. We will want to upgrade that once we move over to the jakarta libraries. There is also ldp-testsuite which is the backbone of fcrepo-integration-ldp, but hasn't been updated since 2014. We'll need to decide what to do about that at some point.


# How should this be tested?

These are all test dependencies, so just running the tests.