### PR TITLE
Deduplicate premis:hasSize

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -101,6 +101,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_NAMESPACE;
 import static org.fcrepo.kernel.api.RdfLexicon.REPOSITORY_ROOT;
 import static org.fcrepo.kernel.api.RdfLexicon.RESOURCE;
+import static org.fcrepo.kernel.api.RdfLexicon.SIZE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONED_RESOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
@@ -5559,49 +5560,63 @@ public class FedoraLdpIT extends AbstractResourceIT {
     @Test
     public void testPutOnBinaryHasSize() throws IOException {
         final String xsdLong = "http://www.w3.org/2001/XMLSchema#long";
+        final String xsdNonNegative = "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
         final String putBodyTemplate = "PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>\n" +
+                "PREFIX premis3: <http://www.loc.gov/premis/rdf/v3/>\n" +
                 "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
                 "\n" +
-                "<%s>\n" +
-                "        premis:hasSize           \"%s\"^^<%s>;\n" +
+                "<%1$s>\n" +
+                "        premis:hasSize           \"%2$s\"^^<%3$s>;\n" +
+                "        premis3:size             \"%2$s\"^^<%4$s>;\n" +
                 "        ebucore:filename         \"empty-test-file.txt\";\n" +
                 "        ebucore:hasMimeType      \"application/x-www-form-urlencoded\".";
+
         final String location;
         final var postBinary = postObjMethod();
         postBinary.setEntity(new StringEntity(generateRandomString(25)));
         postBinary.addHeader("Content-Disposition", "attachment; filename=\"empty-test-file.txt\"");
+        // Create the binary
         try (final var response = execute(postBinary)) {
             assertEquals(SC_CREATED, response.getStatusLine().getStatusCode());
             location = getLocation(response);
         }
+        // Get the binary description
         final Long hasSizeValue;
         try (final var dataset = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(dataset));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(dataset);
-            assertEquals(1, hasSizeTriples.size());
+            assertEquals(2, hasSizeTriples.size());
             hasSizeValue = Long.valueOf(hasSizeTriples.getFirst().getObject().getLiteral().getValue().toString());
         }
         // Triple with actual size (25L) as object
         final Triple actualSizeTriple = Triple.create(createURI(location), HAS_SIZE.asNode(),
                 createLiteralByValue(hasSizeValue));
+        final Triple actualSize3Triple = Triple.create(createURI(location), SIZE.asNode(),
+                createLiteralByValue(hasSizeValue, XSDDatatype.XSDnonNegativeInteger));
         // Add a different value for premis:hasSize
-        final String body = String.format(putBodyTemplate, location, "12345", xsdLong);
+        final String body = String.format(putBodyTemplate, location, "12345", xsdLong, xsdNonNegative);
         // Triple with fake size (12345L) as object
         final Triple fakeSize_12345_triple = Triple.create(createURI(location), HAS_SIZE.asNode(),
                 createLiteralByValue(12345L));
+        final Triple fakeSize3_12345_triple = Triple.create(createURI(location), SIZE.asNode(),
+                createLiteralByValue(12345, XSDDatatype.XSDnonNegativeInteger));
+        // Update binary description with user size triples
         final var putBinary = new HttpPut(location + "/" + FCR_METADATA);
         putBinary.setEntity(new StringEntity(body, UTF_8));
         putBinary.addHeader(CONTENT_TYPE, TURTLE);
         assertEquals(SC_NO_CONTENT, getStatus(putBinary));
+        // Get the binary description to check all triples exist
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(2, hasSizeTriples.size());
+            assertEquals(4, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
+            assertTrue(hasSizeTriples.contains(fakeSize3_12345_triple));
         }
         // Try to add the same value as originally calculated (i.e. 25L)
-        final String body2 = String.format(putBodyTemplate, location, hasSizeValue, xsdLong);
+        final String body2 = String.format(putBodyTemplate, location, hasSizeValue, xsdLong, xsdNonNegative);
         final var putBinary2 = new HttpPut(location + "/" + FCR_METADATA);
         putBinary2.setEntity(new StringEntity(body2, UTF_8));
         putBinary2.addHeader(CONTENT_TYPE, TURTLE);
@@ -5609,10 +5624,12 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(1, hasSizeTriples.size());
+            assertEquals(2, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
             // Just to make sure it was changed.
             assertFalse(hasSizeTriples.contains(fakeSize_12345_triple));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
+            assertFalse(hasSizeTriples.contains(fakeSize3_12345_triple));
         }
         // Now try excluding SMTs and still see the user's value which is the same.
         final var get4 = new HttpGet(location + "/" + FCR_METADATA);
@@ -5620,14 +5637,17 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(get4)) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(1, hasSizeTriples.size());
+            assertEquals(2, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
         }
         // Try to put the same value with a different datatype (int instead of long)
         // Triple with changed datatype as object
         final Triple wrong_datatype_triple = Triple.create(createURI(location), HAS_SIZE.asNode(),
                 createLiteralByValue(String.valueOf(hasSizeValue), XSDDatatype.XSDint));
