### PR TITLE
Restore configurable S3 connection acquisition timeout

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -126,6 +126,9 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.s3.timeout.connection.seconds:60}")
     private int s3ConnectionTimeout;
 
+    @Value("${fcrepo.ocfl.s3.timeout.acquisition.seconds:60}")
+    private int s3ConnectionAcquisitionTimeout;
+
     @Value("${fcrepo.ocfl.s3.timeout.write.seconds:60}")
     private int s3WriteTimeout;
 
@@ -530,10 +533,18 @@ public class OcflPropsConfig extends BasePropsConfig {
     }
 
     /**
-     * @return the AWS S3 connection acquisition timeout in seconds.
+     * @return the AWS S3 connection timeout in seconds.
      */
     public int getS3ConnectionTimeout() {
         return s3ConnectionTimeout;
+    }
+
+    /**
+     * @return the AWS S3 connection acquisition timeout in seconds. This is the maximum time a request will wait to
+     *         acquire a connection from the client's connection pool before failing.
+     */
+    public int getS3ConnectionAcquisitionTimeout() {
+        return s3ConnectionAcquisitionTimeout;
     }
 
     /**

--- a/fcrepo-configs/src/test/java/org/fcrepo/config/OcflPropsConfigTest.java
+++ b/fcrepo-configs/src/test/java/org/fcrepo/config/OcflPropsConfigTest.java
@@ -86,6 +86,7 @@ public class OcflPropsConfigTest {
         assertFalse(config.isOcflUpgradeOnWrite());
         assertTrue(config.verifyInventory());
         assertEquals(60, config.getS3ConnectionTimeout());
+        assertEquals(60, config.getS3ConnectionAcquisitionTimeout());
         assertEquals(60, config.getS3WriteTimeout());
         assertEquals(60, config.getS3ReadTimeout());
         assertEquals(100, config.getS3MaxConcurrency());

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -184,6 +184,8 @@ public class OcflPersistenceConfig {
         // May want to do additional HTTP client configuration, connection pool, etc
         final var httpClientBuilder = NettyNioAsyncHttpClient.builder()
                 .connectionTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ConnectionTimeout()))
+                .connectionAcquisitionTimeout(
+                        Duration.ofSeconds(ocflPropsConfig.getS3ConnectionAcquisitionTimeout()))
                 .writeTimeout(Duration.ofSeconds(ocflPropsConfig.getS3WriteTimeout()))
                 .readTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ReadTimeout()))
                 .maxConcurrency(ocflPropsConfig.getS3MaxConcurrency());

--- a/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfigTest.java
+++ b/fcrepo-persistence-ocfl/src/test/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfigTest.java
@@ -242,6 +242,7 @@ public class OcflPersistenceConfigTest {
         // Need to provide mock values for S3 client configuration
         when(ocflPropsConfig.getAwsRegion()).thenReturn("us-east-1");
         when(ocflPropsConfig.getS3ConnectionTimeout()).thenReturn(30);
+        when(ocflPropsConfig.getS3ConnectionAcquisitionTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3ReadTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3WriteTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3MaxConcurrency()).thenReturn(100);
@@ -279,6 +280,7 @@ public class OcflPersistenceConfigTest {
         // Need to provide mock values for S3 client configuration
         when(ocflPropsConfig.getAwsRegion()).thenReturn("us-east-1");
         when(ocflPropsConfig.getS3ConnectionTimeout()).thenReturn(30);
+        when(ocflPropsConfig.getS3ConnectionAcquisitionTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3ReadTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3WriteTimeout()).thenReturn(30);
         when(ocflPropsConfig.getS3MaxConcurrency()).thenReturn(100);


### PR DESCRIPTION
## Problem

Users on S3/OCFL storage hit this during commits under load:

```
software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request:
Acquire operation took longer than the configured maximum time. This indicates that a request
cannot get a connection from the pool within the specified maximum time.
...
org.fcrepo.persistence.api.exceptions.PersistentStorageException: Failed to move files ...
into ...extensions/0005-mutable-head/head/content/r1
```

This is a Netty **connection-acquisition** timeout — a request couldn't get a connection from the pool in time.

## Root cause

Two recent changes combined to cause it:

- **#2314** ("Rewiring s3 timeout property") changed `OcflPersistenceConfig` from
  `.connectionAcquisitionTimeout(getS3ConnectionTimeout())` to `.connectionTimeout(getS3ConnectionTimeout())`.
  The property `fcrepo.ocfl.s3.timeout.connection.seconds` (default 60) used to set the **acquisition**
  timeout; afterwards it sets the TCP **connection** timeout, and `connectionAcquisitionTimeout` fell back to
  the SDK default of **10s** — with no property left to configure it. (The `getS3ConnectionTimeout()` Javadoc
  still read "acquisition timeout," confirming this was unintended.)
- **#2309** enabled `multipartEnabled(true)`, so a single large-object PUT/copy now fans out into many
  concurrent part requests, each drawing a connection from the pool (`maxConcurrency`, default 100).

Net effect: connection demand went **up** (multipart) while the window to acquire a pooled connection dropped
**60s → 10s**, with no way to tune it back. Under concurrency or large files, the pool is exhausted and
acquisition times out — exactly the error above, on the large-file S3 write path.

## Fix

- Add a dedicated `fcrepo.ocfl.s3.timeout.acquisition.seconds` property (default **60**) wired to
  `connectionAcquisitionTimeout`, restoring configurable behavior and the pre-#2314 default.
- Keep #2314's `connectionTimeout` wiring (that part was a legitimate addition).
- Correct the stale `getS3ConnectionTimeout()` Javadoc.

No behavior change for anyone who wasn't relying on the old 60s acquisition default; operators can now also
raise it (or `fcrepo.ocfl.s3.max_concurrency`) to relieve pool pressure from multipart.

## Testing

`OcflPersistenceConfigTest` (builds the real Netty client) and `OcflPropsConfigTest` pass (9/9 in the former,
incl. both S3-client-creation tests); added the new default assertion and the client-builder stub.

## Backport

Needs backporting to `6.5-maintenance` for 6.5.3 — the affected users are on 6.5.2, which shipped both #2309
and #2314.
