### PR TITLE
 Add AWS STS dependency for ocfl-s3 IRSA support

### DIFF
--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -62,6 +62,10 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>netty-nio-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
**Issue**: https://github.com/fcrepo/fcrepo/issues/2311

# What does this Pull Request do?

This PR adds the `software.amazon.awssdk:sts` dependency to the fcrepo S3/OCFL persistence module so that
Fedora can successfully use IAM Roles for Service Accounts (IRSA) when `fcrepo.storage=ocfl-s3` in AWS EKS.

The AWS SDK v2 default credential chain activates a web identity token provider in IRSA-enabled pods,
which requires the STS module on the classpath in order to exchange the projected token for temporary
credentials. Without `sts`, OCFL S3 initialization fails with a warning that the STS service module is
missing and Fedora cannot list objects under the configured prefix.

# How should this be tested?

1. **Baseline (optional, to see the failure)**
   - Deploy Fedora with `fcrepo.storage=ocfl-s3` to an existing EKS cluster.
   - Configure:
     - An S3 bucket and prefix for the OCFL root.
     - An IAM role with sufficient S3 access.
     - A Kubernetes service account annotated for IRSA with that role.
   - Ensure the pod uses the default AWS SDK credential chain (no explicit access keys / secrets).
   - Start Fedora and observe:
     - Warning from `WebIdentityCredentialsUtils` that the `sts` service module must be on the classpath.
     - OCFL S3 initialization failure due to inability to list objects under the configured prefix.

2. **Build and run Fedora with this change**
   - Build Fedora including this PR.
   - Build a Docker image using the `fcrepo-docker` repository and the newly built WAR.
   - Deploy this image to your EKS environment using the same IRSA-enabled service account and S3
     configuration as above.
   - Start Fedora and verify:
     - The previous STS warning is no longer present in the logs.
     - Fedora successfully initializes the S3-backed OCFL repository.
     - Fedora can create, read, and delete resources backed by the OCFL S3 storage.

   > This is the testing approach used to validate this change in our EKS environment.

3. **Sanity checks outside AWS**
   - Run Fedora with a non-S3 OCFL configuration (e.g., filesystem-based OCFL) and confirm that:
     - Startup still succeeds.
     - No regressions are observed in non-EKS, non-IRSA environments.

# Interested parties

@Surfrdan 