-        final String body3 = String.format(putBodyTemplate, location, hasSizeValue, "http://www.w3.org/2001/XMLSchema#int");
+        final Triple wrong_datatype_triple2 = Triple.create(createURI(location), SIZE.asNode(),
+                createLiteralByValue(String.valueOf(hasSizeValue), XSDDatatype.XSDint));
+        final String body3 = String.format(putBodyTemplate, location, hasSizeValue, "http://www.w3.org/2001/XMLSchema#int", "http://www.w3.org/2001/XMLSchema#int");
         final var putBinary3 = new HttpPut(location + "/" + FCR_METADATA);
         putBinary3.setEntity(new StringEntity(body3, UTF_8));
         putBinary3.addHeader(CONTENT_TYPE, TURTLE);
@@ -5635,9 +5655,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(2, hasSizeTriples.size());
+            assertEquals(4, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(wrong_datatype_triple));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
+            assertTrue(hasSizeTriples.contains(wrong_datatype_triple2));
         }
         // Try to add the same value as first added (i.e. 12345L)
         final var putBinary4 = new HttpPut(location + "/" + FCR_METADATA);
@@ -5647,23 +5669,28 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(2, hasSizeTriples.size());
+            assertEquals(4, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
+            assertTrue(hasSizeTriples.contains(fakeSize3_12345_triple));
         }
         // Now add a whole new value
         final var putBinary5 = new HttpPut(location + "/" + FCR_METADATA);
-        final var body4 = String.format(putBodyTemplate, location, "9999", xsdLong);
+        final var body4 = String.format(putBodyTemplate, location, "9999", xsdLong, xsdNonNegative);
         putBinary5.setEntity(new StringEntity(body4, UTF_8)); // Reuse the body
         putBinary5.addHeader(CONTENT_TYPE, TURTLE);
         assertEquals(SC_NO_CONTENT, getStatus(putBinary5));
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(2, hasSizeTriples.size());
+            assertEquals(4, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), HAS_SIZE.asNode(),
                     createLiteralByValue(9999L))));
+            assertTrue(hasSizeTriples.contains(actualSize3Triple));
+            assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), SIZE.asNode(),
+                    createLiteralByValue(9999, XSDDatatype.XSDnonNegativeInteger))));
         }
         // Now try excluding SMTs and still see the user's value.
         final var get5 = new HttpGet(location + "/" + FCR_METADATA);
@@ -5671,10 +5698,13 @@ public class FedoraLdpIT extends AbstractResourceIT {
         try (final var response = execute(get5)) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
-            assertEquals(1, hasSizeTriples.size());
+            assertEquals(2, hasSizeTriples.size());
             assertFalse(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), HAS_SIZE.asNode(),
                     createLiteralByValue(9999L))));
+            assertFalse(hasSizeTriples.contains(actualSize3Triple));
+            assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), SIZE.asNode(),
+                    createLiteralByValue(9999, XSDDatatype.XSDnonNegativeInteger))));
         }
     }
 
@@ -5724,7 +5754,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
     /**
      * A graph/model is a set of triples, to be able to see duplicates we use a RDFParser directly.
      * @param resp The Response object from the GET
-     * @return a list of triples for premis:hasSize
+     * @return a list of triples for premis:hasSize and premis3:size
      * @throws IOException On exception reading HTTP response.
      */
     private List<Triple> parseResponseToHasSizeTriples(final CloseableHttpResponse resp)
@@ -5732,6 +5762,8 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final List<Triple> triples = new ArrayList<>();
         final Sink<Triple> triplesSink = new SinkToCollection<>(triples);
         RDFParser.source(resp.getEntity().getContent()).lang(Lang.TURTLE).parse(StreamRDFLib.sinkTriples(triplesSink));
-        return triples.stream().filter(t -> t.getPredicate().equals(HAS_SIZE.asNode())).toList();
+        return triples.stream().filter(t ->
+            t.getPredicate().equals(HAS_SIZE.asNode()) || t.getPredicate().equals(SIZE.asNode())
+        ).toList();
     }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -5,35 +5,6 @@
  */
 package org.fcrepo.integration.http.api;
 
-import static java.lang.Thread.sleep;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.time.ZoneId.of;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
-import static java.util.Arrays.asList;
-import static java.util.regex.Pattern.compile;
-import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static jakarta.ws.rs.core.HttpHeaders.LINK;
-import static jakarta.ws.rs.core.HttpHeaders.LOCATION;
-import static jakarta.ws.rs.core.Link.fromUri;
-import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
-import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
-import static jakarta.ws.rs.core.Response.Status.CONFLICT;
-import static jakarta.ws.rs.core.Response.Status.CREATED;
-import static jakarta.ws.rs.core.Response.Status.GONE;
-import static jakarta.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
-import static jakarta.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
-import static jakarta.ws.rs.core.Response.Status.NOT_MODIFIED;
-import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
-import static jakarta.ws.rs.core.Response.Status.OK;
-import static jakarta.ws.rs.core.Response.Status.PARTIAL_CONTENT;
-import static jakarta.ws.rs.core.Response.Status.PRECONDITION_FAILED;
-import static jakarta.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
-import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-import static nu.validator.htmlparser.common.XmlViolationPolicy.ALLOW;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
@@ -61,8 +32,17 @@ import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
 import static org.apache.jena.riot.WebContent.contentTypeTurtle;
 import static org.apache.jena.vocabulary.DC_11.title;
 import static org.apache.jena.vocabulary.RDF.type;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.slf4j.LoggerFactory.getLogger;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_ACL;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_FIXITY;
 import static org.fcrepo.kernel.api.FedoraTypes.FCR_METADATA;
