### PR TITLE
Prepare 6.5.2 on new 6.5-maintenance line (S3 backports + search perf + SDK bump)

### DIFF
--- a/fcrepo-auth-common/pom.xml
+++ b/fcrepo-auth-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-auth-common</artifactId>
   <name>Fedora Repository Authorization Commons Module</name>

--- a/fcrepo-auth-webac/pom.xml
+++ b/fcrepo-auth-webac/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-auth-webac</artifactId>
   <name>Fedora Repository WebAC Authorization Module</name>

--- a/fcrepo-common/pom.xml
+++ b/fcrepo-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-common</artifactId>

--- a/fcrepo-configs/pom.xml
+++ b/fcrepo-configs/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-configs</artifactId>
   <name>Fedora Repository Configurations Module</name>

--- a/fcrepo-configs/src/main/resources/sql/h2/R__Create_search.sql
+++ b/fcrepo-configs/src/main/resources/sql/h2/R__Create_search.sql
@@ -8,6 +8,18 @@ CREATE TABLE IF NOT EXISTS simple_search (
     mime_type varchar(255) DEFAULT NULL
 );
 
+CREATE INDEX IF NOT EXISTS simple_search_idx1
+    ON simple_search (created);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx2
+    ON simple_search (modified);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx3
+    ON simple_search (content_size);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx4
+    ON simple_search (mime_type);
+
 CREATE TABLE IF NOT EXISTS simple_search_transactions (
     id bigint PRIMARY KEY AUTO_INCREMENT,
     fedora_id  varchar(503) NOT NULL,
@@ -19,6 +31,9 @@ CREATE TABLE IF NOT EXISTS simple_search_transactions (
     operation varchar(10) NOT NULL,
     UNIQUE (fedora_id, transaction_id)
 );
+
+CREATE INDEX IF NOT EXISTS simple_search_transactions_idx1
+    ON simple_search_transactions (transaction_id, operation);
 
 CREATE TABLE IF NOT EXISTS search_rdf_type (
     id bigint PRIMARY KEY AUTO_INCREMENT,
@@ -43,14 +58,5 @@ CREATE TABLE IF NOT EXISTS search_resource_rdf_type_transactions (
 CREATE INDEX IF NOT EXISTS search_resource_rdf_type_transactions_idx1
     ON search_resource_rdf_type_transactions (fedora_id, transaction_id);
 
-CREATE INDEX IF NOT EXISTS simple_search_idx1
-    ON simple_search (created);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx2
-    ON simple_search (modified);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx3
-    ON simple_search (content_size);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx4
-    ON simple_search (mime_type);
+CREATE INDEX IF NOT EXISTS search_resource_rdf_type_tx_idx2
+    ON search_resource_rdf_type_transactions (transaction_id, rdf_type_uri);

--- a/fcrepo-configs/src/main/resources/sql/mariadb/R__Create_search.sql
+++ b/fcrepo-configs/src/main/resources/sql/mariadb/R__Create_search.sql
@@ -9,6 +9,18 @@ CREATE TABLE IF NOT EXISTS simple_search (
     UNIQUE KEY fedora_id (fedora_id)
 );
 
+CREATE INDEX IF NOT EXISTS simple_search_idx1
+    ON simple_search (created);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx2
+    ON simple_search (modified);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx3
+    ON simple_search (content_size);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx4
+    ON simple_search (mime_type);
+
 CREATE TABLE IF NOT EXISTS simple_search_transactions (
     id bigint PRIMARY KEY AUTO_INCREMENT,
     fedora_id  varchar(503) NOT NULL,
@@ -20,6 +32,9 @@ CREATE TABLE IF NOT EXISTS simple_search_transactions (
     operation varchar(10) NOT NULL,
     UNIQUE (fedora_id, transaction_id)
 );
+
+CREATE INDEX IF NOT EXISTS simple_search_transactions_idx1
+    ON simple_search_transactions (transaction_id, operation);
 
 CREATE TABLE IF NOT EXISTS search_rdf_type (
     id bigint PRIMARY KEY AUTO_INCREMENT,
@@ -45,16 +60,5 @@ CREATE TABLE IF NOT EXISTS search_resource_rdf_type_transactions (
 CREATE INDEX IF NOT EXISTS search_resource_rdf_type_transactions_idx1
     ON search_resource_rdf_type_transactions (fedora_id, transaction_id);
 
-CREATE INDEX IF NOT EXISTS simple_search_idx1
-    ON simple_search (created);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx2
-    ON simple_search (modified);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx3
-    ON simple_search (content_size);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx4
-    ON simple_search (mime_type);
-
-
+CREATE INDEX IF NOT EXISTS search_resource_rdf_type_tx_idx2
+    ON search_resource_rdf_type_transactions (transaction_id, rdf_type_uri);

--- a/fcrepo-configs/src/main/resources/sql/mysql/R__Create_search.sql
+++ b/fcrepo-configs/src/main/resources/sql/mysql/R__Create_search.sql
@@ -9,47 +9,6 @@ CREATE TABLE IF NOT EXISTS simple_search (
     UNIQUE KEY fedora_id (fedora_id)
 );
 
-CREATE TABLE IF NOT EXISTS simple_search_transactions (
-    id bigint PRIMARY KEY AUTO_INCREMENT,
-    fedora_id  varchar(503) NOT NULL,
-    created timestamp NOT NULL,
-    modified timestamp NOT NULL,
-    content_size bigint DEFAULT NULL,
-    mime_type varchar(255) DEFAULT NULL,
-    transaction_id varchar(37) NOT NULL,
-    operation varchar(10) NOT NULL,
-    UNIQUE (fedora_id, transaction_id)
-);
-
-
-CREATE TABLE IF NOT EXISTS search_rdf_type (
-    id bigint PRIMARY KEY AUTO_INCREMENT,
-    rdf_type_uri varchar(228) NOT NULL,
-    UNIQUE KEY rdf_type_uri (rdf_type_uri)
-);
-
-CREATE TABLE IF NOT EXISTS search_resource_rdf_type (
-    resource_id bigint NOT NULL,
-    rdf_type_id bigint NOT NULL,
-    PRIMARY KEY(resource_id, rdf_type_id),
-    FOREIGN KEY (resource_id) REFERENCES simple_search(id) ON DELETE CASCADE,
-    FOREIGN KEY (rdf_type_id) REFERENCES search_rdf_type(id)  ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS search_resource_rdf_type_transactions (
-    fedora_id  varchar(503) NOT NULL,
-    rdf_type_uri varchar(228) NOT NULL,
-    transaction_id varchar(37) NOT NULL,
-    PRIMARY KEY(fedora_id, rdf_type_uri, transaction_id)
-);
-
-SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
-    WHERE table_name = 'search_resource_rdf_type_transactions' AND index_name = 'search_resource_rdf_type_transactions_idx1' AND table_schema = database());
-SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
-    'CREATE INDEX search_resource_rdf_type_transactions_idx1 ON search_resource_rdf_type_transactions (fedora_id, transaction_id)');
-PREPARE stmt FROM @sqlstmt;
-EXECUTE stmt;
-
 SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
     WHERE table_name = 'simple_search' AND index_name = 'simple_search_idx1' AND table_schema = database());
 SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
@@ -78,3 +37,59 @@ SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
 PREPARE stmt FROM @sqlstmt;
 EXECUTE stmt;
 
+CREATE TABLE IF NOT EXISTS simple_search_transactions (
+    id bigint PRIMARY KEY AUTO_INCREMENT,
+    fedora_id  varchar(503) NOT NULL,
+    created timestamp NOT NULL,
+    modified timestamp NOT NULL,
+    content_size bigint DEFAULT NULL,
+    mime_type varchar(255) DEFAULT NULL,
+    transaction_id varchar(37) NOT NULL,
+    operation varchar(10) NOT NULL,
+    UNIQUE (fedora_id, transaction_id)
+);
+
+-- Create an index on the transaction_id and operation in simple_search_transactions
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'simple_search_transactions' AND index_name = 'simple_search_transactions_idx1' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX simple_search_transactions_idx1 ON simple_search_transactions (transaction_id, operation)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+CREATE TABLE IF NOT EXISTS search_rdf_type (
+    id bigint PRIMARY KEY AUTO_INCREMENT,
+    rdf_type_uri varchar(228) NOT NULL,
+    UNIQUE KEY rdf_type_uri (rdf_type_uri)
+);
+
+CREATE TABLE IF NOT EXISTS search_resource_rdf_type (
+    resource_id bigint NOT NULL,
+    rdf_type_id bigint NOT NULL,
+    PRIMARY KEY(resource_id, rdf_type_id),
+    FOREIGN KEY (resource_id) REFERENCES simple_search(id) ON DELETE CASCADE,
+    FOREIGN KEY (rdf_type_id) REFERENCES search_rdf_type(id)  ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS search_resource_rdf_type_transactions (
+    fedora_id  varchar(503) NOT NULL,
+    rdf_type_uri varchar(228) NOT NULL,
+    transaction_id varchar(37) NOT NULL,
+    PRIMARY KEY(fedora_id, rdf_type_uri, transaction_id)
+);
+
+
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'search_resource_rdf_type_transactions' AND index_name = 'search_resource_rdf_type_transactions_idx1' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX search_resource_rdf_type_transactions_idx1 ON search_resource_rdf_type_transactions (fedora_id, transaction_id)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;
+
+-- Create an index on transaction_id and rdf_type_uri for commit RDF type association transactions.
+SET @exist := (SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_name = 'search_resource_rdf_type_transactions' AND index_name = 'search_resource_rdf_type_tx_idx2' AND table_schema = database());
+SET @sqlstmt := IF (@exist > 0, 'SELECT ''INFO: Index already exists.''',
+    'CREATE INDEX search_resource_rdf_type_tx_idx2 ON search_resource_rdf_type_transactions (transaction_id, rdf_type_uri)');
+PREPARE stmt FROM @sqlstmt;
+EXECUTE stmt;

--- a/fcrepo-configs/src/main/resources/sql/postgresql/R__Create_search.sql
+++ b/fcrepo-configs/src/main/resources/sql/postgresql/R__Create_search.sql
@@ -8,6 +8,18 @@ CREATE TABLE IF NOT EXISTS simple_search (
     mime_type varchar(255) DEFAULT NULL
 );
 
+CREATE INDEX IF NOT EXISTS simple_search_idx1
+    ON simple_search (created);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx2
+    ON simple_search (modified);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx3
+    ON simple_search (content_size);
+
+CREATE INDEX IF NOT EXISTS simple_search_idx4
+    ON simple_search (mime_type);
+
 CREATE TABLE IF NOT EXISTS simple_search_transactions (
     id bigserial PRIMARY KEY,
     fedora_id  varchar(503) NOT NULL,
@@ -19,6 +31,9 @@ CREATE TABLE IF NOT EXISTS simple_search_transactions (
     operation varchar(10) NOT NULL,
     UNIQUE (fedora_id, transaction_id)
 );
+
+CREATE INDEX IF NOT EXISTS simple_search_transactions_idx1
+    ON simple_search_transactions (transaction_id, operation);
 
 CREATE TABLE IF NOT EXISTS search_rdf_type (
     id bigserial PRIMARY KEY,
@@ -43,15 +58,5 @@ CREATE TABLE IF NOT EXISTS search_resource_rdf_type_transactions (
 CREATE INDEX IF NOT EXISTS search_resource_rdf_type_transactions_idx1
     ON search_resource_rdf_type_transactions (fedora_id, transaction_id);
 
-CREATE INDEX IF NOT EXISTS simple_search_idx1
-    ON simple_search (created);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx2
-    ON simple_search (modified);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx3
-    ON simple_search (content_size);
-
-CREATE INDEX IF NOT EXISTS simple_search_idx4
-    ON simple_search (mime_type);
-
+CREATE INDEX IF NOT EXISTS search_resource_rdf_type_tx_idx2
+    ON search_resource_rdf_type_transactions (transaction_id, rdf_type_uri);

--- a/fcrepo-event-serialization/pom.xml
+++ b/fcrepo-event-serialization/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-event-serialization</artifactId>
   <name>Fedora Event Serialization</name>

--- a/fcrepo-http-api/pom.xml
+++ b/fcrepo-http-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-http-api</artifactId>

--- a/fcrepo-http-commons/pom.xml
+++ b/fcrepo-http-commons/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-http-commons</artifactId>
   <name>Fedora Repository HTTP Commons Module</name>

--- a/fcrepo-integration-ldp/pom.xml
+++ b/fcrepo-integration-ldp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>fcrepo-parent</artifactId>
     <groupId>org.fcrepo</groupId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
     <relativePath>../fcrepo-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/fcrepo-integration-rdf/pom.xml
+++ b/fcrepo-integration-rdf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>fcrepo</artifactId>
         <groupId>org.fcrepo</groupId>
-        <version>6.5.1</version>
+        <version>6.5.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/fcrepo-jms/pom.xml
+++ b/fcrepo-jms/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-jms</artifactId>
   <name>Fedora Repository JMS Module</name>

--- a/fcrepo-kernel-api/pom.xml
+++ b/fcrepo-kernel-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-kernel-api</artifactId>
   <name>Fedora Repository Kernel API</name>

--- a/fcrepo-kernel-impl/pom.xml
+++ b/fcrepo-kernel-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-kernel-impl</artifactId>
   <name>Fedora Repository Kernel Implementation</name>

--- a/fcrepo-parent/pom.xml
+++ b/fcrepo-parent/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.fcrepo</groupId>
   <artifactId>fcrepo-parent</artifactId>
-  <version>6.5.1</version>
+  <version>6.5.2-SNAPSHOT</version>
   <name>Fedora Commons :: Parent POM</name>
   <description>Parent POM for Fedora Commons Projects</description>
   <url>http://fedorarepository.org</url>
@@ -707,7 +707,7 @@
     <connection>scm:git:git://github.com/${project_organization}/${project_name}.git</connection>
     <developerConnection>scm:git:git@github.com:${project_organization}/${project_name}.git</developerConnection>
     <url>https://github.com/${project_organization}/${project_name}</url>
-    <tag>fcrepo-6.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/fcrepo-persistence-api/pom.xml
+++ b/fcrepo-persistence-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-persistence-api</artifactId>

--- a/fcrepo-persistence-common/pom.xml
+++ b/fcrepo-persistence-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-persistence-common</artifactId>

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-persistence-ocfl</artifactId>
   <name>Fedora Repository OCFL Persistence Impl</name>

--- a/fcrepo-persistence-ocfl/pom.xml
+++ b/fcrepo-persistence-ocfl/pom.xml
@@ -80,6 +80,10 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>netty-nio-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -140,7 +140,10 @@ public class OcflPersistenceConfig {
     }
 
     private S3AsyncClient s3Client() {
-        final var builder = S3AsyncClient.builder();
+        // multipartEnabled lets the client transparently use UploadPartCopy for objects larger than the 5GB
+        // single-operation CopyObject limit. ocfl-java's OcflS3Client.copyObject() goes through this client, so
+        // without this, committing objects with files over 5GB fails with an S3 exception.
+        final var builder = S3AsyncClient.builder().multipartEnabled(true);
 
         if (StringUtils.isNotBlank(ocflPropsConfig.getAwsRegion())) {
             builder.region(Region.of(ocflPropsConfig.getAwsRegion()));

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -164,7 +164,7 @@ public class OcflPersistenceConfig {
 
         // May want to do additional HTTP client configuration, connection pool, etc
         final var httpClientBuilder = NettyNioAsyncHttpClient.builder()
-                .connectionAcquisitionTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ConnectionTimeout()))
+                .connectionTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ConnectionTimeout()))
                 .writeTimeout(Duration.ofSeconds(ocflPropsConfig.getS3WriteTimeout()))
                 .readTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ReadTimeout()))
                 .maxConcurrency(ocflPropsConfig.getS3MaxConcurrency());

--- a/fcrepo-search-api/pom.xml
+++ b/fcrepo-search-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-search-api</artifactId>
   <name>Fedora Repository Search API</name>

--- a/fcrepo-search-impl/pom.xml
+++ b/fcrepo-search-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-search-impl</artifactId>
   <name>Fedora Repository Search Impl</name>

--- a/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
+++ b/fcrepo-search-impl/src/main/java/org/fcrepo/search/impl/DbSearchIndexImpl.java
@@ -22,7 +22,6 @@ import java.sql.Types;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,6 +49,7 @@ import org.fcrepo.search.api.SearchParameters;
 import org.fcrepo.search.api.SearchResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -209,11 +209,31 @@ public class DbSearchIndexImpl implements SearchIndex {
             CONTENT_SIZE_COLUMN + " = EXCLUDED." + CONTENT_SIZE_COLUMN + ", " +
             MIME_TYPE_COLUMN + " = EXCLUDED." + MIME_TYPE_COLUMN;
 
-    private static final String COMMIT_RDF_TYPES =
+    private static final String COMMIT_RDF_TYPES_MYSQL_MARIA =
+            "INSERT IGNORE INTO " + SEARCH_RDF_TYPE_TABLE + " (" + RDF_TYPE_URI_COLUMN + ") " +
+                    "SELECT DISTINCT " + RDF_TYPE_URI_COLUMN + " FROM " + SEARCH_RESOURCE_RDF_TYPE_TRANSACTIONS_TABLE +
+                    " WHERE " + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM;
+    private static final String COMMIT_RDF_TYPES_POSTGRES =
             "INSERT INTO " + SEARCH_RDF_TYPE_TABLE + " (" + RDF_TYPE_URI_COLUMN + ")" +
-                    " SELECT distinct " + RDF_TYPE_URI_COLUMN + " FROM " + SEARCH_RESOURCE_RDF_TYPE_TRANSACTIONS_TABLE +
-                    " WHERE " + TRANSACTION_ID_COLUMN + "= :" + TRANSACTION_ID_PARAM + " AND " + RDF_TYPE_URI_COLUMN +
-                    " NOT IN (SELECT " + RDF_TYPE_URI_PARAM + " FROM " + SEARCH_RDF_TYPE_TABLE + ")";
+                    "SELECT DISTINCT " + RDF_TYPE_URI_COLUMN + " FROM " + SEARCH_RESOURCE_RDF_TYPE_TRANSACTIONS_TABLE +
+                    " WHERE " + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM + " ON CONFLICT " +
+                    "(" + RDF_TYPE_URI_COLUMN + ") DO NOTHING";
+    private static final String COMMIT_RDF_TYPES_H2 =
+            "INSERT INTO " + SEARCH_RDF_TYPE_TABLE + " (" + RDF_TYPE_URI_COLUMN + ") " +
+                    "SELECT DISTINCT tx." + RDF_TYPE_URI_COLUMN + " " +
+                    "FROM " + SEARCH_RESOURCE_RDF_TYPE_TRANSACTIONS_TABLE + " tx " +
+                    "WHERE tx." + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM + " " +
+                    "AND NOT EXISTS ( " +
+                    "  SELECT 1 FROM " + SEARCH_RDF_TYPE_TABLE + " existing " +
+                    "  WHERE existing." + RDF_TYPE_URI_COLUMN + " = tx." + RDF_TYPE_URI_COLUMN +
+                    ")";
+
+    private static final Map<DbPlatform, String> COMMIT_RDF_TYPES_MAP = Map.of(
+            DbPlatform.H2, COMMIT_RDF_TYPES_H2,
+            DbPlatform.MYSQL, COMMIT_RDF_TYPES_MYSQL_MARIA,
+            DbPlatform.MARIADB, COMMIT_RDF_TYPES_MYSQL_MARIA,
+            DbPlatform.POSTGRESQL, COMMIT_RDF_TYPES_POSTGRES
+    );
 
     private static final String INSERT_RDF_TYPE =
             "INSERT INTO " + SEARCH_RDF_TYPE_TABLE + " (" + RDF_TYPE_URI_COLUMN + ")" +
@@ -233,17 +253,55 @@ public class DbSearchIndexImpl implements SearchIndex {
                     "= c." + RDF_TYPE_URI_COLUMN + " AND c." + FEDORA_ID_COLUMN + " = a." + FEDORA_ID_COLUMN +
                     " GROUP BY a." + ID_COLUMN + ", b." + ID_COLUMN;
 
-    private static final String COMMIT_DELETE_RESOURCES_IN_TRANSACTION =
-            "DELETE FROM " + SIMPLE_SEARCH_TABLE + " WHERE " + FEDORA_ID_COLUMN + " IN (SELECT  " + FEDORA_ID_COLUMN +
-                    " FROM " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " WHERE " + TRANSACTION_ID_COLUMN + " = " +
-                    ":" + TRANSACTION_ID_PARAM + " AND " + OPERATION_COLUMN + " = 'delete')";
+    private static final String COMMIT_DELETE_RESOURCES_IN_TRANSACTION_MYSQL_MARIA =
+            "DELETE s FROM " + SIMPLE_SEARCH_TABLE + " s JOIN " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " tx ON s." +
+                    FEDORA_ID_COLUMN + " = tx." + FEDORA_ID_COLUMN + " WHERE tx." + TRANSACTION_ID_COLUMN +
+                    " = :" + TRANSACTION_ID_PARAM + " AND tx." + OPERATION_COLUMN + " = 'delete'";
+    private static final String COMMIT_DELETE_RESOURCES_IN_TRANSACTION_POSTGRES =
+            "DELETE FROM " + SIMPLE_SEARCH_TABLE + " s " +
+                    "USING " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " tx " +
+                    "WHERE s." + FEDORA_ID_COLUMN + " = tx." + FEDORA_ID_COLUMN + " " +
+                    "AND tx." + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM + " " +
+                    "AND tx." + OPERATION_COLUMN + " = 'delete'";
+    private static final String COMMIT_DELETE_RESOURCES_IN_TRANSACTION_H2 =
+            "DELETE FROM " + SIMPLE_SEARCH_TABLE + " WHERE " + FEDORA_ID_COLUMN + " IN (" +
+                    "SELECT " + FEDORA_ID_COLUMN + " FROM " + SIMPLE_SEARCH_TRANSACTIONS_TABLE +
+                    " WHERE " + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM +
+                    " AND " + OPERATION_COLUMN + " = 'delete')";
+    private static final Map<DbPlatform, String> COMMIT_DELETE_RESOURCES_IN_TRANSACTION_MAP = Map.of(
+            DbPlatform.H2, COMMIT_DELETE_RESOURCES_IN_TRANSACTION_H2,
+            DbPlatform.MYSQL, COMMIT_DELETE_RESOURCES_IN_TRANSACTION_MYSQL_MARIA,
+            DbPlatform.MARIADB, COMMIT_DELETE_RESOURCES_IN_TRANSACTION_MYSQL_MARIA,
+            DbPlatform.POSTGRESQL, COMMIT_DELETE_RESOURCES_IN_TRANSACTION_POSTGRES
+    );
 
-    private static final String COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS =
-            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " where " +
-                    RESOURCE_ID_COLUMN + " in (SELECT a." + ID_COLUMN + " FROM " + SIMPLE_SEARCH_TABLE + " a, " +
-                    SIMPLE_SEARCH_TRANSACTIONS_TABLE + " b " +
-                    " WHERE a." + FEDORA_ID_COLUMN + "= b." + FEDORA_ID_COLUMN + " AND b." + TRANSACTION_ID_COLUMN +
-                    "= :" + TRANSACTION_ID_PARAM + ")";
+    private static final String COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA =
+            "DELETE s FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s JOIN " + SIMPLE_SEARCH_TABLE + " a ON s." +
+                    RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " JOIN " + SIMPLE_SEARCH_TRANSACTIONS_TABLE +
+                    " b ON a." + FEDORA_ID_COLUMN + "= b." + FEDORA_ID_COLUMN + " WHERE b." +
+                    TRANSACTION_ID_COLUMN + "= :" + TRANSACTION_ID_PARAM;
+    private static final String COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_POSTGRES =
+            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s " +
+                    "USING " + SIMPLE_SEARCH_TABLE + " a, " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " b " +
+                    "WHERE s." + RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " " +
+                    "AND a." + FEDORA_ID_COLUMN + " = b." + FEDORA_ID_COLUMN + " " +
+                    "AND b." + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM;
+    private static final String COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_H2 =
+            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s " +
+                    "WHERE EXISTS ( " +
+                    "SELECT 1 FROM " + SIMPLE_SEARCH_TABLE + " a " +
+                    "JOIN " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " b " +
+                    "ON a." + FEDORA_ID_COLUMN + " = b." + FEDORA_ID_COLUMN + " " +
+                    "WHERE s." + RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " " +
+                    "AND b." + TRANSACTION_ID_COLUMN + " = :" + TRANSACTION_ID_PARAM +
+                    ")";
+
+    private static final Map<DbPlatform, String> COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_MAP = Map.of(
+            DbPlatform.H2, COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_H2,
+            DbPlatform.MYSQL, COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA,
+            DbPlatform.MARIADB, COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA,
+            DbPlatform.POSTGRESQL, COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_POSTGRES
+    );
 
     private static final String DELETE_TRANSACTION =
             "DELETE FROM " + SIMPLE_SEARCH_TRANSACTIONS_TABLE + " WHERE " + TRANSACTION_ID_COLUMN + " = :" +
@@ -302,12 +360,30 @@ public class DbSearchIndexImpl implements SearchIndex {
                     FEDORA_ID_COLUMN + "= :" + FEDORA_ID_PARAM + " AND " + TRANSACTION_ID_COLUMN + "= :" +
                     TRANSACTION_ID_PARAM;
 
-    private static final String DELETE_RDF_TYPE_ASSOCIATIONS =
-            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " WHERE " + RESOURCE_ID_COLUMN +
-                    " = (SELECT " + ID_COLUMN + " FROM " + SIMPLE_SEARCH_TABLE + " WHERE " +
-                    FEDORA_ID_COLUMN + " = :" + FEDORA_ID_PARAM + ")";
+    private static final String DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA =
+            "DELETE s FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s JOIN " + SIMPLE_SEARCH_TABLE + " a ON s." +
+                    RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " WHERE a." + FEDORA_ID_COLUMN + "= :" +
+                    FEDORA_ID_PARAM;
+    private static final String DELETE_RDF_TYPE_ASSOCIATIONS_POSTGRES =
+            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s " +
+                    "USING " + SIMPLE_SEARCH_TABLE + " a " +
+                    "WHERE s." + RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " " +
+                    "AND a." + FEDORA_ID_COLUMN + "= :" + FEDORA_ID_PARAM;
+    private static final String DELETE_RDF_TYPE_ASSOCIATIONS_H2 =
+            "DELETE FROM " + SEARCH_RESOURCE_RDF_TYPE_TABLE + " s " +
+                    "WHERE EXISTS ( " +
+                    "SELECT 1 FROM " + SIMPLE_SEARCH_TABLE + " a " +
+                    "WHERE s." + RESOURCE_ID_COLUMN + " = a." + ID_COLUMN + " " +
+                    "AND a." + FEDORA_ID_COLUMN + "= :" + FEDORA_ID_PARAM +
+                    ")";
+    private static final Map<DbPlatform, String> DELETE_RDF_TYPE_ASSOCIATIONS_MAP = Map.of(
+            DbPlatform.H2, DELETE_RDF_TYPE_ASSOCIATIONS_H2,
+            DbPlatform.MYSQL, DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA,
+            DbPlatform.MARIADB, DELETE_RDF_TYPE_ASSOCIATIONS_MYSQL_MARIA,
+            DbPlatform.POSTGRESQL, DELETE_RDF_TYPE_ASSOCIATIONS_POSTGRES
+    );
 
-    private static final List<String> COUNT_QUERY_COLUMNS = Arrays.asList("count(0) as count");
+    private static final List<String> COUNT_QUERY_COLUMNS = List.of("count(0) as count");
 
     @Inject
     private DataSource dataSource;
@@ -385,82 +461,74 @@ public class DbSearchIndexImpl implements SearchIndex {
                                             final List<String> selectedFields, final boolean isCountQuery)
             throws InvalidQueryException {
 
-        final var queryFields = new ArrayList<>(selectedFields);
-        final var fedoraIdStr = FEDORA_ID.toString();
+        final List<String> queryFields = new ArrayList<>(selectedFields);
+        final String fedoraIdStr = FEDORA_ID.toString();
 
-        if (!isCountQuery) {
-            if (!queryFields.contains(fedoraIdStr)) {
-                queryFields.add(0,fedoraIdStr);
-            }
-            queryFields.add(0,"id");
-        } else {
+        if (isCountQuery) {
+            queryFields.clear();
             queryFields.add("count(0)");
+        } else {
+            if (!queryFields.contains(fedoraIdStr)) {
+                queryFields.add(0, fedoraIdStr);
+            }
+            queryFields.add(0, "id");
         }
 
-        final var whereClauses = new ArrayList<String>();
-        final var conditions = parameters.getConditions();
-        final var fields = new ArrayList<String>(queryFields);
-        final var rdfTypeConditionValue =
-                conditions.stream().filter(c -> c.getField().equals(RDF_TYPE)).findFirst().orElse(null);
-        final var returnRdfType = fields.stream().anyMatch(x -> x.equals(RDF_TYPE.toString()));
-        final var returnFields = fields.stream().filter(x -> !x.equals(RDF_TYPE.toString())).collect(toList());
+        final List<String> whereClauses = new ArrayList<>();
+        final List<Condition> conditions = parameters.getConditions();
+        final boolean returnRdfType = queryFields.contains(RDF_TYPE.toString());
+        final List<String> returnFields = queryFields.stream()
+                .filter(x -> !x.equals(RDF_TYPE.toString())).collect(toList());
 
-        final var sql = new StringBuilder("")
-                .append("SELECT ")
-                .append(String.join(",", returnFields));
-        sql.append(" FROM ")
-                .append(SIMPLE_SEARCH_TABLE).append(" s ");
+        final var sql = new StringBuilder("SELECT ")
+                .append(String.join(",", returnFields))
+                .append(" FROM ").append(SIMPLE_SEARCH_TABLE).append(" s ");
 
-        if (rdfTypeConditionValue != null) {
-            final var rdfTypeOperator = rdfTypeConditionValue.getObject().contains("*") ? " LIKE " : " = ";
-            sql.append(", (SELECT ").append(RESOURCE_ID_COLUMN).append(" FROM ")
-                    .append(SEARCH_RESOURCE_RDF_TYPE_TABLE).append(" WHERE ")
-                    .append(RDF_TYPE_ID_COLUMN).append(" IN (").append("SELECT ID FROM ").append(SEARCH_RDF_TYPE_TABLE)
-                    .append(" WHERE ").append(RDF_TYPE_URI_COLUMN).append(rdfTypeOperator)
-                    .append(":").append(RDF_TYPE_URI_PARAM).append(")) rdf_type_filter ");
-            whereClauses.add("rdf_type_filter.resource_id = s.id");
-            addRdfTypeParam(parameterSource, conditions);
-        }
+        conditions.stream().filter(c -> c.getField().equals(RDF_TYPE)).findFirst()
+                .ifPresent(rdfTypeCondition -> {
+                    final String rdfTypeOperator = rdfTypeCondition.getObject().contains("*") ? " LIKE " : " = ";
+                    sql.append(" JOIN (SELECT srrt.").append(RESOURCE_ID_COLUMN).append(" FROM ")
+                    .append(SEARCH_RESOURCE_RDF_TYPE_TABLE).append(" srrt JOIN ").append(SEARCH_RDF_TYPE_TABLE)
+                            .append(" srt ON srrt.").append(RDF_TYPE_ID_PARAM).append(" = srt.")
+                            .append(ID_COLUMN).append(" WHERE srt.").append(RDF_TYPE_URI_COLUMN).append(rdfTypeOperator)
+                    .append(":").append(RDF_TYPE_URI_PARAM)
+                            .append(") rdf_type_filter ON rdf_type_filter.resource_id = s.id");
+                addRdfTypeParam(parameterSource, conditions);
+        });
 
+        // Add general conditions
         for (int i = 0; i < conditions.size(); i++) {
             addWhereClause(i, parameterSource, whereClauses, conditions.get(i));
         }
 
         if (!whereClauses.isEmpty()) {
             sql.append(" WHERE ");
-            for (final var it = whereClauses.iterator(); it.hasNext(); ) {
-                sql.append(it.next());
-                if (it.hasNext()) {
-                    sql.append(" AND ");
-                }
+            sql.append(String.join(" AND ", whereClauses));
+        }
+
+        if (!isCountQuery) {
+            if (parameters.getOrderBy() != null) {
+                sql.append(" ORDER BY ").append(parameters.getOrderBy())
+                        .append(" ").append(parameters.getOrder());
             }
+            sql.append(" LIMIT :limit OFFSET :offset");
+            parameterSource.addValue("limit", parameters.getMaxResults());
+            parameterSource.addValue("offset", parameters.getOffset());
         }
-
-        if (isCountQuery) {
-            return sql;
-        }
-
-        if (parameters.getOrderBy() != null) {
-            //add order by limit and offset to selectquery.
-            sql.append(" ORDER BY ").append(parameters.getOrderBy()).append(" ").append(parameters.getOrder());
-        }
-
-        sql.append(" LIMIT :limit OFFSET :offset");
-        parameterSource.addValue("limit", parameters.getMaxResults());
-        parameterSource.addValue("offset", parameters.getOffset());
 
         if (!returnRdfType) {
             return sql;
         } else {
-            final var rdfTypeWrapperSql = new StringBuilder();
-            rdfTypeWrapperSql.append("SELECT a.*, ")
+            final StringBuilder rdfTypeWrapperSql = new StringBuilder()
+                    .append("SELECT a.*, ")
                     .append(isPostgres() ? POSTGRES_GROUP_CONCAT_FUNCTION : DEFAULT_GROUP_CONCAT_FUNCTION)
-                    .append(" as rdf_type")
-                    .append(" FROM ")
-                    .append("(").append(sql).append(") a, ")
-                    .append("(SELECT rrt.resource_id , rt.rdf_type_uri FROM search_resource_rdf_type rrt, " +
-                            "search_rdf_type rt WHERE  rrt.rdf_type_id = rt.id) b ")
-                    .append("WHERE a.id = b.resource_id GROUP BY ").append(String.join(",", returnFields));
+                    .append(" as rdf_type FROM (")
+                    .append(sql).append(") a ")
+                    .append("JOIN (SELECT rrt.resource_id , rt.rdf_type_uri FROM ")
+                    .append(SEARCH_RESOURCE_RDF_TYPE_TABLE).append(" rrt, ")
+                    .append(SEARCH_RDF_TYPE_TABLE)
+                    .append(" rt WHERE rrt.rdf_type_id = rt.id) b ON a.id = b.resource_id GROUP BY ")
+                    .append(String.join(", ", returnFields));
 
             if (parameters.getOrderBy() != null) {
                 //add order by limit and offset to selectquery.
@@ -579,24 +647,31 @@ public class DbSearchIndexImpl implements SearchIndex {
     private Set<URI> insertRdfTypes(final List<URI> rdfTypes) {
         final var addTypes = new HashSet<URI>();
 
-        rdfTypes.stream()
+        final List<URI> types = new ArrayList<>();
+        final MapSqlParameterSource[] params = rdfTypes.stream()
                 .filter(rdfType -> !rdfTypeIdCache.containsKey(rdfType))
-                .forEach(rdfType -> {
-                    try {
-                        final var params = new MapSqlParameterSource();
-                        params.addValue(RDF_TYPE_URI_PARAM, rdfType.toString());
-                        if (isPostgres()) {
-                            // weirdly, postgres spoils the entire tx on duplicate keys and must be handled differently
-                            jdbcTemplate.update(INSERT_RDF_TYPE_POSTGRES, params);
-                        } else {
-                            jdbcTemplate.update(INSERT_RDF_TYPE, params);
-                        }
+                .map(r -> {
+                    types.add(r);
+                    return new MapSqlParameterSource().addValue(RDF_TYPE_URI_PARAM, r.toString());
+                })
+                .toArray(MapSqlParameterSource[]::new);
 
-                        addTypes.add(rdfType);
-                    } catch (DuplicateKeyException e) {
-                        // ignore duplicate keys
-                    }
-                });
+        try {
+            if (isPostgres()) {
+                // weirdly, postgres spoils the entire tx on duplicate keys and must be handled differently
+                jdbcTemplate.batchUpdate(INSERT_RDF_TYPE_POSTGRES, params);
+            } else {
+                jdbcTemplate.batchUpdate(INSERT_RDF_TYPE, params);
+            }
+
+            addTypes.addAll(types);
+
+        } catch (final DuplicateKeyException e) {
+            // ignore duplicate keys
+        } catch (final CannotAcquireLockException e) {
+            // if we can't get a lock
+            throw new RepositoryRuntimeException("Failed to add RDF type(s) to search index", e);
+        }
 
         return addTypes;
     }
@@ -707,7 +782,7 @@ public class DbSearchIndexImpl implements SearchIndex {
     private void deleteRdfTypeAssociations(final FedoraId fedoraId) {
         final var deleteParams = new MapSqlParameterSource();
         deleteParams.addValue(FEDORA_ID_PARAM, fedoraId.getFullId());
-        jdbcTemplate.update(DELETE_RDF_TYPE_ASSOCIATIONS,
+        jdbcTemplate.update(DELETE_RDF_TYPE_ASSOCIATIONS_MAP.get(dbPlatForm),
                 deleteParams);
     }
 
@@ -827,11 +902,15 @@ public class DbSearchIndexImpl implements SearchIndex {
             try {
                 final MapSqlParameterSource parameterSource = new MapSqlParameterSource();
                 parameterSource.addValue(TRANSACTION_ID_PARAM, txId);
-                final int deletedAssociations = jdbcTemplate.update(COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS,
+                final int deletedAssociations = jdbcTemplate.update(
+                        COMMIT_DELETE_RDF_TYPE_ASSOCIATIONS_MAP.get(dbPlatForm),
                         parameterSource);
-                final int deletedResources = jdbcTemplate.update(COMMIT_DELETE_RESOURCES_IN_TRANSACTION,
+                final int deletedResources = jdbcTemplate.update(
+                        COMMIT_DELETE_RESOURCES_IN_TRANSACTION_MAP.get(dbPlatForm),
                         parameterSource);
-                final int addedRdfTypes = jdbcTemplate.update(COMMIT_RDF_TYPES, parameterSource);
+                final int addedRdfTypes = jdbcTemplate.update(
+                        COMMIT_RDF_TYPES_MAP.get(dbPlatForm),
+                        parameterSource);
                 final int addedResources = jdbcTemplate.update(UPSERT_COMMIT_MAPPING.get(dbPlatForm),
                         parameterSource);
                 final int addRdfTypeAssociations = jdbcTemplate.update(COMMIT_RDF_TYPE_ASSOCIATIONS, parameterSource);

--- a/fcrepo-stats-api/pom.xml
+++ b/fcrepo-stats-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-stats-api</artifactId>
   <name>Fedora Repository Statistics API</name>

--- a/fcrepo-stats-impl/pom.xml
+++ b/fcrepo-stats-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-stats-impl</artifactId>
   <name>Fedora Repository Stats Impl</name>

--- a/fcrepo-webapp/pom.xml
+++ b/fcrepo-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>fcrepo-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     <fcrepo-storage-ocfl.version>6.4.0-SNAPSHOT</fcrepo-storage-ocfl.version>
     <!-- Dependency version properties -->
     <activemq.version>5.16.7</activemq.version>
-    <aws.sdk.version>2.25.29</aws.sdk.version>
-    <aws.crt.version>0.29.16</aws.crt.version>
+    <aws.sdk.version>2.42.5</aws.sdk.version>
+    <aws.crt.version>0.43.6</aws.crt.version>
     <caffeine.version>3.0.4</caffeine.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>

--- a/pom.xml
+++ b/pom.xml
@@ -599,6 +599,13 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- Pin aws-crt ahead of the AWS SDK BOM. The BOM ships an older aws-crt that is missing
+           S3MetaRequestOptions$ResponseFileOption, causing ClassNotFoundException on S3 writes. -->
+      <dependency>
+        <groupId>software.amazon.awssdk.crt</groupId>
+        <artifactId>aws-crt</artifactId>
+        <version>${aws.crt.version}</version>
+      </dependency>
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>6.5.1</version>
+    <version>6.5.2-SNAPSHOT</version>
     <relativePath>./fcrepo-parent</relativePath>
   </parent>
 
   <groupId>org.fcrepo</groupId>
   <artifactId>fcrepo</artifactId>
-  <version>6.5.1</version>
+  <version>6.5.2-SNAPSHOT</version>
   <name>Fedora Commons</name>
   <description>Parent project for Fedora Commons Repository</description>
   <url>http://fedorarepository.org</url>
@@ -1066,7 +1066,7 @@
     <connection>scm:git:git://github.com/${project_organization}/${project_name}.git</connection>
     <developerConnection>scm:git:git@github.com:${project_organization}/${project_name}.git</developerConnection>
     <url>https://github.com/${project_organization}/${project_name}</url>
-    <tag>fcrepo-6.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
 </project>


### PR DESCRIPTION
## Establish the 6.5.x maintenance line and prep 6.5.2

Targets the new **`6.5-maintenance`** branch (forked from the `fcrepo-6.5.1` release commit) rather than the frozen `6.5.1` release branch. This becomes the long-lived 6.5.x line; `6.5.2`, `6.5.3`, … get **tagged** from `6.5-maintenance` via the maven-release-plugin. `6.5.2-prep` is the short-lived prep branch for this PR (delete on merge).

Version bumped to `6.5.2-SNAPSHOT` for the next development iteration.

### Included changes
1. `[maven-release-plugin] prepare for next development iteration` — bump all module poms `6.5.1` → `6.5.2-SNAPSHOT`, reset `<scm><tag>` to `HEAD`.
2. **FCREPO-4084 – OCFL-java S3 5GB issue** (backport of #2309) — `S3AsyncClient.builder().multipartEnabled(true)` so committing objects with files >5GB no longer fails the single-operation CopyObject limit; plus the `aws-crt` dependencyManagement pin.
3. **Added STS dependency for AWS IRSA-based auth** (backport of #2312) — adds `software.amazon.awssdk:sts` to `fcrepo-persistence-ocfl`.
4. **Rewiring s3 timeout property** (backport of #2314) — `connectionAcquisitionTimeout` → `connectionTimeout` for `S3ConnectionTimeout`.
5. **Simple search performance improvements** (from `6.5.1-whikloj-simple-search-queries`, commit `e524c31`) — Jared's search-query performance backport (search SQL + `DbSearchIndexImpl`).
6. **Bump AWS SDK `2.25.29` → `2.42.5` and aws-crt `0.29.16` → `0.43.6`** — align the maintenance line with the SDK combination the three S3 backports were developed/tested against on `main`. Builds and OCFL unit tests pass against the newer SDK.

Cherry-picks 2–5 were applied with `-x` (original commit references preserved in the messages).

### Notes / points for review
- **AWS SDK bump.** With #6 the line now matches `main` (`2.42.5` / `0.43.6`), so the `aws-crt` pin from #2309 resolves to the same version as `main` and the S3 changes run against their tested SDK. It's a sizeable jump on a maintenance line (2.25 → 2.42); reviewers should sanity-check transitive-dependency impact. Full CI (incl. mariadb/mysql/postgres ITs) covers this.
- **Verification:** `mvn -pl fcrepo-persistence-ocfl -am install` passes against the bumped SDK.
- Cutting the actual `6.5.2` tag/deploy via the maven-release-plugin is left to a maintainer.

Supersedes #2318 (same work, correct target branch + renamed prep branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
