### PR TITLE
Adding support for fcrepo.metrics.enabled

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/MetricsConfig.java
@@ -32,13 +32,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class MetricsConfig extends BasePropsConfig {
 
+    @Deprecated
     @Value("${fcrepo.metrics.enable:false}")
+    private boolean metricsEnable;
+
+    @Value("${fcrepo.metrics.enabled:false}")
     private boolean metricsEnabled;
 
     @Bean
     public MeterRegistry meterRegistry() {
         final MeterRegistry registry;
-        if (metricsEnabled) {
+        if (metricsEnabled || metricsEnable) {
             registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, PrometheusRegistry.defaultRegistry,
                     Clock.SYSTEM);
             registry.config().meterFilter(new MeterFilter() {
@@ -70,7 +74,10 @@ public class MetricsConfig extends BasePropsConfig {
      * @return whether metrics are enabled
      */
     public boolean isMetricsEnabled() {
-        return metricsEnabled;
+        if (metricsEnabled || metricsEnable) {
+            return true;
+        } else {
+            return false;
+        }
     }
-
 }

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/MetricsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/MetricsConfigTest.java
@@ -70,7 +70,7 @@ public class MetricsConfigTest {
 
     @Test
     public void testMetricsEnabled() {
-        env.setProperty("fcrepo.metrics.enable", "true");
+        env.setProperty("fcrepo.metrics.enabled", "true");
         initializeContext();
         initializeConfig();
 
@@ -87,7 +87,7 @@ public class MetricsConfigTest {
 
     @Test
     public void testTimerMetricsConfiguration() {
-        env.setProperty("fcrepo.metrics.enable", "true");
+        env.setProperty("fcrepo.metrics.enabled", "true");
         initializeContext();
         initializeConfig();
 

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/MetricsEndpointIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/MetricsEndpointIT.java
@@ -44,7 +44,7 @@ public class MetricsEndpointIT extends AbstractResourceIT {
 
     static {
         // Ensure the metrics property is set before tests run
-        System.setProperty("fcrepo.metrics.enable", "true");
+        System.setProperty("fcrepo.metrics.enabled", "true");
     }
 
     @BeforeEach
@@ -63,7 +63,7 @@ public class MetricsEndpointIT extends AbstractResourceIT {
                     }
                 });
         // Now that fedora has started, clear the property so it won't impact other tests
-        System.clearProperty("fcrepo.metrics.enable");
+        System.clearProperty("fcrepo.metrics.enabled");
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4026

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Adding support for `fcrepo.metrics.enabled` and marking `fcrepo.metrics.enable` as deprecated yet still allowed.

# How should this be tested?

A description of what steps someone could take to:
* Use either config to turn on metrics endpoint. Both should work for now. 
* simple test with `mvn jetty:run -Dfcrepo.metrics.enable=true` and `mvn jetty:run -Dfcrepo.metrics.enabled=true` should result in metrics on http://localhost:8080/rest/prometheus
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