@@ -105,15 +85,93 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
 import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 import static org.fcrepo.kernel.api.models.ExternalContent.REDIRECT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.slf4j.LoggerFactory.getLogger;
+import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneId.of;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.Arrays.asList;
+import static java.util.regex.Pattern.compile;
+import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.LINK;
+import static jakarta.ws.rs.core.HttpHeaders.LOCATION;
+import static jakarta.ws.rs.core.Link.fromUri;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static jakarta.ws.rs.core.Response.Status.GONE;
+import static jakarta.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
+import static jakarta.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.NOT_MODIFIED;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.PARTIAL_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static jakarta.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static nu.validator.htmlparser.common.XmlViolationPolicy.ALLOW;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.atlas.lib.Sink;
+import org.apache.jena.atlas.lib.SinkToCollection;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.system.StreamRDFLib;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.DC_11;
+import org.apache.jena.vocabulary.RDF;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.springframework.test.context.TestExecutionListeners;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.fcrepo.http.commons.domain.RDFMediaType;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.api.RdfLexicon;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -142,64 +200,11 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
-
 import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.Variant;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterators;
 import nu.validator.htmlparser.sax.HtmlParser;
 import nu.validator.saxtree.TreeBuilder;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.FileEntity;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.apache.http.util.EntityUtils;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.vocabulary.DC_11;
-import org.apache.jena.vocabulary.RDF;
-import org.fcrepo.http.commons.domain.RDFMediaType;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.kernel.api.RdfLexicon;
-import org.glassfish.jersey.media.multipart.ContentDisposition;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.springframework.test.context.TestExecutionListeners;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 /**
  * @author cabeer
@@ -5548,6 +5553,90 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    @Test
+    public void testPutOnBinaryHasSize() throws IOException {
+        final String putBodyTemplate = "PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>\n" +
+                "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
+                "\n" +
+                "<%s>\n" +
+                "        premis:hasSize           \"%s\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
+                "        ebucore:filename         \"empty-test-file.txt\";\n" +
+                "        ebucore:hasMimeType      \"application/x-www-form-urlencoded\".";
+        final String location;
+        final var postBinary = postObjMethod();
+        postBinary.setEntity(new StringEntity(generateRandomString(25)));
+        postBinary.addHeader("Content-Disposition", "attachment; filename=\"empty-test-file.txt\"");
+        try (final var response = execute(postBinary)) {
+            assertEquals(SC_CREATED, response.getStatusLine().getStatusCode());
+            location = getLocation(response);
+        }
+        final Long hasSizeValue;
+        try (final var dataset = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(dataset));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(dataset);
+            assertEquals(1, hasSizeTriples.size());
+            hasSizeValue = Long.valueOf(hasSizeTriples.getFirst().getObject().getLiteral().getValue().toString());
+        }
+        // Triple with actual size (25L) as object
+        final Triple actualSizeTriple = Triple.create(createURI(location), HAS_SIZE.asNode(),
+                createLiteralByValue(hasSizeValue));
+        // Add a different value for premis:hasSize
+        final String body = String.format(putBodyTemplate, location, "12345");
+        // Triple with fake size (12345L) as object
+        final Triple fakeSize_12345_triple = Triple.create(createURI(location), HAS_SIZE.asNode(),
+                createLiteralByValue(12345L));
+        final var putBinary = new HttpPut(location + "/" + FCR_METADATA);
+        putBinary.setEntity(new StringEntity(body, UTF_8));
+        putBinary.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary));
+        try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(2, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
+        }
+        // Try to add the same value as originally calculated (i.e. 25L)
+        final String body2 = String.format(putBodyTemplate, location, hasSizeValue);
+        final var putBinary2 = new HttpPut(location + "/" + FCR_METADATA);
+        putBinary2.setEntity(new StringEntity(body2, UTF_8));
+        putBinary2.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary2));
+        try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(1, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertFalse(hasSizeTriples.contains(fakeSize_12345_triple));
+        }
+        // Try to add the same value as first added (i.e. 12345L)
+        final var putBinary3 = new HttpPut(location + "/" + FCR_METADATA);
+        putBinary3.setEntity(new StringEntity(body, UTF_8)); // Reuse the body
+        putBinary3.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary3));
+        try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(2, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
+        }
+        // Now add a whole new value
+        final var putBinary4 = new HttpPut(location + "/" + FCR_METADATA);
+        final var body4 = String.format(putBodyTemplate, location, "9999");
+        putBinary4.setEntity(new StringEntity(body4, UTF_8)); // Reuse the body
+        putBinary4.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary4));
+        try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(2, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), HAS_SIZE.asNode(),
+                    createLiteralByValue(9999L))));
+        }
+    }
+
     private void assertIdStringConstraint(final String id) throws IOException {
         assertInvalidId(id);
         assertValidId(id + "-suffix");
@@ -5576,4 +5665,27 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    private String generateRandomString(final int length) {
+        final String characters = "0123456abcdefghijklmnopqrstuvwxyz";
+        final var rng = new Random();
+        final char[] text = new char[length];
+        for (int i = 0; i < length; i++) {
+            text[i] = characters.charAt(rng.nextInt(characters.length()));
+        }
+        return new String(text);
+    }
+
+    /**
+     * A graph/model is a set of triples, to be able to see duplicates we use a RDFParser directly.
+     * @param resp The Response object from the GET
+     * @return a list of triples for premis:hasSize
+     * @throws IOException On exception reading HTTP response.
+     */
+    private List<Triple> parseResponseToHasSizeTriples(final CloseableHttpResponse resp)
+            throws IOException {
+        final List<Triple> triples = new ArrayList<>();
+        final Sink<Triple> triplesSink = new SinkToCollection<>(triples);
+        RDFParser.source(resp.getEntity().getContent()).lang(Lang.TURTLE).parse(StreamRDFLib.sinkTriples(triplesSink));
+        return triples.stream().filter(t -> t.getPredicate().equals(HAS_SIZE.asNode())).toList();
+    }
 }

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -5,6 +5,35 @@
  */
 package org.fcrepo.integration.http.api;
 
