### PR TITLE
GH-2229 - Update git-commit-id-maven-plugin to 9.0.2. This requires maven 3.6.3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -799,7 +799,7 @@
         <plugin>
           <groupId>io.github.git-commit-id</groupId>
           <artifactId>git-commit-id-maven-plugin</artifactId>
-          <version>5.0.0</version>
+          <version>9.0.2</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2229

* Update git-commit-id-maven-plugin to 9.0.2. 

***NOTE**:* This requires maven 3.6.3+. https://github.com/git-commit-id/git-commit-id-maven-plugin/releases/tag/v9.0.0