### PR TITLE
Use separate queries per DB for containment, ocfl, and references

### DIFF
--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ReferenceServiceImpl.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import javax.sql.DataSource;
 
+import org.fcrepo.common.db.DbPlatform;
 import org.fcrepo.kernel.api.ContainmentIndex;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
@@ -156,6 +157,29 @@ public class ReferenceServiceImpl implements ReferenceService {
             " t." + SUBJECT_COLUMN + " = " + TABLE_NAME + "." + SUBJECT_COLUMN +
             " AND t." + PROPERTY_COLUMN + " = " + TABLE_NAME + "." + PROPERTY_COLUMN +
             " AND t." + TARGET_COLUMN + " = " + TABLE_NAME + "." + TARGET_COLUMN + ")";
+    private static final String COMMIT_DELETE_RECORD_POSTGRES = "DELETE FROM " + TABLE_NAME + " r" +
+            " USING " + TRANSACTION_TABLE + " rto" +
+            " WHERE r." + RESOURCE_COLUMN + " = rto." + RESOURCE_COLUMN +
+            " AND r." + SUBJECT_COLUMN + " = rto." + SUBJECT_COLUMN +
+            " AND r." + PROPERTY_COLUMN + " = rto." + PROPERTY_COLUMN +
+            " AND r." + TARGET_COLUMN + " = rto." + TARGET_COLUMN +
+            " AND rto." + TRANSACTION_COLUMN + " = :transactionId" +
+            " AND rto." + OPERATION_COLUMN + " = 'delete'";
+    private static final String COMMIT_DELETE_RECORD_MYSQL = "DELETE r" +
+            " FROM " + TABLE_NAME + " r" +
+            " INNER JOIN " + TRANSACTION_TABLE + " rto" +
+            " ON r." + RESOURCE_COLUMN + " = rto." + RESOURCE_COLUMN +
+            " AND r." + SUBJECT_COLUMN + " = rto." + SUBJECT_COLUMN +
+            " AND r." + PROPERTY_COLUMN + " = rto." + PROPERTY_COLUMN +
+            " AND r." + TARGET_COLUMN + " = rto." + TARGET_COLUMN +
+            " WHERE rto." + TRANSACTION_COLUMN + " = :transactionId" +
+            " AND rto." + OPERATION_COLUMN + " = 'delete'";
+    private static final Map<DbPlatform, String> COMMIT_DELETE_RECORD_MAP = Map.of(
+            DbPlatform.POSTGRESQL, COMMIT_DELETE_RECORD_POSTGRES,
+            DbPlatform.MYSQL, COMMIT_DELETE_RECORD_MYSQL,
+            DbPlatform.MARIADB, COMMIT_DELETE_RECORD_MYSQL,
+            DbPlatform.H2, COMMIT_DELETE_RECORDS
+            );
 
     private static final String DELETE_TRANSACTION = "DELETE FROM " + TRANSACTION_TABLE + " WHERE " +
             TRANSACTION_COLUMN + " = :transactionId";
@@ -163,8 +187,11 @@ public class ReferenceServiceImpl implements ReferenceService {
     private static final String TRUNCATE_TABLE = "TRUNCATE TABLE " + TABLE_NAME;
     private static final String TRUNCATE_TX_TABLE = "TRUNCATE TABLE " + TRANSACTION_TABLE;
 
+    private DbPlatform dbPlatform;
+
     @PostConstruct
     public void setUp() {
+        dbPlatform = DbPlatform.fromDataSource(dataSource);
         jdbcTemplate = new NamedParameterJdbcTemplate(getDataSource());
     }
 
@@ -295,7 +322,7 @@ public class ReferenceServiceImpl implements ReferenceService {
             tx.ensureCommitting();
             try {
                 final Map<String, String> parameterSource = Map.of("transactionId", tx.getId());
-                jdbcTemplate.update(COMMIT_DELETE_RECORDS, parameterSource);
+                jdbcTemplate.update(COMMIT_DELETE_RECORD_MAP.get(dbPlatform), parameterSource);
                 jdbcTemplate.update(COMMIT_ADD_RECORDS, parameterSource);
                 jdbcTemplate.update(DELETE_TRANSACTION, parameterSource);
             } catch (final Exception e) {


### PR DESCRIPTION
# What does this Pull Request do?
Adds separate queries for mysql/mariadb and postgres during transaction commit for three queries that were taking the most time when testing with a few million resource test set.

I was primarily monitoring performance of these queries in mariadb due to the test dataset. On my old laptop these queries took around 7-8s for committing a single newly created resource (on a newer m3 laptop they only take a bit over a second). After updating they only take a few milliseconds.

# How should this be tested?

Build should pass with all DBs.

For what it's worth, I tested with the following steps
```
# Create VM
docker run --name mariadb-container --platform=linux/arm64 --env MARIADB_ROOT_PASSWORD=my-secret-pw -p 3306:3306 -d mariadb:latest

# Start fedora with clean DB
mvn -Djetty.http.idleTimeout=300000 -Dfcrepo.dynamic.test.port=8088 -Dfcrepo.rebuild.on.start=false -Dfcrepo.db.url=jdbc:mariadb://localhost:3306/fcrepo -Dfcrepo.db.user=root -Dfcrepo.db.password=my-secret-pw clean jetty:run -pl fcrepo-webapp

# Import the data after fedora has started up
docker exec -i mariadb-container mariadb -u root -pmy-secret-pw -e "DROP DATABASE fcrepo;"
docker exec -i mariadb-container mariadb -u root -pmy-secret-pw -e "CREATE DATABASE fcrepo;"

# Reload the test data
{ echo "SET FOREIGN_KEY_CHECKS = 0;"; grep -E "^INSERT" /path/to/fedoradb_insertonly.sql; echo "SET FOREIGN_KEY_CHECKS = 1;"; } | docker exec -i mariadb-container mariadb -u root -pmy-secret-pw fcrepo -f


# Enabling slow query logging

docker exec -i mariadb-container mariadb -u root -pmy-secret-pw fcrepo -e "SET GLOBAL slow_query_log = 'ON';"
docker exec -i mariadb-container mariadb -u root -pmy-secret-pw fcrepo -e "SET GLOBAL long_query_time = 0.1;";
docker exec -i mariadb-container mariadb -u root -pmy-secret-pw fcrepo -e "SET GLOBAL log_queries_not_using_indexes = 1;";

docker exec -i mariadb-container mariadb -u root -pmy-secret-pw fcrepo -e "SELECT @@slow_query_log_file;";


# TX and create resources

curl -ufedoraAdmin:fedoraAdmin -i -X POST "http://localhost:8088/rest/fcr:tx"
# create a single resource
curl -ufedoraAdmin:fedoraAdmin -H"Atomic-ID: http://localhost:8088/rest/fcr:tx/f92bb503-f80e-4f79-a820-2beb47a68cae" -X POST "http://localhost:8088/rest/"
# commit
time curl -ufedoraAdmin:fedoraAdmin -X PUT "http://localhost:8088/rest/fcr:tx/f92bb503-f80e-4f79-a820-2beb47a68cae"

# alternatively, create 500 resources
for run in {1..500}; do
  curl -ufedoraAdmin:fedoraAdmin -H"Atomic-ID: http://localhost:8088/rest/fcr:tx/157b059e-ec6f-46d0-900f-3242eb9ca3cc" -X POST "http://localhost:8088/rest/"
done

# alternatively, cancel tx
time curl -ufedoraAdmin:fedoraAdmin -XDELETE http://localhost:8088/rest/fcr:tx/741d3fea-6eb7-4832-ab09-a8eb029a7cfb
```

# Interested parties
@fcrepo/committers