+import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.ZoneId.of;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.Arrays.asList;
+import static java.util.regex.Pattern.compile;
+import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.LINK;
+import static jakarta.ws.rs.core.HttpHeaders.LOCATION;
+import static jakarta.ws.rs.core.Link.fromUri;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.CONFLICT;
+import static jakarta.ws.rs.core.Response.Status.CREATED;
+import static jakarta.ws.rs.core.Response.Status.GONE;
+import static jakarta.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
+import static jakarta.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.NOT_MODIFIED;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.PARTIAL_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static jakarta.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
+import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
+import static nu.validator.htmlparser.common.XmlViolationPolicy.ALLOW;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
@@ -32,14 +61,6 @@ import static org.apache.jena.riot.WebContent.contentTypeSPARQLUpdate;
 import static org.apache.jena.riot.WebContent.contentTypeTurtle;
 import static org.apache.jena.vocabulary.DC_11.title;
 import static org.apache.jena.vocabulary.RDF.type;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.slf4j.LoggerFactory.getLogger;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_RESPONSE_VARIANTS_STRING;
 import static org.fcrepo.http.commons.domain.RDFMediaType.POSSIBLE_RDF_VARIANTS;
 import static org.fcrepo.http.commons.domain.RDFMediaType.TURTLE;
@@ -85,93 +106,15 @@ import static org.fcrepo.kernel.api.RdfLexicon.VERSIONING_TIMEGATE_TYPE;
 import static org.fcrepo.kernel.api.models.ExternalContent.COPY;
 import static org.fcrepo.kernel.api.models.ExternalContent.PROXY;
 import static org.fcrepo.kernel.api.models.ExternalContent.REDIRECT;
-import static java.lang.Thread.sleep;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.time.ZoneId.of;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
-import static java.util.Arrays.asList;
-import static java.util.regex.Pattern.compile;
-import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_LENGTH;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static jakarta.ws.rs.core.HttpHeaders.LINK;
-import static jakarta.ws.rs.core.HttpHeaders.LOCATION;
-import static jakarta.ws.rs.core.Link.fromUri;
-import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
-import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
-import static jakarta.ws.rs.core.Response.Status.CONFLICT;
-import static jakarta.ws.rs.core.Response.Status.CREATED;
-import static jakarta.ws.rs.core.Response.Status.GONE;
-import static jakarta.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
-import static jakarta.ws.rs.core.Response.Status.NOT_ACCEPTABLE;
-import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
-import static jakarta.ws.rs.core.Response.Status.NOT_MODIFIED;
-import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
-import static jakarta.ws.rs.core.Response.Status.OK;
-import static jakarta.ws.rs.core.Response.Status.PARTIAL_CONTENT;
-import static jakarta.ws.rs.core.Response.Status.PRECONDITION_FAILED;
-import static jakarta.ws.rs.core.Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE;
-import static jakarta.ws.rs.core.Response.Status.UNSUPPORTED_MEDIA_TYPE;
-import static nu.validator.htmlparser.common.XmlViolationPolicy.ALLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.slf4j.LoggerFactory.getLogger;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Iterators;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.BasicHttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.entity.FileEntity;
-import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
-import org.apache.http.util.EntityUtils;
-import org.apache.jena.atlas.lib.Sink;
-import org.apache.jena.atlas.lib.SinkToCollection;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.graph.Triple;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Property;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.riot.RDFParser;
-import org.apache.jena.riot.system.StreamRDFLib;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.vocabulary.DC_11;
-import org.apache.jena.vocabulary.RDF;
-import org.glassfish.jersey.media.multipart.ContentDisposition;
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.springframework.test.context.TestExecutionListeners;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.fcrepo.http.commons.domain.RDFMediaType;
-import org.fcrepo.http.commons.test.util.CloseableDataset;
-import org.fcrepo.kernel.api.RdfLexicon;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -200,11 +143,71 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
+
 import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.Variant;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterators;
 import nu.validator.htmlparser.sax.HtmlParser;
 import nu.validator.saxtree.TreeBuilder;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.jena.atlas.lib.Sink;
