### PR TITLE
Deduplicate all types

### DIFF
--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
@@ -652,9 +652,11 @@ public class DbSearchIndexImpl implements SearchIndex {
                                 final FedoraId fedoraId, final List<URI> providedRdfTypes) {
         final var fullId = fedoraId.getFullId();
         try {
-            // If no RDF types were provided, we need to fetch the resource to get them.
-            List<URI> rdfTypes = providedRdfTypes;
-            if (rdfTypes == null) {
+            final List<URI> rdfTypes;
+            if (providedRdfTypes != null) {
+                rdfTypes = new ArrayList<>(Sets.newHashSet(providedRdfTypes));
+            } else {
+                // If no RDF types were provided, we need to fetch the resource to get them.
                 final var fedoraResource = resourceFactory.getResource(transaction, resourceHeaders);
                 rdfTypes = new ArrayList<>(Sets.newHashSet(fedoraResource.getTypes()));
             }

--- a/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/DbSearchIndexImplTest.java
+++ b/fcrepo-search-impl/src/test/java/org/fcrepo/search/impl/DbSearchIndexImplTest.java
@@ -305,6 +305,34 @@ public class DbSearchIndexImplTest {
         assertEquals(2, results5.getPagination().getTotalResults());
     }
 
+    @Test
+    public void testAddToIndexDuplicateTypes() throws Exception {
+        final var parameters = new SearchParameters(
+                List.of(Condition.Field.FEDORA_ID),
+                List.of(Condition.fromExpression("fedora_id=" + testId.getFullId())),
+                10,
+                0,
+                Condition.Field.FEDORA_ID,
+                "asc",
+                true
+        );
+        // Search for the resource before adding it to the index
+        final var results = searchIndex.doSearch(parameters);
+        assertEquals(0, results.getPagination().getTotalResults());
+
+        final List<URI> containerUserTypes = List.of(
+                URI.create(RDF_SOURCE.getURI()),
+                URI.create(RESOURCE.getURI()),
+                URI.create("http://example.fcrepo/user-defined-type"),
+                URI.create("http://example.fcrepo/user-defined-type")
+        );
+        // Add the resource to the index
+        searchIndex.addUpdateIndex(transaction, resourceHeaders1, containerUserTypes);
+        // Search for the resource after adding it to the index
+        final var results2 = searchIndex.doSearch(parameters);
+        assertEquals(1, results2.getPagination().getTotalResults());
+    }
+
     /**
      * Test removing a resource from the index using a short lived transaction.
      */


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4078

# What does this Pull Request do?
When using the rdf types pulled from the resource in the search index, we deduplicate them. But when we pull the rdf types from the resource and pass them to the search index, we don't deduplicate them. This deduplicates all types.

# How should this be tested?

See the same OCFL provided in the above ticket. Add `fcrepo.rebuild=true` to your properties and rebuild using that OCFL. Before this PR, it will fail with either duplicate key or foreign key failures. After it will succeed.

# Interested parties
@fcrepo/committers
