### PR TITLE
Need to use Java 21 to deploy a 21 release

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -167,7 +167,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 21
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
**JIRA Ticket**: 


# What does this Pull Request do?
The big PR failed it's deploy stage with the error
```bash
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project fcrepo-common: Fatal error compiling: error: release version 21 not supported -> [Help 1]
```
This is because the deploy stage is using Java 11 and can't deploy a Java 21 target. This updates the java version.

# How should this be tested?

When this PR is merged, the deploy of the SNAPSHOT artifact should succeed.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