+import org.apache.jena.atlas.lib.SinkToCollection;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.system.StreamRDFLib;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.DC_11;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.http.commons.domain.RDFMediaType;
+import org.fcrepo.http.commons.test.util.CloseableDataset;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.springframework.test.context.TestExecutionListeners;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * @author cabeer
@@ -5555,11 +5558,12 @@ public class FedoraLdpIT extends AbstractResourceIT {
 
     @Test
     public void testPutOnBinaryHasSize() throws IOException {
+        final String xsdLong = "http://www.w3.org/2001/XMLSchema#long";
         final String putBodyTemplate = "PREFIX premis: <http://www.loc.gov/premis/rdf/v1#>\n" +
                 "PREFIX ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#>\n" +
                 "\n" +
                 "<%s>\n" +
-                "        premis:hasSize           \"%s\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
+                "        premis:hasSize           \"%s\"^^<%s>;\n" +
                 "        ebucore:filename         \"empty-test-file.txt\";\n" +
                 "        ebucore:hasMimeType      \"application/x-www-form-urlencoded\".";
         final String location;
@@ -5581,7 +5585,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
         final Triple actualSizeTriple = Triple.create(createURI(location), HAS_SIZE.asNode(),
                 createLiteralByValue(hasSizeValue));
         // Add a different value for premis:hasSize
-        final String body = String.format(putBodyTemplate, location, "12345");
+        final String body = String.format(putBodyTemplate, location, "12345", xsdLong);
         // Triple with fake size (12345L) as object
         final Triple fakeSize_12345_triple = Triple.create(createURI(location), HAS_SIZE.asNode(),
                 createLiteralByValue(12345L));
@@ -5597,7 +5601,7 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
         }
         // Try to add the same value as originally calculated (i.e. 25L)
-        final String body2 = String.format(putBodyTemplate, location, hasSizeValue);
+        final String body2 = String.format(putBodyTemplate, location, hasSizeValue, xsdLong);
         final var putBinary2 = new HttpPut(location + "/" + FCR_METADATA);
         putBinary2.setEntity(new StringEntity(body2, UTF_8));
         putBinary2.addHeader(CONTENT_TYPE, TURTLE);
@@ -5607,13 +5611,39 @@ public class FedoraLdpIT extends AbstractResourceIT {
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
             assertEquals(1, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            // Just to make sure it was changed.
             assertFalse(hasSizeTriples.contains(fakeSize_12345_triple));
         }
-        // Try to add the same value as first added (i.e. 12345L)
+        // Now try excluding SMTs and still see the user's value which is the same.
+        final var get4 = new HttpGet(location + "/" + FCR_METADATA);
+        get4.addHeader("Prefer", "return=representation; omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\"");
+        try (final var response = execute(get4)) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(1, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+        }
+        // Try to put the same value with a different datatype (int instead of long)
+        // Triple with changed datatype as object
+        final Triple wrong_datatype_triple = Triple.create(createURI(location), HAS_SIZE.asNode(),
+                createLiteralByValue(String.valueOf(hasSizeValue), XSDDatatype.XSDint));
+        final String body3 = String.format(putBodyTemplate, location, hasSizeValue, "http://www.w3.org/2001/XMLSchema#int");
         final var putBinary3 = new HttpPut(location + "/" + FCR_METADATA);
-        putBinary3.setEntity(new StringEntity(body, UTF_8)); // Reuse the body
+        putBinary3.setEntity(new StringEntity(body3, UTF_8));
         putBinary3.addHeader(CONTENT_TYPE, TURTLE);
         assertEquals(SC_NO_CONTENT, getStatus(putBinary3));
+        try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(2, hasSizeTriples.size());
+            assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(wrong_datatype_triple));
+        }
+        // Try to add the same value as first added (i.e. 12345L)
+        final var putBinary4 = new HttpPut(location + "/" + FCR_METADATA);
+        putBinary4.setEntity(new StringEntity(body, UTF_8)); // Reuse the body
+        putBinary4.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary4));
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
@@ -5622,16 +5652,27 @@ public class FedoraLdpIT extends AbstractResourceIT {
             assertTrue(hasSizeTriples.contains(fakeSize_12345_triple));
         }
         // Now add a whole new value
