### PR TITLE
FCREPO-4093 Return post-update ETag from PATCH and PUT

### DIFF
--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/ContentExposingResource.java
@@ -421,7 +421,16 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
 
     protected FedoraResource reloadResource() {
         this.fedoraResource = null;
+        invalidateCachedRdfEtag();
         return resource();
+    }
+
+    /**
+     * Discard the etag computed earlier in this request. The cached value is only valid for the state of the
+     * resource at the time it was computed, so it must be dropped after the resource has been modified.
+     */
+    protected void invalidateCachedRdfEtag() {
+        this.cachedRdfEtag = null;
     }
 
     /**
@@ -872,6 +881,7 @@ public abstract class ContentExposingResource extends FedoraBaseResource {
      *         content depending on Prefer headers.
      */
     protected Response createUpdateResponse(final FedoraResource resource, final boolean created) {
+        invalidateCachedRdfEtag();
         addCacheControlHeaders(servletResponse, resource, transaction());
         addResourceLinkHeaders(resource, created);
         addExternalContentHeaders(resource);

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -214,7 +214,12 @@ public class FedoraAcl extends ContentExposingResource {
                 patchResourcewithSparql(aclResource, newRequest);
                 transaction().commitIfShortLived();
             });
-            addCacheControlHeaders(servletResponse, aclResource, transaction());
+            invalidateCachedRdfEtag();
+            try {
+                addCacheControlHeaders(servletResponse, getFedoraResource(transaction(), aclId), transaction());
+            } catch (final PathNotFoundException e) {
+                throw new PathNotFoundRuntimeException(e.getMessage(), e);
+            }
 
             return noContent().build();
         } catch (final IllegalArgumentException iae) {

--- a/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
+++ b/fcrepo-http-api/src/main/java/org/fcrepo/http/api/FedoraAcl.java
@@ -172,7 +172,7 @@ public class FedoraAcl extends ContentExposingResource {
     @PATCH
     @Consumes({ contentTypeSPARQLUpdate })
     public Response updateSparql(final InputStream requestBodyStream)
-        throws IOException, ItemNotFoundException {
+        throws IOException, ItemNotFoundException, PathNotFoundException {
         hasRestrictedPath(externalPath);
 
         if (null == requestBodyStream) {
@@ -215,11 +215,7 @@ public class FedoraAcl extends ContentExposingResource {
                 transaction().commitIfShortLived();
             });
             invalidateCachedRdfEtag();
-            try {
-                addCacheControlHeaders(servletResponse, getFedoraResource(transaction(), aclId), transaction());
-            } catch (final PathNotFoundException e) {
-                throw new PathNotFoundRuntimeException(e.getMessage(), e);
-            }
+            addCacheControlHeaders(servletResponse, getFedoraResource(transaction(), aclId), transaction());
 
             return noContent().build();
         } catch (final IllegalArgumentException iae) {

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraAclIT.java
@@ -25,6 +25,7 @@ import static org.fcrepo.kernel.api.RdfLexicon.RDF_SOURCE;
 import static org.fcrepo.kernel.api.RdfLexicon.WEBAC_NAMESPACE_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -140,6 +141,31 @@ public class FedoraAclIT extends AbstractResourceIT {
                                       createURI("http://www.w3.org/ns/auth/acl#Write")));
         }
 
+    }
+
+    @Test
+    public void testPatchAclResponseReturnsUpdatedEtag() throws Exception {
+        createObjectAndClose(id);
+        final String aclURI = createACL();
+
+        final String etagBefore = getEtag(aclURI);
+        assertTrue(etagBefore.startsWith("W/"), "Expected weak ETag");
+
+        final HttpPatch patch = new HttpPatch(aclURI);
+        patch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patch.addHeader("If-Match", etagBefore.substring(2));
+        patch.setEntity(new StringEntity("PREFIX acl: <http://www.w3.org/ns/auth/acl#> " +
+                                         "INSERT { <#writeAccess> acl:mode acl:Write . } WHERE { }"));
+
+        final String etagFromPatch;
+        try (final CloseableHttpResponse response = execute(patch)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+            etagFromPatch = getEtag(response);
+        }
+
+        final String etagAfter = getEtag(aclURI);
+        assertNotEquals(etagBefore, etagFromPatch, "PATCH returned the ETag from before the update");
+        assertEquals(etagAfter, etagFromPatch, "PATCH ETag does not match the ETag of the updated ACL");
     }
 
     @Test

--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraLdpIT.java
@@ -1706,6 +1706,57 @@ public class FedoraLdpIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPatchResponseReturnsUpdatedEtag() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String uri = serverAddress + id;
+
+        final String etagBefore = getEtag(uri);
+        assertTrue(etagBefore.startsWith("W/"), "Expected weak ETag");
+
+        final HttpPatch patch = patchObjMethod(id);
+        patch.addHeader(CONTENT_TYPE, "application/sparql-update");
+        patch.addHeader("If-Match", etagBefore.substring(2));
+        patch.setEntity(new StringEntity(
+                "INSERT { <> <http://purl.org/dc/elements/1.1/title> 'patched title' } WHERE {}"));
+
+        final String etagFromPatch;
+        try (final CloseableHttpResponse response = execute(patch)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+            etagFromPatch = getEtag(response);
+        }
+
+        final String etagAfter = getEtag(uri);
+        assertNotEquals(etagBefore, etagFromPatch, "PATCH returned the ETag from before the update");
+        assertEquals(etagAfter, etagFromPatch, "PATCH ETag does not match the ETag of the updated resource");
+    }
+
+    @Test
+    public void testPutResponseReturnsUpdatedEtag() throws IOException {
+        final String id = getRandomUniqueId();
+        createObjectAndClose(id);
+        final String uri = serverAddress + id;
+
+        final String etagBefore = getEtag(uri);
+        assertTrue(etagBefore.startsWith("W/"), "Expected weak ETag");
+
+        final HttpPut put = putObjMethod(id);
+        put.addHeader(CONTENT_TYPE, "text/turtle");
+        put.addHeader("If-Match", etagBefore.substring(2));
+        put.setEntity(new StringEntity("<> <http://purl.org/dc/elements/1.1/title> 'replaced title' ."));
+
+        final String etagFromPut;
+        try (final CloseableHttpResponse response = execute(put)) {
+            assertEquals(NO_CONTENT.getStatusCode(), getStatus(response));
+            etagFromPut = getEtag(response);
+        }
+
+        final String etagAfter = getEtag(uri);
+        assertNotEquals(etagBefore, etagFromPut, "PUT returned the ETag from before the update");
+        assertEquals(etagAfter, etagFromPut, "PUT ETag does not match the ETag of the updated resource");
+    }
+
+    @Test
     public void testContainmentHashChanges() throws Exception {
         final String parentUri;
         final String createdEtag;


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-4093

* Regression introduced by FCREPO-4073 (#2298)
* Client-side note: https://github.com/fcrepo-exts/fcrepo-java-client/pull/75

# What does this Pull Request do?

Makes `PATCH` and `PUT` return the ETag of the resource as it is after the update, instead of as it was before.

FCREPO-4073 added a per-request `cachedRdfEtag` field to `ContentExposingResource` so that a HEAD/GET request computes the RDF etag once instead of twice. On a mutating request the cache is populated by `evaluateRequestPreconditions` before the update is applied, and then reused by `addCacheControlHeaders` when the response is built, so the response carried the pre-update value. `PATCH` already called `reloadResource()`, but the reloaded resource never reached the etag computation.

Changes:

* Add `invalidateCachedRdfEtag()` to `ContentExposingResource`, called from `reloadResource()` (used by `PATCH` and `FedoraVersioning`) and at the start of `createUpdateResponse()` (used by `PUT` and `POST`).
* `FedoraAcl.updateSparql` passed its pre-update `FedoraResource` object to `addCacheControlHeaders`. It now re-reads the ACL resource after the update.

# How should this be tested?

To reproduce on `main`:

1. `POST` a container, note the `ETag` from a `HEAD` on it.
2. `PATCH` the container with a SPARQL update and an `If-Match` for that ETag.
3. The `ETag` on the 204 response equals the ETag from step 1. A following `HEAD` returns a different, correct ETag.

Two integration tests in `FedoraLdpIT` cover this:

```bash
mvn -pl fcrepo-http-api verify -Dit.test='FedoraLdpIT#testPatchResponseReturnsUpdatedEtag+testPutResponseReturnsUpdatedEtag'
```

Each asserts the response ETag differs from the pre-request ETag and matches the ETag of a following `HEAD`. Both fail on unmodified source with "returned the ETag from before the update" and pass with this change.

Full `fcrepo-http-api` suite run: 583 tests, 2 failures. Both are pre-existing and unrelated:

* `LDPContainerIT.indirectContainerModifyProxyOnDemandVersioning` fails identically with this change reverted.
* `FedoraVersioningIT.testResponseForMultipleMementosInASecond` passes when run on its own (timing-sensitive under load).

Other modules' test suites were not run.

# Interested parties

@fcrepo/committers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
