### PR TITLE
Push Docker images built from main branch to Docker Hub

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -193,4 +193,4 @@ jobs:
           FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
           cd fcrepo-docker
           echo "build and push image to dockerhub"
-          ./build-and-push-to-dockerhub.sh ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}
+          ./build-and-push-to-dockerhub.sh --push ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}


### PR DESCRIPTION
**JIRA Ticket**: [FCREPO-4080](https://fedora-repository.atlassian.net/browse/FCREPO-4080)

# What does this Pull Request do?

Runs the script `build-and-push-to-dockerhub.sh` with the command line flag `--push`.

The script is executed at the end of the deploy job in the step "Deploy Docker image".Without the command line flag `--push`, the built Docker images are not pushed to Docker Hub.

# How should this be tested?

* Run the following commands in your local copy of `fcrepo`:
```
mvn -U -B -DskipTests=true install
FCREPO_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
```
* Switch to your local copy of [fcrepo-docker](https://github.com/fcrepo-exts/fcrepo-docker)
* Execute `build-and-push-to-dockerhub.sh` inside `fcrepo-docker`:
```
./build-and-push-to-dockerhub.sh --push ../fcrepo-webapp/target/fcrepo-webapp-${FCREPO_VERSION}.war ${FCREPO_VERSION}
```
* You should see that the script tries to push the Docker images to Docker Hub (depending on the credentials provided, the script might fail to push them).

# Interested parties
@fcrepo/committers