-        final var putBinary4 = new HttpPut(location + "/" + FCR_METADATA);
-        final var body4 = String.format(putBodyTemplate, location, "9999");
-        putBinary4.setEntity(new StringEntity(body4, UTF_8)); // Reuse the body
-        putBinary4.addHeader(CONTENT_TYPE, TURTLE);
-        assertEquals(SC_NO_CONTENT, getStatus(putBinary4));
+        final var putBinary5 = new HttpPut(location + "/" + FCR_METADATA);
+        final var body4 = String.format(putBodyTemplate, location, "9999", xsdLong);
+        putBinary5.setEntity(new StringEntity(body4, UTF_8)); // Reuse the body
+        putBinary5.addHeader(CONTENT_TYPE, TURTLE);
+        assertEquals(SC_NO_CONTENT, getStatus(putBinary5));
         try (final var response = execute(new HttpGet(location + "/" + FCR_METADATA))) {
             assertEquals(SC_OK, getStatus(response));
             final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
             assertEquals(2, hasSizeTriples.size());
             assertTrue(hasSizeTriples.contains(actualSizeTriple));
+            assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), HAS_SIZE.asNode(),
+                    createLiteralByValue(9999L))));
+        }
+        // Now try excluding SMTs and still see the user's value.
+        final var get5 = new HttpGet(location + "/" + FCR_METADATA);
+        get5.addHeader("Prefer", "return=representation; omit=\"http://fedora.info/definitions/fcrepo#ServerManaged\"");
+        try (final var response = execute(get5)) {
+            assertEquals(SC_OK, getStatus(response));
+            final List<Triple> hasSizeTriples = parseResponseToHasSizeTriples(response);
+            assertEquals(1, hasSizeTriples.size());
+            assertFalse(hasSizeTriples.contains(actualSizeTriple));
             assertTrue(hasSizeTriples.contains(Triple.create(createURI(location), HAS_SIZE.asNode(),
                     createLiteralByValue(9999L))));
         }
@@ -5665,6 +5706,11 @@ public class FedoraLdpIT extends AbstractResourceIT {
         }
     }
 
+    /**
+     * Generate a random alphanumeric string
+     * @param length the length of the string
+     * @return the string
+     */
     private String generateRandomString(final int length) {
         final String characters = "0123456abcdefghijklmnopqrstuvwxyz";
         final var rng = new Random();

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -5,6 +5,9 @@
  */
 package org.fcrepo.kernel.impl.services;
 
+import static org.apache.jena.graph.NodeFactory.createLiteralByValue;
+import static org.apache.jena.graph.NodeFactory.createURI;
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
 import static java.util.stream.Stream.empty;
 
 import java.util.ArrayList;
@@ -13,8 +16,12 @@ import java.util.stream.Stream;
 
 import jakarta.inject.Inject;
 
+import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
+import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
+import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
 import org.fcrepo.kernel.api.services.ContainmentTriplesService;
 import org.fcrepo.kernel.api.services.ManagedPropertiesService;
@@ -22,6 +29,8 @@ import org.fcrepo.kernel.api.services.MembershipService;
 import org.fcrepo.kernel.api.services.ReferenceService;
 import org.fcrepo.kernel.api.services.ResourceTripleService;
 
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -55,7 +64,11 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
 
         // Provide user RDF if we didn't ask for omit=ldp:PreferMinimalContainer.
         if (preferences.displayUserRdf()) {
-            streams.add(resource.getTriples());
+            RdfStream userTriples = resource.getTriples();
+            if (preferences.displayServerManaged() && resource instanceof NonRdfSourceDescription) {
+                userTriples = deduplicateHasSize(resource, userTriples);
+            }
+            streams.add(userTriples);
         }
         // Provide server-managed triples if we didn't ask for omit=fedora:ServerManaged or
         // omit=ldp:PreferMinimalContainer
@@ -86,6 +99,23 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
         }
 
         return streams.stream().reduce(empty(), Stream::concat);
+    }
+
+    /**
+     * Filter out premis:hasSize triples from the user if it's identical to the server manage instance.
+     * @param resource The resource
+     * @param userTriples The user provided triples
+     * @return The new stream of triples
+     */
+    private RdfStream deduplicateHasSize(final FedoraResource resource, final RdfStream userTriples) {
+        final Node subject = createURI(resource.getDescribedResource().getId());
+        final Triple hasSizeSMT = Triple.create(
+                subject,
+                HAS_SIZE.asNode(),
+                createLiteralByValue(String.valueOf(((Binary)resource.getDescribedResource()).getContentSize()),
+                        XSDDatatype.XSDlong)
+        );
+        return new DefaultRdfStream(subject, userTriples.filter(t -> !t.equals(hasSizeSMT)));
     }
 
 }

--- a/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
+++ b/fcrepo-kernel-impl/src/main/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImpl.java
@@ -8,6 +8,7 @@ package org.fcrepo.kernel.impl.services;
 import static org.apache.jena.graph.NodeFactory.createLiteralByValue;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
+import static org.fcrepo.kernel.api.RdfLexicon.SIZE;
 import static java.util.stream.Stream.empty;
 
 import java.util.ArrayList;
