### PR TITLE
GH-2128 - Update to guava 33

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/MembershipServiceImpl.java
@@ -29,7 +29,7 @@ import org.fcrepo.kernel.api.services.MembershipService;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 import jakarta.inject.Inject;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/api/FedoraToOcflObjectIndex.java
@@ -5,7 +5,7 @@
  */
 package org.fcrepo.persistence.ocfl.api;
 
-import javax.annotation.Nonnull;
+import jakarta.annotation.Nonnull;
 
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <failsafe.version>2.4.4</failsafe.version>
     <flyway.version>11.8.2</flyway.version>
     <flyway.test.version>10.0.0</flyway.test.version>
-    <guava.version>32.0.0-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
     <h2database.version>2.2.220</h2database.version>
     <hamcrest.version>3.0</hamcrest.version>
     <hikari.version>5.0.0</hikari.version>


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2128

* Update to guava 33.
* Replace javax.annotation with jakarta.annotation, since guava is no longer transitively pulling in javax.annotation