### PR TITLE
Restore configurable S3 connection acquisition timeout (6.5.x backport of #2327)

### DIFF
--- a/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
+++ b/fcrepo-configs/src/main/java/org/fcrepo/config/OcflPropsConfig.java
@@ -123,6 +123,9 @@ public class OcflPropsConfig extends BasePropsConfig {
     @Value("${fcrepo.ocfl.s3.timeout.connection.seconds:60}")
     private int s3ConnectionTimeout;
 
+    @Value("${fcrepo.ocfl.s3.timeout.acquisition.seconds:60}")
+    private int s3ConnectionAcquisitionTimeout;
+
     @Value("${fcrepo.ocfl.s3.timeout.write.seconds:60}")
     private int s3WriteTimeout;
 
@@ -524,10 +527,18 @@ public class OcflPropsConfig extends BasePropsConfig {
     }
 
     /**
-     * @return the AWS S3 connection acquisition timeout in seconds.
+     * @return the AWS S3 connection timeout in seconds.
      */
     public int getS3ConnectionTimeout() {
         return s3ConnectionTimeout;
+    }
+
+    /**
+     * @return the AWS S3 connection acquisition timeout in seconds. This is the maximum time a request will wait to
+     *         acquire a connection from the client's connection pool before failing.
+     */
+    public int getS3ConnectionAcquisitionTimeout() {
+        return s3ConnectionAcquisitionTimeout;
     }
 
     /**

--- a/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
+++ b/fcrepo-persistence-ocfl/src/main/java/org/fcrepo/persistence/ocfl/impl/OcflPersistenceConfig.java
@@ -165,6 +165,8 @@ public class OcflPersistenceConfig {
         // May want to do additional HTTP client configuration, connection pool, etc
         final var httpClientBuilder = NettyNioAsyncHttpClient.builder()
                 .connectionTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ConnectionTimeout()))
+                .connectionAcquisitionTimeout(
+                        Duration.ofSeconds(ocflPropsConfig.getS3ConnectionAcquisitionTimeout()))
                 .writeTimeout(Duration.ofSeconds(ocflPropsConfig.getS3WriteTimeout()))
                 .readTimeout(Duration.ofSeconds(ocflPropsConfig.getS3ReadTimeout()))
                 .maxConcurrency(ocflPropsConfig.getS3MaxConcurrency());


### PR DESCRIPTION
## Backport of #2327 to the 6.5.x line (for 6.5.3)

Fixes the `Acquire operation took longer than the configured maximum time` failures reported against **6.5.2**, which shipped both #2309 (`multipartEnabled(true)`) and #2314 (which repurposed `fcrepo.ocfl.s3.timeout.connection.seconds` from the connection *acquisition* timeout to the TCP connection timeout, dropping `connectionAcquisitionTimeout` to the SDK default of 10s with no way to configure it).

Adds a dedicated `fcrepo.ocfl.s3.timeout.acquisition.seconds` property (default 60) wired to `connectionAcquisitionTimeout`, restoring the pre-#2314 default and making it configurable, while keeping #2314's `connectionTimeout` wiring. Also corrects the stale `getS3ConnectionTimeout()` Javadoc.

See #2327 for the full root-cause writeup.

### Note on tests
The `main` PR (#2327) also updates `OcflPropsConfigTest` / `OcflPersistenceConfigTest`, but **those test classes don't exist on `6.5-maintenance`** (added on main after the branch diverged), so this backport is the production change only. Verified with `mvn -pl fcrepo-persistence-ocfl -am compile`.

### Mitigation for affected 6.5.2 users (no upgrade required)
Raise `fcrepo.ocfl.s3.max_concurrency` (default 100) to relieve connection-pool pressure from multipart. Raising `...s3.timeout.connection.seconds` no longer helps the acquire timeout on 6.5.2.