@@ -102,20 +103,26 @@ public class ResourceTripleServiceImpl implements ResourceTripleService {
     }
 
     /**
-     * Filter out premis:hasSize triples from the user if it's identical to the server manage instance.
+     * Filter out premis:hasSize and premis3:size triples from the user if it's identical to the server manage instance.
      * @param resource The resource
      * @param userTriples The user provided triples
      * @return The new stream of triples
      */
     private RdfStream deduplicateHasSize(final FedoraResource resource, final RdfStream userTriples) {
         final Node subject = createURI(resource.getDescribedResource().getId());
+        final Long contentSize = ((Binary)resource.getDescribedResource()).getContentSize();
         final Triple hasSizeSMT = Triple.create(
                 subject,
                 HAS_SIZE.asNode(),
-                createLiteralByValue(String.valueOf(((Binary)resource.getDescribedResource()).getContentSize()),
-                        XSDDatatype.XSDlong)
+                createLiteralByValue(String.valueOf(contentSize), XSDDatatype.XSDlong)
         );
-        return new DefaultRdfStream(subject, userTriples.filter(t -> !t.equals(hasSizeSMT)));
+        final Triple hasSize3SMT = Triple.create(
+                subject,
+                SIZE.asNode(),
+                createLiteralByValue(String.valueOf(contentSize), XSDDatatype.XSDnonNegativeInteger)
+        );
+        return new DefaultRdfStream(subject, userTriples
+                .filter(t -> !(t.equals(hasSizeSMT) || t.equals(hasSize3SMT))));
     }
 
 }

--- a/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImplTest.java
+++ b/fcrepo-kernel-impl/src/test/java/org/fcrepo/kernel/impl/services/ResourceTripleServiceImplTest.java
@@ -6,19 +6,28 @@
 package org.fcrepo.kernel.impl.services;
 
 import static java.util.stream.Stream.of;
+import static org.apache.jena.graph.NodeFactory.createLiteralByValue;
 import static org.apache.jena.graph.NodeFactory.createLiteralString;
 import static org.apache.jena.graph.NodeFactory.createURI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import static org.fcrepo.kernel.api.RdfLexicon.HAS_SIZE;
+import static org.fcrepo.kernel.api.RdfLexicon.SIZE;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.Transaction;
 import org.fcrepo.kernel.api.identifiers.FedoraId;
+import org.fcrepo.kernel.api.models.Binary;
 import org.fcrepo.kernel.api.models.FedoraResource;
+import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.rdf.LdpTriplePreferences;
 import org.fcrepo.kernel.api.services.ContainmentTriplesService;
