### PR TITLE
GH-2218 - Upgrade to htmlunit 4.4

### DIFF
--- a/fcrepo-http-api/src/test/resources/logback-test.xml
+++ b/fcrepo-http-api/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="com.gargoylesoftware.htmlunit" additivity="false" level="ERROR">
+  <logger name="org.htmlunit" additivity="false" level="ERROR">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.glassfish" additivity="false" level="ERROR">

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -161,7 +161,7 @@
 
     <!-- test gear -->
     <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
+      <groupId>org.htmlunit</groupId>
       <artifactId>htmlunit</artifactId>
       <scope>test</scope>
       <version>${htmlunit.version}</version>

--- a/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
+++ b/fcrepo-webapp/src/test/java/org/fcrepo/integration/FedoraHtmlResponsesIT.java
@@ -214,7 +214,6 @@ public class FedoraHtmlResponsesIT extends AbstractResourceIT {
 
         final String pid = createNewObject();
         final HtmlPage page = webClient.getPage(serverAddress + pid);
-//        System.out.println("Page: " + page.asXml());
         final HtmlForm action_delete = page.getFormByName("action_delete");
         action_delete.getButtonByName("delete-button").click();
         webClient.waitForBackgroundJavaScript(1000);

--- a/fcrepo-webapp/src/test/resources/logback-test.xml
+++ b/fcrepo-webapp/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
   <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">
     <appender-ref ref="STDOUT"/>
   </logger>
-  <logger name="com.gargoylesoftware.htmlunit" additivity="false" level="ERROR">
+  <logger name="org.htmlunit" additivity="false" level="ERROR">
     <appender-ref ref="STDOUT"/>
   </logger>
   <logger name="org.glassfish" additivity="false" level="ERROR">

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
     <hamcrest.version>3.0</hamcrest.version>
     <hikari.version>5.0.0</hikari.version>
     <hk2.version>3.1.1</hk2.version>
-    <htmlunit.version>2.53.0</htmlunit.version>
+    <!-- Last version that supports our version of jquery -->
+    <htmlunit.version>4.4.0</htmlunit.version>
     <httpclient.version>4.5.14</httpclient.version>
     <httpmime.version>4.5.14</httpmime.version>
     <httpcore.version>4.4.16</httpcore.version>


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/fcrepo/fcrepo/issues/2218

* Upgrades htmlunit from version 2 to 4.4. 
    * The most recent version is 4.13, but 4.5+ all fail because of an error parsing/executing jquery 1.12 which is used in the UI. We could probably upgrade further if we upgraded jquery, but I assume we are not going to prioritize that since we are planning to replace the UI.