@@ -66,6 +75,9 @@ public class ResourceTripleServiceImplTest {
     private FedoraResource resource;
 
     @Mock
+    private NonRdfSourceDescription resource2;
+
+    @Mock
     private LdpTriplePreferences preferences;
 
     @InjectMocks
@@ -73,6 +85,7 @@ public class ResourceTripleServiceImplTest {
 
     private Node resourceSubject;
     private FedoraId resourceId;
+    private FedoraId resourceId2;
 
     private Triple userTriple1;
     private Triple userTriple2;
@@ -86,6 +99,14 @@ public class ResourceTripleServiceImplTest {
     private Triple referenceTriple2;
     private Triple membershipByObjectTriple;
     private Triple containedByTriple;
+    // Server managed premis:hasSize
+    private Triple hasSizeTriple;
+    // User provided premis:hasSize
+    private Triple hasSizeTriple2;
+    // Server managed premis3:size
+    private Triple hasSize3Triple;
+    // User provided premis3:size
+    private Triple hasSize3Triple2;
 
     @BeforeEach
     public void setup() {
@@ -138,6 +159,14 @@ public class ResourceTripleServiceImplTest {
         containedByTriple = Triple.create(createURI("info:fedora/parent"),
                 createURI("http://www.w3.org/ns/ldp#contains"),
                 resourceSubject);
+
+        hasSizeTriple = Triple.create(resourceSubject, HAS_SIZE.asNode(), createLiteralByValue(123L));
+        hasSizeTriple2 = Triple.create(resourceSubject, HAS_SIZE.asNode(),
+                createLiteralByValue("123", XSDDatatype.XSDint));
+        hasSize3Triple = Triple.create(resourceSubject, SIZE.asNode(),
+                createLiteralByValue(123, XSDDatatype.XSDnonNegativeInteger));
+        hasSize3Triple2 = Triple.create(resourceSubject, SIZE.asNode(),
+                createLiteralByValue("123", XSDDatatype.XSDint));
 
         when(resource.getTriples()).thenReturn(rdfStreamOf(userTriple1, userTriple2));
         when(managedPropertiesService.get(resource)).thenReturn(of(serverTriple1, serverTriple2));
@@ -270,5 +299,120 @@ public class ResourceTripleServiceImplTest {
         verify(referenceService).getInboundReferences(transaction, resource);
         verify(membershipService).getMembershipByObject(transaction, resourceId);
         verify(containmentTriplesService).getContainedBy(transaction, resource);
+    }
+
+    /**
+     * Don't deduplicate when size/hasSize triples are not exact copies
+     */
+    @Test
+    public void testShowAllSizesWhenNotMatch() {
+        // Make a NonRdfDescription
+        resourceId2 = resourceId.asDescription();
+        when(resource2.getFedoraId()).thenReturn(resourceId2);
+        resource = mock(Binary.class);
+        when(resource.getId()).thenReturn(resourceId.getFullId());
+        when(((Binary)resource).getContentSize()).thenReturn(123L);
+        when(resource2.getDescribedResource()).thenReturn(resource);
+
+
+        // Setup preferences - turn off the other services
+        when(preferences.displayUserRdf()).thenReturn(true);
+        when(preferences.displayServerManaged()).thenReturn(true);
+        when(preferences.displayContainment()).thenReturn(false);
+        when(preferences.displayMembership()).thenReturn(false);
+        when(preferences.displayReferences()).thenReturn(false);
+
+        // User returns a different value from SMTs
+        when(resource2.getTriples()).thenReturn(rdfStreamOf(hasSizeTriple2, hasSize3Triple2));
+        when(managedPropertiesService.get(resource2)).thenReturn(rdfStreamOf(hasSizeTriple, hasSize3Triple));
+
+        // Call the service
+        final Stream<Triple> resultStream = service.getResourceTriples(transaction, resource2, preferences, -1);
+
+        // Get all triples from the stream
+        final List<Triple> results = resultStream.collect(Collectors.toList());
+
+        // Verify both premis:hasSize and both premis3:size triples are returned
+        assertEquals(4, results.size());
+
+        // Verify all services were called
+        verify(resource2).getTriples();
+        verify(managedPropertiesService).get(resource2);
+    }
+
+    /**
+     * Deduplicate when size/hasSize triples are exact copies
+     */
+    @Test
+    public void testDeduplicateHasSizeMatch() {
+        // Make a NonRdfDescription
+        resourceId2 = resourceId.asDescription();
+        when(resource2.getFedoraId()).thenReturn(resourceId2);
+        resource = mock(Binary.class);
+        when(resource.getId()).thenReturn(resourceId.getFullId());
+        when(((Binary)resource).getContentSize()).thenReturn(123L);
+        when(resource2.getDescribedResource()).thenReturn(resource);
+
+        // Setup preferences - turn off the other services
+        when(preferences.displayUserRdf()).thenReturn(true);
+        when(preferences.displayServerManaged()).thenReturn(true);
+        when(preferences.displayContainment()).thenReturn(false);
+        when(preferences.displayMembership()).thenReturn(false);
+        when(preferences.displayReferences()).thenReturn(false);
+
+        // User returns the same hasSize as SMTs
+        when(resource2.getTriples()).thenReturn(rdfStreamOf(hasSizeTriple, hasSize3Triple));
+        when(managedPropertiesService.get(resource2)).thenReturn(rdfStreamOf(hasSizeTriple, hasSize3Triple));
+
+        // Call the service
+        final Stream<Triple> resultStream = service.getResourceTriples(transaction, resource2, preferences, -1);
+
+        // Get all triples from the stream
+        final List<Triple> results = resultStream.collect(Collectors.toList());
+
+        // Verify only one premis:hasSize and one premis3:size triple is returned
+        assertEquals(2, results.size());
+
+        // Verify all services were called
+        verify(resource2).getTriples();
+        verify(managedPropertiesService).get(resource2);
+    }
+
+    /**
+     * Don't deduplicate if we are not displaying Server Managed Triples
+     */
+    @Test
+    public void testNoDeduplicateHasSizeWhenNoSMT() {
+        // Make a NonRdfDescription
+        resourceId2 = resourceId.asDescription();
+        when(resource2.getFedoraId()).thenReturn(resourceId2);
+        resource = mock(Binary.class);
+        when(resource.getId()).thenReturn(resourceId.getFullId());
+        when(((Binary)resource).getContentSize()).thenReturn(123L);
+        when(resource2.getDescribedResource()).thenReturn(resource);
+
+        // Setup preferences - shouldn't matter as all services return empty
+        when(preferences.displayUserRdf()).thenReturn(true);
+        when(preferences.displayServerManaged()).thenReturn(false);
+        when(preferences.displayContainment()).thenReturn(false);
+        when(preferences.displayMembership()).thenReturn(false);
+        when(preferences.displayReferences()).thenReturn(false);
+
+        // User returns the same hasSize as SMTs
+        when(resource2.getTriples()).thenReturn(rdfStreamOf(hasSizeTriple, hasSize3Triple));
+        when(managedPropertiesService.get(resource2)).thenReturn(rdfStreamOf(hasSizeTriple, hasSize3Triple));
+
+        // Call the service
+        final Stream<Triple> resultStream = service.getResourceTriples(transaction, resource2, preferences, -1);
+
+        // Get all triples from the stream
+        final List<Triple> results = resultStream.collect(Collectors.toList());
+
+        // Verify only one premis:hasSize and one premis3:size triple is returned
+        assertEquals(2, results.size());
+
+        // Verify all services were called
+        verify(resource2).getTriples();
+        verifyNoInteractions(managedPropertiesService);
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4096

# What does this Pull Request do?
Remove user's `premis:hasSize` triple if it is identical to the server managed triple of the same property.

# How should this be tested?

* Create a binary
* Get the binary description (fcr:metadata)
* Remove all of the properties except the premis:hasSize and premis3:size
* PUT it back over-top the fcr:metadata endpoint.
* Get the binary description and see it now has 2 premis:hasSize triples that are identical and 2 premis3:size triples that are identical.
* Stop Fedora
* Pull down and build this PR.
* Start Fedora
* Get the binary description and see it now has 1 premis:hasSize and 1 premis3:size triple.
* Confirm while including the `Prefer: return=representation; omit="http://fedora.info/definitions/fcrepo#ServerManaged"` header.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
